### PR TITLE
Fix: add .ts extension to filename for generated prisma fields

### DIFF
--- a/.changeset/fluffy-grapes-enjoy.md
+++ b/.changeset/fluffy-grapes-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-prisma": patch
+---
+
+Fix: add .ts extension to filename for generated prisma fields

--- a/packages/plugin-prisma/src/generator.ts
+++ b/packages/plugin-prisma/src/generator.ts
@@ -24,7 +24,7 @@ function checkTSVersion() {
   }
 }
 
-const defaultOutput = resolvePath(__dirname, '../generated');
+const defaultOutput = resolvePath(__dirname, '../generated.ts');
 
 generatorHandler({
   onManifest: () => ({


### PR DESCRIPTION
Related issue: #575 

Thanks to https://github.com/hayes/pothos/commit/521cde32f3a223cf5479322418a911f4a467f60e , the default location of the file of generated prisma fields is now correctly set, but missing `.ts` extension confuses module resolution.

I think adding `.ts` is also needed to keep consistency as `generated.ts` is expected filename and it is used in several place, e.g. https://github.com/hayes/pothos/blob/7cbbbe7315b2e5cd2275c1ba0c043d6a2d76abb5/packages/plugin-prisma/prisma/schema.prisma#L17