### PR TITLE
fix: respect options.complexity.complexityError

### DIFF
--- a/.changeset/kind-mangos-rule.md
+++ b/.changeset/kind-mangos-rule.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-complexity": patch
+---
+
+Allow to configure `complexityError` via options.

--- a/packages/plugin-complexity/src/index.ts
+++ b/packages/plugin-complexity/src/index.ts
@@ -28,6 +28,7 @@ export class PothosComplexityPlugin<Types extends SchemaTypes> extends BasePlugi
     DEFAULT_LIST_MULTIPLIER;
 
   complexityError: ComplexityErrorFn =
+    this.options.complexity?.complexityError ??
     this.builder.options.complexity?.complexityError ??
     ((kind, { depth, breadth, complexity, maxBreadth, maxComplexity, maxDepth }) => {
       if (kind === ComplexityErrorKind.Depth) {


### PR DESCRIPTION
Right now the complexityError can only be set using the builder options.