### PR TITLE
Add support for inline composite rules to AuthZ plugin

### DIFF
--- a/.changeset/curvy-olives-argue.md
+++ b/.changeset/curvy-olives-argue.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-authz': patch
+---
+
+Added support for inline composite rules

--- a/packages/plugin-authz/README.md
+++ b/packages/plugin-authz/README.md
@@ -70,3 +70,20 @@ Post.implement({
   }),
 });
 ```
+
+## Defining inline composite rules
+
+```typescript
+const Post = builder.objectRef<IPost>('Post');
+
+Post.implement({
+  authz: {
+    compositeRules: [{ or: ['CanReadPost', 'IsAdmin'] }],
+  },
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+```
+
+More details about composite rules are in the documentation of [AuthZ](https://github.com/AstrumU/graphql-authz#inline-composition-rules)

--- a/packages/plugin-authz/src/types.ts
+++ b/packages/plugin-authz/src/types.ts
@@ -1,5 +1,19 @@
 import { SchemaTypes } from '@pothos/core';
 
-export interface AuthZOption<Types extends SchemaTypes> {
-  rules: Types['AuthZRule'][];
-}
+type RequireAtLeastOne<T> = {
+  [K in keyof T]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<keyof T, K>>>;
+}[keyof T];
+
+type CompositeRules<Types extends SchemaTypes> = RequireAtLeastOne<{
+  and?: Types['AuthZRule'][];
+  or?: Types['AuthZRule'][];
+  not?: Types['AuthZRule'];
+}>[];
+
+export type AuthZOption<Types extends SchemaTypes> =
+  | {
+      rules: Types['AuthZRule'][];
+    }
+  | {
+      compositeRules: CompositeRules<Types>;
+    };

--- a/packages/plugin-authz/tests/example/data.ts
+++ b/packages/plugin-authz/tests/example/data.ts
@@ -15,6 +15,11 @@ export const users = [
     username: 'user02',
     email: 'user02@gmail.com',
     role: 'Admin',
+  },{
+    id: '3',
+    username: 'user03',
+    email: 'user03@gmail.com',
+    role: 'Customer',
   },
 ];
 

--- a/packages/plugin-authz/tests/example/schema/index.ts
+++ b/packages/plugin-authz/tests/example/schema/index.ts
@@ -9,7 +9,7 @@ const Post = builder.objectRef<typeof posts[number]>('Post');
 
 Post.implement({
   authz: {
-    rules: ['CanReadPost'],
+    compositeRules: [{ or: ['IsAdmin', 'CanReadPost'] }],
   },
   fields: (t) => ({
     id: t.exposeID('id'),

--- a/packages/plugin-authz/tests/index.test.ts
+++ b/packages/plugin-authz/tests/index.test.ts
@@ -55,6 +55,9 @@ describe('authz', () => {
             {
               "id": "2",
             },
+            {
+              "id": "3",
+            },
           ],
         },
       }
@@ -84,7 +87,7 @@ describe('authz', () => {
     });
   });
 
-  it('amin user, admin query', async () => {
+  it('admin user, admin query', async () => {
     const query = gql`
       query {
         users {
@@ -114,6 +117,46 @@ describe('authz', () => {
               "email": "user02@gmail.com",
               "id": "2",
             },
+            {
+              "email": "user03@gmail.com",
+              "id": "3",
+            },
+          ],
+        },
+      }
+    `);
+  });
+
+  it('admin user, normal query', async () => {
+    const query = gql`
+      query {
+        posts {
+          id
+          title
+        }
+      }
+    `;
+
+    const result = await execute({
+      schema,
+      document: query,
+      contextValue: {
+        user: users[1],
+      },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "posts": [
+            {
+              "id": "1",
+              "title": "Post01 title",
+            },
+            {
+              "id": "2",
+              "title": "Post02 title",
+            },
           ],
         },
       }
@@ -133,12 +176,10 @@ describe('authz', () => {
         schema,
         document: query,
         contextValue: {
-          user: users[1],
+          user: users[2],
         },
       }),
-    ).rejects.toMatchObject({
-      message: 'Access denied',
-    });
+    ).rejects.toMatchObject({ message: 'User is not admin\nAccess denied'});
   });
 
   it('auth rule on type (authorized)', async () => {

--- a/website/pages/docs/plugins/authz.mdx
+++ b/website/pages/docs/plugins/authz.mdx
@@ -84,3 +84,21 @@ Post.implement({
   }),
 });
 ```
+
+## Defining inline composite rules
+
+```typescript
+const Post = builder.objectRef<IPost>('Post');
+
+Post.implement({
+  authz: {
+    compositeRules: [{ or: ['CanReadPost', 'IsAdmin'] }],
+  },
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+```
+
+More details about composite rules are in the documentation of [AuthZ](https://github.com/AstrumU/graphql-authz#inline-composition-rules)
+


### PR DESCRIPTION
The AuthZ security layer supports a few more ways to configure authorization rules than what's currently available in the AuthZ plugin. 
For example, if you want to allow an admin user access to many endpoints in your API, you would (with the current implementation of the plugin) need to update all AuthZ rules and add an explicit admin role check. But AuthZ also allows you to write [inline composite rules](https://github.com/AstrumU/graphql-authz#inline-composition-rules), with which you could write an 'IsAdmin' rule just once, and use simple boolean logic to add admin access to endpoints without touching the other rule implementations. 
This PR updates the implementation, the tests and the plugin documentation.
