### PR TITLE
fix(#553): use the right types when fullTextSearch is enabled

### DIFF
--- a/.changeset/nine-readers-rush.md
+++ b/.changeset/nine-readers-rush.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-prisma": patch
+---
+
+Support `fullTextSearch` types (#553)

--- a/packages/plugin-prisma/src/generator.ts
+++ b/packages/plugin-prisma/src/generator.ts
@@ -38,6 +38,11 @@ generatorHandler({
       options.otherGenerators.find((gen) => gen.provider.value === 'prisma-client-js')!.output!
         .value;
 
+    // See https://github.com/hayes/pothos/issues/553
+    const hasFullTextSearch = options.otherGenerators
+      .find((gen) => gen.provider.value === 'prisma-client-js')!
+      .previewFeatures.includes('fullTextSearch');
+
     const importStatement = ts.factory.createImportDeclaration(
       [],
       [],
@@ -98,7 +103,11 @@ generatorHandler({
             [],
             'OrderBy',
             undefined,
-            ts.factory.createTypeReferenceNode(`Prisma.${model.name}OrderByWithRelationInput`),
+            ts.factory.createTypeReferenceNode(
+              `Prisma.${model.name}OrderByWithRelation${
+                hasFullTextSearch ? 'AndSearchRelevance' : ''
+              }Input`,
+            ),
           ),
           ts.factory.createPropertySignature(
             [],


### PR DESCRIPTION
Fixes #553

This is a temporary workaround while full-text search is in preview (since August 2021), and should be removed as soon as it reaches stable (no ETA yet).

`WithAggregation` seems to be disabled by https://github.com/prisma/prisma-engines/blob/1b996e940dc3998d2003ab429f3ac9a3f98a1fbd/query-engine/schema-builder/src/input_types/fields/arguments.rs#L99-L102