### PR TITLE
fix: explicitly make pageInfo non nullable

### DIFF
--- a/.changeset/neat-cobras-ring.md
+++ b/.changeset/neat-cobras-ring.md
@@ -1,5 +1,13 @@
 ---
-"@pothos/plugin-relay": patch
+"@pothos/plugin-relay": minor
 ---
 
 Explicitly make `pageInfo` non nullable. Previously `pageInfo` was nullable for `defaultFieldNullability: true`, which is against the Relay spec.
+You can revert back to previous behaviour by updating your builder relay options:
+```
+relay: {
+  pageInfoFieldOptions: {
+    nullable: true,
+  },
+},
+```

--- a/.changeset/neat-cobras-ring.md
+++ b/.changeset/neat-cobras-ring.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-relay": patch
+---
+
+Explicitly make `pageInfo` non nullable. Previously `pageInfo` was nullable for `defaultFieldNullability: true`, which is against the Relay spec.

--- a/packages/plugin-relay/src/schema-builder.ts
+++ b/packages/plugin-relay/src/schema-builder.ts
@@ -409,6 +409,7 @@ schemaBuilderProto.connectionObject = function connectionObject(
       pageInfo: t.field({
         ...pageInfoFieldOptions,
         type: this.pageInfoRef(),
+        nullable: false,
         resolve: (parent) => parent.pageInfo,
       }),
       edges: t.field({


### PR DESCRIPTION
`PageInfo` is nullable when `defaultFieldNullability` is `true`, but [the relay spec indicates, that `PageInfo` must not be nullable](https://relay.dev/graphql/connections.htm#sec-Connection-Types.Fields.PageInfo)