### PR TITLE
Remove args from global unauthorizedError callback

### DIFF
--- a/.changeset/pretty-laws-kiss.md
+++ b/.changeset/pretty-laws-kiss.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-scope-auth': minor
+---
+
+Remove args option from global unauthorizedError callback

--- a/packages/plugin-scope-auth/src/resolve-helper.ts
+++ b/packages/plugin-scope-auth/src/resolve-helper.ts
@@ -24,10 +24,20 @@ export function resolveHelper<Types extends SchemaTypes>(
   const unauthorizedResolver =
     fieldConfig.pothosOptions.unauthorizedResolver ?? defaultUnauthorizedResolver;
 
+  const globalUnauthorizedError = plugin.builder.options.scopeAuthOptions?.unauthorizedError;
+  const defaultUnauthorizedError: UnauthorizedErrorFn<Types, object, {}> = (
+    parent,
+    args,
+    context,
+    info,
+    result,
+  ) =>
+    globalUnauthorizedError
+      ? globalUnauthorizedError(parent, context, info, result)
+      : result.message;
+
   const createError: UnauthorizedErrorFn<Types, object, {}> =
-    fieldConfig.pothosOptions.unauthorizedError ??
-    plugin.builder.options.scopeAuthOptions?.unauthorizedError ??
-    ((parent, args, context, info, result) => result.message);
+    fieldConfig.pothosOptions.unauthorizedError ?? defaultUnauthorizedError;
 
   return (parent: unknown, args: {}, context: Types['Context'], info: GraphQLResolveInfo) => {
     const state = new ResolveState(RequestCache.fromContext(context, plugin));

--- a/packages/plugin-scope-auth/src/types.ts
+++ b/packages/plugin-scope-auth/src/types.ts
@@ -12,7 +12,7 @@ import {
 import ResolveState from './resolve-state';
 
 export interface ScopeAuthPluginOptions<Types extends SchemaTypes> {
-  unauthorizedError?: UnauthorizedErrorFn<Types, unknown, {}>;
+  unauthorizedError?: UnauthorizedForTypeErrorFn<Types, {}>;
 }
 
 export interface BuiltInScopes<Types extends SchemaTypes> {
@@ -161,6 +161,13 @@ export type UnauthorizedErrorFn<
 > = (
   parent: ParentShape,
   args: InputShapeFromFields<Args>,
+  context: Types['Context'],
+  info: GraphQLResolveInfo,
+  result: ForbiddenResult,
+) => Error | string;
+
+export type UnauthorizedForTypeErrorFn<Types extends SchemaTypes, ParentShape> = (
+  parent: ParentShape,
   context: Types['Context'],
   info: GraphQLResolveInfo,
   result: ForbiddenResult,

--- a/packages/plugin-scope-auth/tests/example/schema/custom-errors.ts
+++ b/packages/plugin-scope-auth/tests/example/schema/custom-errors.ts
@@ -23,7 +23,7 @@ const builder = new SchemaBuilder<{
 }>({
   defaultFieldNullability: true,
   scopeAuthOptions: {
-    unauthorizedError: (parent, args, context, info, result) =>
+    unauthorizedError: (parent, context, info, result) =>
       new Error(`${result.failure.kind}: ${result.message}`),
   },
   plugins: [ScopeAuthPlugin],

--- a/website/pages/docs/plugins/scope-auth.mdx
+++ b/website/pages/docs/plugins/scope-auth.mdx
@@ -295,7 +295,7 @@ const builder = new SchemaBuilder<{
   };
 }>({
   scopeAuthOptions: {
-    unauthorizedError: (parent, args, context, info, result) => new Error(`Not authorized`),
+    unauthorizedError: (parent, context, info, result) => new Error(`Not authorized`),
   },
   plugins: [ScopeAuthPlugin],
   authScopes: async (context) => ({
@@ -304,10 +304,10 @@ const builder = new SchemaBuilder<{
 });
 ```
 
-The `unauthorizedError` callback will be called with the same arguments as the resolver for the
-unauthorized field. It will also include a 5th argument `result` that has the default message for
+The `unauthorizedError` callback will be called with the parent, context, and info object of the
+unauthorized field. It will also include a 4th argument `result` that has the default message for
 this type of failure, and a `failure` property with some details about what caused the field to be
-unauthorizerd. This callback can either return an `Error` instance (or an instance of a class that
+unauthorized. This callback can either return an `Error` instance (or an instance of a class that
 extends `Error`), or a `string`. If a string is returned, it will be converted to a
 `ForbiddenError`.
 


### PR DESCRIPTION
@PabloSzx I realized that I made a mistake when I added the `unauthorizedError` logic.  I think you are the only one using it so far, so I am going to release this as a minor version.

Basically, I need to remove the args option from the global callback.  I have some work in progress to allow authorization checks that will not work if the global error formater takes args. 