### PR TITLE
Fix typo on smart-subscriptions website page

### DIFF
--- a/website/pages/docs/plugins/smart-subscriptions.mdx
+++ b/website/pages/docs/plugins/smart-subscriptions.mdx
@@ -97,7 +97,7 @@ subscription.
 This would be queried as:
 
 ```graphql
-subsciption {
+subscription {
   polls {
     question
     answers {


### PR DESCRIPTION
Fixes typo in word `subscription` on the Smart Subscriptions page of the website