### PR TITLE
add custom resolve option for node/nodes

### DIFF
--- a/packages/plugin-relay/README.md
+++ b/packages/plugin-relay/README.md
@@ -548,6 +548,32 @@ const builder = new SchemaBuilder({
 });
 ```
 
+### Using custom resolve for node and or nodes
+
+if you want to resolve the queries for `node` and or `nodes` you can provide a custom resolve
+functions into the relay options of the builder:
+
+```typescript
+import RelayPlugin, { decodeGlobalID } from '@pothos/plugin-relay';
+
+function node(globalId: string) {
+  const { id } = decodeGlobalID(globalID);
+  return getThing(id);
+}
+
+const builder = new SchemaBuilder({
+  plugins: [RelayPlugin],
+  relayOptions: {
+    nodeQueryOptions: {
+      resolve: (globalID, context) => node(globalID),
+    },
+    nodesQueryOptions: {
+      resolve: (globalIDs, context) => globalIDs.map((globalID) => node(globalID)),
+    },
+  },
+});
+```
+
 ### Extending all connections
 
 There are 2 builder methods for adding fields to all connection objects: `t.globalConnectionField`

--- a/packages/plugin-relay/src/schema-builder.ts
+++ b/packages/plugin-relay/src/schema-builder.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { defaultTypeResolver, GraphQLResolveInfo } from 'graphql';
 import SchemaBuilder, {
   createContextCache,
   FieldRef,
@@ -16,6 +15,7 @@ import SchemaBuilder, {
   SchemaTypes,
   verifyRef,
 } from '@pothos/core';
+import { defaultTypeResolver, GraphQLResolveInfo } from 'graphql';
 import { ConnectionShape, GlobalIDShape, PageInfoShape } from './types';
 import { capitalize, resolveNodes } from './utils';
 
@@ -156,6 +156,7 @@ schemaBuilderProto.nodeInterfaceRef = function nodeInterfaceRef() {
           id: t.arg.id({ required: true }),
         },
         resolve: async (root, args, context, info) =>
+          this.options.relayOptions?.nodeQueryOptions?.resolve?.(String(args.id), context) ??
           (await resolveNodes(this, context, info, [String(args.id)]))[0],
       }) as FieldRef<unknown>,
   );
@@ -172,9 +173,10 @@ schemaBuilderProto.nodeInterfaceRef = function nodeInterfaceRef() {
         ids: t.arg.idList({ required: true }),
       },
       resolve: async (root, args, context, info) =>
-        (await resolveNodes(this, context, info, args.ids as string[])) as Promise<
+        this.options.relayOptions?.nodesQueryOptions?.resolve?.(args.ids as string[], context) ??
+        ((await resolveNodes(this, context, info, args.ids as string[])) as Promise<
           ObjectParam<SchemaTypes>
-        >[],
+        >[]),
     }),
   );
 

--- a/packages/plugin-relay/src/schema-builder.ts
+++ b/packages/plugin-relay/src/schema-builder.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+import { defaultTypeResolver, GraphQLResolveInfo } from 'graphql';
 import SchemaBuilder, {
   createContextCache,
   FieldRef,
@@ -15,7 +16,6 @@ import SchemaBuilder, {
   SchemaTypes,
   verifyRef,
 } from '@pothos/core';
-import { defaultTypeResolver, GraphQLResolveInfo } from 'graphql';
 import { ConnectionShape, GlobalIDShape, PageInfoShape } from './types';
 import { capitalize, resolveNodes } from './utils';
 

--- a/packages/plugin-relay/src/types.ts
+++ b/packages/plugin-relay/src/types.ts
@@ -1,3 +1,4 @@
+import { GraphQLResolveInfo } from 'graphql';
 import {
   EmptyToOptional,
   FieldKind,
@@ -28,7 +29,6 @@ import {
   ShapeFromListTypeParam,
   ShapeFromTypeParam,
 } from '@pothos/core';
-import { GraphQLResolveInfo } from 'graphql';
 
 export type RelayPluginOptions<Types extends SchemaTypes> = EmptyToOptional<{
   idFieldName?: string;

--- a/packages/plugin-relay/src/types.ts
+++ b/packages/plugin-relay/src/types.ts
@@ -1,4 +1,3 @@
-import { GraphQLResolveInfo } from 'graphql';
 import {
   EmptyToOptional,
   FieldKind,
@@ -29,6 +28,7 @@ import {
   ShapeFromListTypeParam,
   ShapeFromTypeParam,
 } from '@pothos/core';
+import { GraphQLResolveInfo } from 'graphql';
 
 export type RelayPluginOptions<Types extends SchemaTypes> = EmptyToOptional<{
   idFieldName?: string;
@@ -49,20 +49,24 @@ export type RelayPluginOptions<Types extends SchemaTypes> = EmptyToOptional<{
       OutputRefShape<GlobalIDShape<Types> | string>,
       boolean,
       { id: InputFieldRef<InputShape<Types, 'ID'>> },
-      Promise<unknown>
+      Promise<Types['Objects']>
     >,
     'args' | 'resolve' | 'type'
-  >;
+  > & {
+    resolve?: (id: string, context: Types['Context']) => MaybePromise<Types['Objects']>;
+  };
   nodesQueryOptions: Omit<
     PothosSchemaTypes.QueryFieldOptions<
       Types,
       [OutputRefShape<GlobalIDShape<Types> | string>],
       FieldNullability<[unknown]>,
       { ids: InputFieldRef<InputShape<Types, 'ID'>[]> },
-      Promise<unknown>[]
+      Promise<Types['Objects']>[]
     >,
     'args' | 'resolve' | 'type'
-  >;
+  > & {
+    resolve?: (ids: string[], context: Types['Context']) => MaybePromise<Types['Objects'][]>;
+  };
   mutationInputArgOptions: Omit<
     PothosSchemaTypes.ArgFieldOptions<Types, InputRef<{}>, boolean>,
     'fields' | 'type'

--- a/packages/plugin-relay/tests/__snapshots__/customResolve.test.ts.snap
+++ b/packages/plugin-relay/tests/__snapshots__/customResolve.test.ts.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1
+
+exports[`cursor based connection > queries 1`] = `
+{
+  "data": {
+    "node": {
+      "number": 2,
+    },
+  },
+}
+`;

--- a/packages/plugin-relay/tests/customResolve.test.ts
+++ b/packages/plugin-relay/tests/customResolve.test.ts
@@ -1,0 +1,28 @@
+import { execute } from 'graphql';
+import { gql } from 'graphql-tag';
+import schema from './examples/custom-resolve/schema';
+
+describe('custom node resolve', () => {
+  it('resolves a node with a global id', async () => {
+    const query = gql`
+      query {
+        node(id: "TnVtYmVyOjI") {
+          ... on BatchNumber {
+            batchNumber: number
+          }
+          ... on Number {
+            number
+          }
+        }
+      }
+    `;
+
+    const result = await execute({
+      schema,
+      document: query,
+      contextValue: {},
+    });
+
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/plugin-relay/tests/examples/custom-resolve/builder.ts
+++ b/packages/plugin-relay/tests/examples/custom-resolve/builder.ts
@@ -1,0 +1,59 @@
+import SchemaBuilder from '@pothos/core';
+import RelayPlugin, { decodeGlobalID } from '../../../src';
+import { Poll } from './data';
+import { ContextType } from './types';
+
+function node(globalID: string) {
+  const { id } = decodeGlobalID(globalID);
+  return Poll.map.get(Number(id));
+}
+
+export default new SchemaBuilder<{
+  Objects: {
+    Poll: Poll;
+    Answer: { id: number; value: string; count: number };
+  };
+  Context: ContextType;
+  Connection: {
+    totalCount: number;
+  };
+  DefaultEdgesNullability: false;
+  DefaultNodeNullability: true;
+}>({
+  plugins: [RelayPlugin],
+  relayOptions: {
+    nodesOnConnection: true,
+    idFieldName: 'nodeId',
+    nodeFieldOptions: {
+      nullable: true,
+    },
+    edgesFieldOptions: {
+      nullable: false,
+    },
+    clientMutationId: 'omit',
+    cursorType: 'String',
+    nodeQueryOptions: {
+      description: 'node query',
+      resolve: (globalID, context) => node(globalID) as any,
+    },
+    nodesQueryOptions: {
+      description: 'nodes query',
+      resolve: (globalIDs, context) => globalIDs.map((globalID) => node(globalID)) as any[],
+    },
+    nodeTypeOptions: {
+      description: 'node type',
+    },
+    pageInfoTypeOptions: {
+      description: 'page info type',
+    },
+    clientMutationIdFieldOptions: {
+      description: 'client id output',
+    },
+    clientMutationIdInputOptions: {
+      description: 'client id input',
+    },
+    mutationInputArgOptions: {
+      description: 'mutation input arg',
+    },
+  },
+});

--- a/packages/plugin-relay/tests/examples/custom-resolve/data.ts
+++ b/packages/plugin-relay/tests/examples/custom-resolve/data.ts
@@ -1,0 +1,37 @@
+export class Poll {
+  static map = new Map<number, Poll>();
+
+  static lastID = 0;
+
+  static lastAnswerID = 0;
+
+  __type: 'Poll' = 'Poll';
+
+  id: number;
+
+  question: string;
+
+  answers: { id: number; value: string; count: number }[];
+
+  constructor(question: string, answers: string[]) {
+    this.id = Poll.lastID + 1;
+
+    this.question = question;
+
+    this.answers = answers.map((value) => {
+      Poll.lastAnswerID += 1;
+
+      return { value, id: Poll.lastAnswerID, count: 0 };
+    });
+
+    Poll.lastID = this.id;
+  }
+
+  static create(question: string, answers: string[]) {
+    const poll = new Poll(question, answers);
+
+    this.map.set(poll.id, poll);
+
+    return poll;
+  }
+}

--- a/packages/plugin-relay/tests/examples/custom-resolve/schema/index.ts
+++ b/packages/plugin-relay/tests/examples/custom-resolve/schema/index.ts
@@ -1,0 +1,175 @@
+/* eslint-disable unicorn/no-useless-promise-resolve-reject */
+import './poll';
+import './numbers';
+import builder from '../builder';
+
+interface GlobalIDInputsShape {
+  circular?: GlobalIDInputsShape;
+  id: {
+    id: string;
+    typename: string;
+  };
+  idList: {
+    id: string;
+    typename: string;
+  }[];
+}
+
+interface CircularWithoutGlobalIds {
+  circular?: CircularWithoutGlobalIds;
+  id?: number | string;
+}
+
+const GlobalIDInput = builder.inputRef<GlobalIDInputsShape>('GlobalIDInput');
+const NoGlobalIDInput = builder.inputRef<CircularWithoutGlobalIds>('NoGlobalIDInput');
+
+GlobalIDInput.implement({
+  fields: (t) => ({
+    circularWithoutGlobalIds: t.field({
+      type: NoGlobalIDInput,
+    }),
+    circular: t.field({
+      type: GlobalIDInput,
+    }),
+    id: t.globalID({
+      required: true,
+    }),
+    idList: t.globalIDList({
+      required: {
+        list: true,
+        items: true,
+      },
+    }),
+  }),
+});
+
+NoGlobalIDInput.implement({
+  fields: (t) => ({
+    circular: t.field({
+      type: NoGlobalIDInput,
+    }),
+    id: t.id({}),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    inputGlobalID: t.string({
+      args: {
+        id: t.arg.globalID({
+          required: true,
+        }),
+        normalId: t.arg.id({ required: true }),
+        inputObj: t.arg({
+          type: GlobalIDInput,
+          required: true,
+        }),
+      },
+      resolve(parent, args) {
+        return JSON.stringify({
+          normal: args.normalId,
+          inputObj: {
+            circular: {
+              id: {
+                id: args.inputObj.circular?.id.id,
+                typename: args.inputObj.circular?.id.typename,
+              },
+              idList: args.inputObj.circular?.idList,
+              circular: args.inputObj.circular?.circular,
+            },
+            id: {
+              id: args.inputObj.id.id,
+              typename: args.inputObj.id.typename,
+            },
+            idList: args.inputObj.idList?.map((id) => ({
+              id: id.id,
+              typename: id.typename,
+            })),
+          },
+          id: {
+            id: args.id.id,
+            typename: args.id.typename,
+          },
+        });
+      },
+    }),
+  }),
+});
+
+builder.mutationType({ fields: (t) => ({}) });
+
+builder.relayMutationField(
+  'exampleMutation',
+  {
+    inputFields: (t) => ({
+      id: t.id({
+        required: true,
+      }),
+    }),
+  },
+  {
+    resolve: async (root, args) => {
+      if (!args.input.clientMutationId) {
+        throw new Error('clientMutationId is missing');
+      }
+
+      return Promise.resolve({ status: args.input.id === '123' ? 200 : 500 });
+    },
+  },
+  {
+    outputFields: (t) => ({
+      itWorked: t.boolean({
+        resolve: (parent) => parent.status === 200,
+      }),
+    }),
+  },
+);
+
+builder.relayMutationField(
+  'exampleWithDescriptions',
+  {
+    name: 'CustomInputName',
+    argName: 'customInput',
+    description: 'input type',
+    inputFields: (t) => ({
+      id: t.id({
+        required: true,
+      }),
+    }),
+  },
+  {
+    description: 'mutation field',
+    resolve: async (root, args) => {
+      if (!args.customInput.clientMutationId) {
+        throw new Error('clientMutationId is missing');
+      }
+
+      return Promise.resolve({ status: args.customInput.id === '123' ? 200 : 500 });
+    },
+  },
+  {
+    name: 'CustomOutputName',
+    description: 'output type',
+    outputFields: (t) => ({
+      itWorked: t.boolean({
+        resolve: (parent) => parent.status === 200,
+      }),
+    }),
+  },
+);
+
+builder.globalConnectionField('totalCount', (t) =>
+  t.int({
+    nullable: false,
+    resolve: (parent) => parent.totalCount,
+  }),
+);
+
+builder.globalConnectionFields((t) => ({
+  totalCount2: t.int({
+    nullable: false,
+    resolve: (parent) => parent.totalCount,
+  }),
+}));
+
+export default builder.toSchema();

--- a/packages/plugin-relay/tests/examples/custom-resolve/schema/numbers.ts
+++ b/packages/plugin-relay/tests/examples/custom-resolve/schema/numbers.ts
@@ -1,0 +1,175 @@
+import { resolveArrayConnection, resolveOffsetConnection } from '../../../../src';
+import builder from '../builder';
+
+class NumberThing {
+  id: number;
+
+  constructor(n: number) {
+    this.id = n;
+  }
+}
+
+class BatchLoadableNumberThing {
+  id: number;
+
+  constructor(n: number) {
+    this.id = n;
+  }
+}
+
+builder.node(NumberThing, {
+  id: {
+    resolve: (n) => n.id,
+  },
+  loadOne: (id) => new NumberThing(Number.parseInt(id, 10)),
+  name: 'Number',
+  fields: (t) => ({
+    number: t.exposeInt('id', {}),
+  }),
+});
+
+builder.node(BatchLoadableNumberThing, {
+  id: {
+    resolve: (n) => n.id,
+  },
+  loadMany: (ids) => ids.map((id) => new BatchLoadableNumberThing(Number.parseInt(id, 10))),
+  name: 'BatchNumber',
+  fields: (t) => ({
+    number: t.exposeInt('id', {}),
+  }),
+});
+
+builder.queryFields((t) => ({
+  numbers: t.connection(
+    {
+      type: NumberThing,
+      resolve: async (parent, args) => {
+        const result = await resolveOffsetConnection({ args }, ({ limit, offset }) => {
+          const items = [];
+
+          for (let i = offset; i < Math.min(offset + limit, 200); i += 1) {
+            items.push(new NumberThing(i));
+          }
+
+          return items;
+        });
+
+        return {
+          totalCount: 500,
+          other: 'abc',
+          ...result,
+        };
+      },
+    },
+    {
+      fields: (t2) => ({
+        other: t2.exposeString('other'),
+      }),
+    },
+  ),
+}));
+
+builder.queryFields((t) => ({
+  nullableNumbers: t.connection(
+    {
+      type: NumberThing,
+      nullable: true,
+      resolve: async (parent, args) => {
+        const result = await resolveOffsetConnection(
+          { args },
+          ({ limit, offset }) => null as NumberThing[] | null,
+        );
+
+        if (!result) {
+          return null;
+        }
+
+        return {
+          totalCount: 500,
+          other: 'abc',
+          ...result,
+        };
+      },
+    },
+    {
+      fields: (t2) => ({
+        other: t2.exposeString('other'),
+      }),
+    },
+  ),
+  oddNumbers: t.connection({
+    type: NumberThing,
+    edgesNullable: {
+      items: true,
+      list: false,
+    },
+    nodeNullable: false,
+    resolve: async (parent, args) => {
+      const result = await resolveOffsetConnection({ args }, () => [
+        new NumberThing(1),
+        null,
+        new NumberThing(3),
+      ]);
+
+      return {
+        totalCount: 500,
+        other: 'abc',
+        ...result,
+      };
+    },
+  }),
+}));
+
+builder.queryFields((t) => ({
+  batchNumbers: t.connection({
+    type: BatchLoadableNumberThing,
+    resolve: (parent, args) => {
+      const numbers: BatchLoadableNumberThing[] = [];
+
+      for (let i = 0; i < 200; i += 1) {
+        numbers.push(new BatchLoadableNumberThing(i));
+      }
+
+      const result = resolveArrayConnection({ args }, numbers);
+
+      return result && { totalCount: 500, ...result };
+    },
+  }),
+  extraNode: t.node({
+    id: () => 'TnVtYmVyOjI=',
+  }),
+  moreNodes: t.nodeList({
+    ids: () => ['TnVtYmVyOjI=', { id: 10, type: NumberThing }],
+  }),
+}));
+
+const SharedConnection = builder.connectionObject({
+  name: 'SharedConnection',
+  type: NumberThing,
+});
+
+builder.queryField('sharedConnection', (t) =>
+  t.field({
+    type: SharedConnection,
+    nullable: true,
+    args: {
+      ...t.arg.connectionArgs(),
+    },
+    resolve: async (root, args) => {
+      const result = await resolveOffsetConnection({ args }, ({ limit, offset }) => {
+        const items = [];
+
+        for (let i = offset; i < Math.min(offset + limit, 200); i += 1) {
+          items.push(new NumberThing(i));
+        }
+
+        return items;
+      });
+
+      return {
+        totalCount: 500,
+        ...result,
+      };
+    },
+  }),
+);

--- a/packages/plugin-relay/tests/examples/custom-resolve/schema/poll.ts
+++ b/packages/plugin-relay/tests/examples/custom-resolve/schema/poll.ts
@@ -1,0 +1,183 @@
+/* eslint-disable @typescript-eslint/no-shadow */
+/* eslint-disable @typescript-eslint/require-await */
+import { resolveArrayConnection, resolveOffsetConnection } from '../../../../src';
+import builder from '../builder';
+
+builder.queryField('pollIds', (t) =>
+  t.globalIDList({
+    resolve: (parent, args, context) =>
+      [...context.Poll.map.keys()].map((key) => ({ id: key, type: 'Poll' as const })),
+  }),
+);
+
+builder.node('Poll', {
+  id: {
+    resolve: (poll) => poll.id,
+  },
+  loadMany: (ids, context) => ids.map((id) => context.Poll.map.get(Number.parseInt(id, 10))),
+  fields: (t) => ({
+    updatedAt: t.string({
+      resolve: () => new Date().toISOString(),
+    }),
+    question: t.exposeString('question', {}),
+    answers: t.expose('answers', {
+      type: ['Answer'],
+    }),
+    answersConnection: t.connection({
+      type: 'Answer',
+      // args automatically gets default cursor pagination args, but you can add more args like any other field
+      resolve: async (parent, args) => ({
+        totalCount: parent.answers.length,
+        // This would be for simple cases where you already have all the data
+        ...(await resolveArrayConnection({ args }, parent.answers))!,
+      }),
+    }),
+    answersUsingOffset: t.connection({
+      type: 'Answer',
+      resolve: async (parent, args) => ({
+        totalCount: parent.answers.length,
+        // This would be the API for limit/offset based APIs
+        ...(await resolveOffsetConnection({ args }, ({ limit, offset }) =>
+          // replace with call to limit/offset based service
+          parent.answers.slice(offset, offset + limit),
+        ))!,
+      }),
+    }),
+    answersWithoutHelpers: t.connection(
+      {
+        type: 'Answer',
+        resolve: (parent, args) =>
+          // If you don't have a helper, this is the shape you are expected to return
+          ({
+            totalCount: parent.answers.length,
+            pageInfo: {
+              hasNextPage: false,
+              hasPreviousPage: false,
+              startCursor: 'abc',
+              endCursor: 'def',
+            },
+            edges: [
+              {
+                cursor: 'xyz',
+                node: parent.answers[0],
+              },
+            ],
+          }),
+      },
+      {
+        // Name for the Connection object
+        name: 'PollAnswersCon', // optional, will use ParentObject + capitalize(FieldName) + "Connection" as the default
+        fields: () => ({
+          /* define extra fields on Connection */
+        }),
+        // Other options like auth would go into this object as well
+      },
+      {
+        // Same as above, but for the Edge Object
+        name: 'PollAnswersConEdge', // optional, will use Connection name + "Edge" as the default
+        fields: () => ({
+          /* define extra fields on Edge */
+        }),
+      },
+    ),
+  }),
+});
+
+builder.objectType('Answer', {
+  fields: (t) => ({
+    id: t.exposeID('id', {}),
+    value: t.exposeString('value', {}),
+    count: t.exposeInt('count', {}),
+  }),
+});
+
+builder.queryField('pollsConnection', (t) =>
+  t.connection(
+    {
+      type: 'Poll',
+      resolve: async (root, args, { Poll: PollList }) => ({
+        totalCount: PollList.map.size,
+        pageInfo: {
+          hasNextPage: false,
+          hasPreviousPage: false,
+        },
+        edges: [...PollList.map.values()].map((node) => ({
+          cursor: String(node.id),
+          extra: 1,
+          node,
+        })),
+        extra: 'abc',
+      }),
+    },
+    {
+      name: 'QueryPollsConnection',
+      fields: (t) => ({
+        extraConnectionField: t.string({
+          resolve: (parent) => parent.extra,
+        }),
+      }),
+    },
+    {
+      name: 'QueryPollsConnectionEdge',
+      fields: (t) => ({
+        extraEdgeField: t.int({
+          resolve: (parent) => parent.extra,
+        }),
+      }),
+    },
+  ),
+);
+
+builder.queryFields((t) => ({
+  polls: t.field({
+    type: ['Poll'],
+    resolve: (root, args, { Poll }, info) => [...Poll.map.values()],
+  }),
+  poll: t.field({
+    type: 'Poll',
+    nullable: true,
+    args: {
+      id: t.arg.int({ required: true }),
+    },
+    resolve: (root, args, { Poll }, info) => Poll.map.get(args.id),
+  }),
+}));
+
+builder.mutationFields((t) => ({
+  createPoll: t.field({
+    type: 'Poll',
+    args: {
+      question: t.arg.string({ required: true }),
+      answers: t.arg.stringList({ required: true }),
+    },
+    resolve: (root, args, { Poll, pubsub }) => {
+      const poll = Poll.create(args.question, args.answers);
+
+      return poll;
+    },
+  }),
+  answerPoll: t.field({
+    type: 'Poll',
+    args: {
+      id: t.arg.id({ required: true }),
+      answer: t.arg.int({ required: true }),
+    },
+    resolve: (root, args, { Poll, pubsub }, info) => {
+      const poll = Poll.map.get(Number(args.id));
+
+      if (!poll) {
+        throw new Error(`Poll ${args.id} not found`);
+      }
+
+      const answer = poll.answers.find((a) => a.id === args.answer);
+
+      if (!answer) {
+        throw new Error(`Invalid answer for poll ${args.id}`);
+      }
+
+      answer.count += 1;
+
+      return poll;
+    },
+  }),
+}));

--- a/packages/plugin-relay/tests/examples/custom-resolve/server.ts
+++ b/packages/plugin-relay/tests/examples/custom-resolve/server.ts
@@ -1,0 +1,18 @@
+import { PubSub } from 'graphql-subscriptions';
+import { createTestServer } from '@pothos/test-utils';
+import { Poll } from './data';
+import schema from './schema';
+
+export const pubsub = new PubSub();
+
+const server = createTestServer({
+  schema,
+  contextFactory: () => ({
+    Poll,
+    pubsub,
+  }),
+});
+
+server.listen(3000, () => {
+  console.log('🚀 Server started at http://127.0.0.1:3000');
+});

--- a/packages/plugin-relay/tests/examples/custom-resolve/types.ts
+++ b/packages/plugin-relay/tests/examples/custom-resolve/types.ts
@@ -1,0 +1,7 @@
+import { PubSub } from 'graphql-subscriptions';
+import { Poll } from './data';
+
+export interface ContextType {
+  Poll: typeof Poll;
+  pubsub: PubSub;
+}


### PR DESCRIPTION
A draft for #664 the only thing i do not know is how to implement type inference.
For now i copied one of the tests & examples but i could provide other tests if needed.
Also i added a small bit to the plugins docs but haven't mentioned that a custom resolve for `node/nodes` isn't something most people would want. 