### PR TITLE
fix: export ForbiddenError for re-use

### DIFF
--- a/.changeset/brave-forks-kick.md
+++ b/.changeset/brave-forks-kick.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-scope-auth': patch
+---
+
+Export ForbiddenError for re-use

--- a/packages/deno/packages/plugin-scope-auth/index.ts
+++ b/packages/deno/packages/plugin-scope-auth/index.ts
@@ -6,6 +6,7 @@ import { resolveHelper } from './resolve-helper.ts';
 import { createFieldAuthScopesStep, createFieldGrantScopesStep, createResolveStep, createTypeAuthScopesStep, createTypeGrantScopesStep, } from './steps.ts';
 import { ResolveStep, TypeAuthScopes, TypeGrantScopes } from './types.ts';
 export * from './types.ts';
+export * from './errors.ts';
 const pluginName = "scopeAuth" as const;
 export default pluginName;
 export class PothosScopeAuthPlugin<Types extends SchemaTypes> extends BasePlugin<Types> {

--- a/packages/plugin-scope-auth/src/index.ts
+++ b/packages/plugin-scope-auth/src/index.ts
@@ -23,6 +23,7 @@ import {
 import { ResolveStep, TypeAuthScopes, TypeGrantScopes } from './types';
 
 export * from './types';
+export * from './errors';
 
 const pluginName = 'scopeAuth' as const;
 


### PR DESCRIPTION
In order to be able to skip reporting to Sentry any authentication errors (using https://www.envelop.dev/plugins/use-sentry), it's required to have access to the class of ForbiddenError, which currently is not possible because it was not exported from the index nor it's possible to do deep imports because the `exports` of the package don't allow it:

```json
{
  "name": "@pothos/plugin-scope-auth",
  "version": "3.0.0",
  "description": "A Pothos plugin for adding scope based authorization checks to your GraphQL Schema",
  "main": "./lib/index.js",
  "types": "./lib/index.d.ts",
  "module": "./esm/index.js",
  "exports": {
    "import": "./esm/index.js",
    "require": "./lib/index.js"
  },
```

---

Now in a separate but related note, I would also like to have the freedom to customize the whole error instance used for the authorization, not only message, both on a global config and resolver level, if you agree, I can help create a PR for it

thank you @hayes, it's a very nice project it has been a nice experience learning to use it