### PR TITLE
Object Type mocks

### DIFF
--- a/packages/deno/packages/plugin-mocks/global-types.ts
+++ b/packages/deno/packages/plugin-mocks/global-types.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
-import { SchemaTypes } from '../core/index.ts';
-import { ResolverMap } from './types.ts';
+import { ObjectParam, SchemaTypes, ShapeFromTypeParam } from '../core/index.ts';
+import { Mock, ResolverMap } from './types.ts';
 import { MocksPlugin } from './index.ts';
 declare global {
     export namespace PothosSchemaTypes {
@@ -9,6 +9,10 @@ declare global {
         }
         export interface BuildSchemaOptions<Types extends SchemaTypes> {
             mocks?: ResolverMap<Types>;
+            typeMocks?: Mock[];
+        }
+        export interface SchemaBuilder<Types extends SchemaTypes> {
+            createMock: <Shape extends NameOrRef extends ObjectParam<Types> ? ShapeFromTypeParam<Types, NameOrRef, false> : object, NameOrRef extends ObjectParam<Types> | string>(nameOrRef: NameOrRef, resolver: () => Partial<Shape>) => Mock;
         }
     }
 }

--- a/packages/deno/packages/plugin-mocks/types.ts
+++ b/packages/deno/packages/plugin-mocks/types.ts
@@ -1,7 +1,10 @@
 // @ts-nocheck
-import { Resolver, SchemaTypes, Subscriber } from '../core/index.ts';
+import { ObjectRef, Resolver, SchemaTypes, Subscriber } from '../core/index.ts';
 export type Resolvers<Types extends SchemaTypes, Parent> = Record<string, Resolver<Parent, {}, Types["Context"], unknown> | {
     resolve: Resolver<Parent, {}, Types["Context"], unknown>;
     subscribe: Subscriber<Parent, {}, Types["Context"], unknown>;
 }>;
 export type ResolverMap<Types extends SchemaTypes> = Record<string, Resolvers<Types, unknown>>;
+export interface Mock {
+    ref: ObjectRef<unknown>;
+}

--- a/packages/plugin-mocks/src/global-types.ts
+++ b/packages/plugin-mocks/src/global-types.ts
@@ -1,5 +1,5 @@
-import { SchemaTypes } from '@pothos/core';
-import { ResolverMap } from './types';
+import { ObjectParam, Resolver, SchemaTypes, ShapeFromTypeParam } from '@pothos/core';
+import { Mock, ResolverMap } from './types';
 import { MocksPlugin } from '.';
 
 declare global {
@@ -10,6 +10,19 @@ declare global {
 
     export interface BuildSchemaOptions<Types extends SchemaTypes> {
       mocks?: ResolverMap<Types>;
+      typeMocks?: Mock<Types>[];
+    }
+
+    export interface SchemaBuilder<Types extends SchemaTypes> {
+      createObjectMock: <
+        Shape extends NameOrRef extends ObjectParam<Types>
+          ? ShapeFromTypeParam<Types, NameOrRef, false>
+          : object,
+        NameOrRef extends ObjectParam<Types> | string,
+      >(
+        nameOrRef: NameOrRef,
+        resolver: Resolver<unknown, unknown, Types['Context'], Partial<Shape>>,
+      ) => Mock<Types>;
     }
   }
 }

--- a/packages/plugin-mocks/src/schema-builder.ts
+++ b/packages/plugin-mocks/src/schema-builder.ts
@@ -1,0 +1,12 @@
+import SchemaBuilder, { SchemaTypes } from '@pothos/core';
+
+const schemaBuilderProto = SchemaBuilder.prototype as PothosSchemaTypes.SchemaBuilder<SchemaTypes>;
+
+schemaBuilderProto.createObjectMock = function createMock(nameOrRef, resolver) {
+  const name = typeof nameOrRef === 'string' ? nameOrRef : (nameOrRef as { name: string }).name;
+
+  return {
+    name,
+    resolver: resolver as never,
+  };
+};

--- a/packages/plugin-mocks/src/types.ts
+++ b/packages/plugin-mocks/src/types.ts
@@ -10,3 +10,8 @@ export type Resolvers<Types extends SchemaTypes, Parent> = Record<
 >;
 
 export type ResolverMap<Types extends SchemaTypes> = Record<string, Resolvers<Types, unknown>>;
+
+export interface Mock<Types extends SchemaTypes> {
+  name: string;
+  resolver: Resolver<unknown, unknown, Types['Context'], unknown>;
+}

--- a/packages/plugin-mocks/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-mocks/tests/__snapshots__/index.test.ts.snap
@@ -9,3 +9,28 @@ Object {
   },
 }
 `;
+
+exports[`mocked type mocks queries lists 1`] = `
+Object {
+  "data": Object {
+    "r2d2": Object {
+      "friends": Array [
+        Object {
+          "name": "C-3PO",
+        },
+      ],
+      "name": "C-3PO",
+    },
+  },
+}
+`;
+
+exports[`mocked type mocks queries stuff 1`] = `
+Object {
+  "data": Object {
+    "r2d2": Object {
+      "name": "C-3PO",
+    },
+  },
+}
+`;

--- a/packages/plugin-mocks/tests/index.test.ts
+++ b/packages/plugin-mocks/tests/index.test.ts
@@ -29,4 +29,63 @@ describe('mocked', () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  describe('type mocks', () => {
+    it('queries stuff', async () => {
+      const DroidMock = builder.createObjectMock('Droid', () => ({
+        name: 'C-3PO',
+      }));
+      const mockedSchema = builder.toSchema({
+        mocks: {},
+        typeMocks: [DroidMock],
+      });
+
+      const query = gql`
+        query {
+          r2d2 {
+            name
+          }
+        }
+      `;
+
+      const result = await execute({
+        schema: mockedSchema,
+        document: query,
+        contextValue: {},
+      });
+
+      expect(result).toMatchSnapshot();
+    });
+
+    it('queries lists', async () => {
+      const DroidMock = builder.createObjectMock('Droid', () => ({
+        type: 'Droid' as const,
+        name: 'C-3PO',
+        friends: ['1002', '1003'],
+      }));
+      const mockedSchema = builder.toSchema({
+        mocks: {},
+        typeMocks: [DroidMock],
+      });
+
+      const query = gql`
+        query {
+          r2d2 {
+            name
+            friends {
+              name
+            }
+          }
+        }
+      `;
+
+      const result = await execute({
+        schema: mockedSchema,
+        document: query,
+        contextValue: {},
+      });
+
+      expect(result).toMatchSnapshot();
+    });
+  });
 });


### PR DESCRIPTION
The idea is to be able to mock certain returned objects whenever they are seen in the schema.
```ts
const DroidMock = createObjectMock('Droid', (...) => fakeDroid);

const mockedSchema = builder.toSchema({
  typeMocks: [DroidMock],
});
```
It would be really amazing if our mock resolver could get some sensible arguments, like the id of the object being resolved, if using dataloader/relay node. I sadly do not think that is possible, given that we have to run the resolver that we try to wrap, to figure out if it is an id or a full object, and that is probably not what is wanted in most cases.
It would also be nice if we were able to be a bit more clever or dynamic with the length of the lists that are requested, but I have found no good way for that.