### PR TITLE
add function to compute custom name for errors plugin generated types

### DIFF
--- a/.changeset/slow-tigers-fail.md
+++ b/.changeset/slow-tigers-fail.md
@@ -1,0 +1,18 @@
+---
+'@pothos/plugin-errors': patch
+---
+
+Add `defaultGetTypeName` option to `@pothos/plugin-errors`, this option allows customizing the
+generated type names by this plugin.
+
+An example usage of this:
+
+```typescript
+export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
+  plugins: [ErrorPlugin, ValidationPlugin],
+  errorOptions: {
+    defaultTypes: [Error],
+    defaultGetTypeName: ({ fieldName, kind }) => `${fieldName}${kind}`,
+  },
+});
+```

--- a/.changeset/slow-tigers-fail.md
+++ b/.changeset/slow-tigers-fail.md
@@ -13,10 +13,10 @@ export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
   errorOptions: {
     defaultTypes: [Error],
     defaultResultOptions: {
-      name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+            name: ({ parentTypeName, fieldName }) => `${fieldName}_CustomResult`,
     },
     defaultUnionOptions: {
-      name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+            name: ({ parentTypeName, fieldName }) => `${fieldName}_CustomUnion`,
     },
   },
 });

--- a/.changeset/slow-tigers-fail.md
+++ b/.changeset/slow-tigers-fail.md
@@ -1,5 +1,5 @@
 ---
-'@pothos/plugin-errors': patch
+'@pothos/plugin-errors': minor
 ---
 
 Add `defaultGetTypeName` option to `@pothos/plugin-errors`, this option allows customizing the
@@ -7,12 +7,17 @@ generated type names by this plugin.
 
 An example usage of this:
 
-```typescript
+```ts
 export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
   plugins: [ErrorPlugin, ValidationPlugin],
   errorOptions: {
     defaultTypes: [Error],
-    defaultGetTypeName: ({ fieldName, kind }) => `${fieldName}${kind}`,
+    defaultResultOptions: {
+      name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+    },
+    defaultUnionOptions: {
+      name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+    },
   },
 });
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,12 @@ pnpm build
 pnpm test
 ```
 
+You can also run tests for specific packages:
+
+```bash
+pnpm --filter @pothos/core exec vitest
+```
+
 ## Regenerating any generated types for examples and tests
 
 ```bash

--- a/packages/plugin-errors/README.md
+++ b/packages/plugin-errors/README.md
@@ -98,7 +98,38 @@ errors plugin will automatically resolve to the corresponding error object type.
 - `defaultTypes`: An array of Error classes to include in every field with error handling.
 - `directResult`: Sets the default for `directResult` option on fields (only affects non-list
   fields)
-- `defaultGetTypeName`: A function to modify how type names are generated. (e.g. maybe you don't want to the 'Query'/'Mutation' prefix in your types, you could customize that using this function.)
+- `defaultResultOptions`: Sets the defaults for `result` option on fields.
+  - `name`: Function to generate a custom name on the generated result types.
+      ```ts
+      export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
+        plugins: [ErrorPlugin, ValidationPlugin],
+        errorOptions: {
+          defaultTypes: [Error],
+          defaultResultOptions: {
+            name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+          },
+          defaultUnionOptions: {
+            name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+          },
+        },
+      });
+      ```
+- `defaultUnionOptions`: Sets the defaults for `result` option on fields.
+  - `name`: Function to generate a custom name on the generated union types.
+      ```ts
+      export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
+        plugins: [ErrorPlugin, ValidationPlugin],
+        errorOptions: {
+          defaultTypes: [Error],
+          defaultResultOptions: {
+            name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+          },
+          defaultUnionOptions: {
+            name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+          },
+        },
+      });
+      ```
 
 ### Options on Fields
 

--- a/packages/plugin-errors/README.md
+++ b/packages/plugin-errors/README.md
@@ -106,10 +106,10 @@ errors plugin will automatically resolve to the corresponding error object type.
         errorOptions: {
           defaultTypes: [Error],
           defaultResultOptions: {
-            name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+            name: ({ parentTypeName, fieldName }) => `${fieldName}_CustomResult`,
           },
           defaultUnionOptions: {
-            name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+            name: ({ parentTypeName, fieldName }) => `${fieldName}_CustomUnion`,
           },
         },
       });

--- a/packages/plugin-errors/README.md
+++ b/packages/plugin-errors/README.md
@@ -98,6 +98,7 @@ errors plugin will automatically resolve to the corresponding error object type.
 - `defaultTypes`: An array of Error classes to include in every field with error handling.
 - `directResult`: Sets the default for `directResult` option on fields (only affects non-list
   fields)
+- `defaultGetTypeName`: A function to modify how type names are generated. (e.g. maybe you don't want to the 'Query'/'Mutation' prefix in your types, you could customize that using this function.)
 
 ### Options on Fields
 

--- a/packages/plugin-errors/src/types.ts
+++ b/packages/plugin-errors/src/types.ts
@@ -1,23 +1,18 @@
 import { EmptyToOptional, FieldNullability, Normalize, SchemaTypes, TypeParam } from '@pothos/core';
 
-export type GetTypeName = (options: {
-  parentTypeName: string;
-  fieldName: string;
-  kind: 'Success' | 'Result';
-}) => string
+export type GetTypeName = (options: { parentTypeName: string; fieldName: string }) => string;
 
 export interface ErrorsPluginOptions<Types extends SchemaTypes> {
   defaultTypes?: (new (...args: any[]) => Error)[];
-  defaultGetTypeName?: GetTypeName;
   directResult?: boolean;
   defaultUnionOptions?: Normalize<
     Omit<PothosSchemaTypes.UnionTypeOptions<Types>, 'resolveType' | 'types'> & {
-      name?: string;
+      name?: GetTypeName;
     }
   >;
   defaultResultOptions?: Normalize<
     Omit<PothosSchemaTypes.ObjectTypeOptions<Types, {}>, 'interfaces' | 'isTypeOf'> & {
-      name?: string;
+      name?: GetTypeName;
     }
   >;
 }

--- a/packages/plugin-errors/src/types.ts
+++ b/packages/plugin-errors/src/types.ts
@@ -1,7 +1,14 @@
 import { EmptyToOptional, FieldNullability, Normalize, SchemaTypes, TypeParam } from '@pothos/core';
 
+export type GetTypeName = (options: {
+  parentTypeName: string;
+  fieldName: string;
+  kind: 'Success' | 'Result';
+}) => string
+
 export interface ErrorsPluginOptions<Types extends SchemaTypes> {
   defaultTypes?: (new (...args: any[]) => Error)[];
+  defaultGetTypeName?: GetTypeName;
   directResult?: boolean;
   defaultUnionOptions?: Normalize<
     Omit<PothosSchemaTypes.UnionTypeOptions<Types>, 'resolveType' | 'types'> & {

--- a/packages/plugin-errors/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-errors/tests/__snapshots__/index.test.ts.snap
@@ -103,7 +103,7 @@ type DirectResult {
   id: ID!
 }
 
-union DirectResult_CUSTOM_NAME_Result = BaseError | DirectResult
+union DirectResult_CUSTOM_UNION_NAME = BaseError | DirectResult
 
 interface Error {
   message: String!
@@ -119,35 +119,35 @@ type ExtendedError implements Error {
   message: String!
 }
 
-union ExtendedErrorList_CUSTOM_NAME_Result = BaseError | Extended2Error | ExtendedError | ExtendedErrorList_CUSTOM_NAME_Success
-
-type ExtendedErrorList_CUSTOM_NAME_Success {
+type ExtendedErrorList_CUSTOM_RESULT_NAME {
   data: [String]!
 }
 
-union ExtendedError_CUSTOM_NAME_Result = BaseError | Extended2Error | ExtendedError | ExtendedError_CUSTOM_NAME_Success
+union ExtendedErrorList_CUSTOM_UNION_NAME = BaseError | Extended2Error | ExtendedError | ExtendedErrorList_CUSTOM_RESULT_NAME
 
-type ExtendedError_CUSTOM_NAME_Success {
+type ExtendedError_CUSTOM_RESULT_NAME {
   data: String!
 }
 
-union FieldWIthValidation_CUSTOM_NAME_Result = BaseError | FieldWIthValidation_CUSTOM_NAME_Success | ZodError
+union ExtendedError_CUSTOM_UNION_NAME = BaseError | Extended2Error | ExtendedError | ExtendedError_CUSTOM_RESULT_NAME
 
-type FieldWIthValidation_CUSTOM_NAME_Success {
+type FieldWIthValidation_CUSTOM_RESULT_NAME {
   result: Boolean!
 }
 
-union HelloWithMinLength_CUSTOM_NAME_Result = BaseError | HelloWithMinLength_CUSTOM_NAME_Success | LengthError
+union FieldWIthValidation_CUSTOM_UNION_NAME = BaseError | FieldWIthValidation_CUSTOM_RESULT_NAME | ZodError
 
-type HelloWithMinLength_CUSTOM_NAME_Success {
+type HelloWithMinLength_CUSTOM_RESULT_NAME {
   data: String!
 }
 
-union Hello_CUSTOM_NAME_Result = BaseError | Hello_CUSTOM_NAME_Success
+union HelloWithMinLength_CUSTOM_UNION_NAME = BaseError | HelloWithMinLength_CUSTOM_RESULT_NAME | LengthError
 
-type Hello_CUSTOM_NAME_Success {
+type Hello_CUSTOM_RESULT_NAME {
   data: String!
 }
+
+union Hello_CUSTOM_UNION_NAME = BaseError | Hello_CUSTOM_RESULT_NAME
 
 type LengthError implements Error {
   message: String!
@@ -155,27 +155,27 @@ type LengthError implements Error {
 }
 
 type Query {
-  directResult(shouldThrow: Boolean): DirectResult_CUSTOM_NAME_Result!
-  extendedError(throw: String): ExtendedError_CUSTOM_NAME_Result
-  extendedErrorList(throw: String): ExtendedErrorList_CUSTOM_NAME_Result
-  fieldWIthValidation(string: String): FieldWIthValidation_CUSTOM_NAME_Result!
-  hello(name: String!): Hello_CUSTOM_NAME_Result!
-  helloWithMinLength(name: String!): HelloWithMinLength_CUSTOM_NAME_Result!
-  simpleError(throw: Boolean): SimpleError_CUSTOM_NAME_Result!
-  validation2(stringList: [String!]): Validation2_CUSTOM_NAME_Result!
+  directResult(shouldThrow: Boolean): DirectResult_CUSTOM_UNION_NAME!
+  extendedError(throw: String): ExtendedError_CUSTOM_UNION_NAME
+  extendedErrorList(throw: String): ExtendedErrorList_CUSTOM_UNION_NAME
+  fieldWIthValidation(string: String): FieldWIthValidation_CUSTOM_UNION_NAME!
+  hello(name: String!): Hello_CUSTOM_UNION_NAME!
+  helloWithMinLength(name: String!): HelloWithMinLength_CUSTOM_UNION_NAME!
+  simpleError(throw: Boolean): SimpleError_CUSTOM_UNION_NAME!
+  validation2(stringList: [String!]): Validation2_CUSTOM_UNION_NAME!
 }
 
-union SimpleError_CUSTOM_NAME_Result = BaseError | SimpleError_CUSTOM_NAME_Success
-
-type SimpleError_CUSTOM_NAME_Success {
+type SimpleError_CUSTOM_RESULT_NAME {
   data: String!
 }
 
-union Validation2_CUSTOM_NAME_Result = BaseError | Validation2_CUSTOM_NAME_Success | ZodError
+union SimpleError_CUSTOM_UNION_NAME = BaseError | SimpleError_CUSTOM_RESULT_NAME
 
-type Validation2_CUSTOM_NAME_Success {
+type Validation2_CUSTOM_RESULT_NAME {
   result: Boolean!
 }
+
+union Validation2_CUSTOM_UNION_NAME = BaseError | Validation2_CUSTOM_RESULT_NAME | ZodError
 
 type ZodError implements Error {
   fieldErrors: [ZodFieldError!]!

--- a/packages/plugin-errors/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-errors/tests/__snapshots__/index.test.ts.snap
@@ -93,3 +93,97 @@ type ZodFieldError {
   path: [String!]!
 }"
 `;
+
+exports[`errors plugin > supports generating custom names 1`] = `
+"type BaseError implements Error {
+  message: String!
+}
+
+type DirectResult {
+  id: ID!
+}
+
+union DirectResult_CUSTOM_NAME_Result = BaseError | DirectResult
+
+interface Error {
+  message: String!
+}
+
+type Extended2Error implements Error {
+  code: Int!
+  message: String!
+}
+
+type ExtendedError implements Error {
+  code: Int!
+  message: String!
+}
+
+union ExtendedErrorList_CUSTOM_NAME_Result = BaseError | Extended2Error | ExtendedError | ExtendedErrorList_CUSTOM_NAME_Success
+
+type ExtendedErrorList_CUSTOM_NAME_Success {
+  data: [String]!
+}
+
+union ExtendedError_CUSTOM_NAME_Result = BaseError | Extended2Error | ExtendedError | ExtendedError_CUSTOM_NAME_Success
+
+type ExtendedError_CUSTOM_NAME_Success {
+  data: String!
+}
+
+union FieldWIthValidation_CUSTOM_NAME_Result = BaseError | FieldWIthValidation_CUSTOM_NAME_Success | ZodError
+
+type FieldWIthValidation_CUSTOM_NAME_Success {
+  result: Boolean!
+}
+
+union HelloWithMinLength_CUSTOM_NAME_Result = BaseError | HelloWithMinLength_CUSTOM_NAME_Success | LengthError
+
+type HelloWithMinLength_CUSTOM_NAME_Success {
+  data: String!
+}
+
+union Hello_CUSTOM_NAME_Result = BaseError | Hello_CUSTOM_NAME_Success
+
+type Hello_CUSTOM_NAME_Success {
+  data: String!
+}
+
+type LengthError implements Error {
+  message: String!
+  minLength: Int!
+}
+
+type Query {
+  directResult(shouldThrow: Boolean): DirectResult_CUSTOM_NAME_Result!
+  extendedError(throw: String): ExtendedError_CUSTOM_NAME_Result
+  extendedErrorList(throw: String): ExtendedErrorList_CUSTOM_NAME_Result
+  fieldWIthValidation(string: String): FieldWIthValidation_CUSTOM_NAME_Result!
+  hello(name: String!): Hello_CUSTOM_NAME_Result!
+  helloWithMinLength(name: String!): HelloWithMinLength_CUSTOM_NAME_Result!
+  simpleError(throw: Boolean): SimpleError_CUSTOM_NAME_Result!
+  validation2(stringList: [String!]): Validation2_CUSTOM_NAME_Result!
+}
+
+union SimpleError_CUSTOM_NAME_Result = BaseError | SimpleError_CUSTOM_NAME_Success
+
+type SimpleError_CUSTOM_NAME_Success {
+  data: String!
+}
+
+union Validation2_CUSTOM_NAME_Result = BaseError | Validation2_CUSTOM_NAME_Success | ZodError
+
+type Validation2_CUSTOM_NAME_Success {
+  result: Boolean!
+}
+
+type ZodError implements Error {
+  fieldErrors: [ZodFieldError!]!
+  message: String!
+}
+
+type ZodFieldError {
+  message: String!
+  path: [String!]!
+}"
+`;

--- a/packages/plugin-errors/tests/example/builder.ts
+++ b/packages/plugin-errors/tests/example/builder.ts
@@ -2,9 +2,19 @@ import SchemaBuilder from '@pothos/core';
 import ValidationPlugin from '@pothos/plugin-validation';
 import ErrorPlugin from '../../src';
 
-export default new SchemaBuilder<{}>({
+export const builder = new SchemaBuilder<{}>({
   plugins: [ErrorPlugin, ValidationPlugin],
   errorOptions: {
     defaultTypes: [Error],
+  },
+});
+
+export type Builder = typeof builder;
+
+export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
+  plugins: [ErrorPlugin, ValidationPlugin],
+  errorOptions: {
+    defaultTypes: [Error],
+    defaultGetTypeName: ({ fieldName, kind }) => `${fieldName}_CUSTOM_NAME_${kind}`,
   },
 });

--- a/packages/plugin-errors/tests/example/builder.ts
+++ b/packages/plugin-errors/tests/example/builder.ts
@@ -15,6 +15,11 @@ export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
   plugins: [ErrorPlugin, ValidationPlugin],
   errorOptions: {
     defaultTypes: [Error],
-    defaultGetTypeName: ({ fieldName, kind }) => `${fieldName}_CUSTOM_NAME_${kind}`,
+    defaultResultOptions: {
+      name: ({ fieldName }) => `${fieldName}_CUSTOM_RESULT_NAME`,
+    },
+    defaultUnionOptions: {
+      name: ({ fieldName }) => `${fieldName}_CUSTOM_UNION_NAME`,
+    },
   },
 });

--- a/packages/plugin-errors/tests/example/schema.ts
+++ b/packages/plugin-errors/tests/example/schema.ts
@@ -1,306 +1,306 @@
 import { ZodError, ZodFormattedError } from 'zod';
-import builder from './builder';
+import type { Builder } from './builder';
 
-const ErrorInterface = builder.interfaceRef<Error>('Error').implement({
-  fields: (t) => ({
-    message: t.exposeString('message'),
-  }),
-});
-
-builder.objectType(Error, {
-  name: 'BaseError',
-  interfaces: [ErrorInterface],
-});
-
-class LengthError extends Error {
-  minLength: number;
-
-  constructor(minLength: number) {
-    super(`string length should be at least ${minLength}`);
-
-    this.minLength = minLength;
-    this.name = 'LengthError';
-  }
-}
-
-builder.objectType(LengthError, {
-  name: 'LengthError',
-  interfaces: [ErrorInterface],
-  fields: (t) => ({
-    minLength: t.exposeInt('minLength'),
-  }),
-});
-
-builder.queryType({
-  fields: (t) => ({
-    // Simple error handling just using base error class
-    hello: t.string({
-      errors: {},
-      args: {
-        name: t.arg.string({ required: true }),
-      },
-      resolve: (parent, { name }) => {
-        if (!name.startsWith(name.slice(0, 1).toUpperCase())) {
-          throw new Error('name must be capitalized');
-        }
-
-        return `hello, ${name || 'World'}`;
-      },
-    }),
-    // Handling custom errors
-    helloWithMinLength: t.string({
-      errors: {
-        types: [LengthError],
-      },
-      args: {
-        name: t.arg.string({ required: true }),
-      },
-      resolve: (parent, { name }) => {
-        if (name.length < 5) {
-          throw new LengthError(5);
-        }
-
-        return `hello, ${name || 'World'}`;
-      },
-    }),
-  }),
-});
-
-class ExtendedError extends Error {
-  errorCode = 123;
-
-  constructor(message: string) {
-    super(message);
-    this.name = 'ExtendedError';
-  }
-}
-
-class Extended2Error extends Error {
-  errorCode = 123;
-
-  constructor(message: string) {
-    super(message);
-    this.name = 'Extended2Error';
-  }
-}
-
-class OtherError {
-  message: string;
-
-  constructor(message: string) {
-    this.message = message;
-  }
-}
-
-builder.objectType(ExtendedError, {
-  name: 'ExtendedError',
-  interfaces: [ErrorInterface],
-  isTypeOf: (obj) => obj instanceof ExtendedError,
-  fields: (t) => ({
-    message: t.exposeString('message'),
-    code: t.exposeInt('errorCode'),
-  }),
-});
-
-builder.objectType(Extended2Error, {
-  name: 'Extended2Error',
-  interfaces: [ErrorInterface],
-  fields: (t) => ({
-    message: t.exposeString('message'),
-    code: t.exposeInt('errorCode'),
-  }),
-});
-
-builder.queryFields((t) => ({
-  simpleError: t.string({
-    args: {
-      throw: t.arg.boolean(),
-    },
-    errors: {
-      types: [Error],
-    },
-    resolve: (parent, args) => {
-      if (args.throw) {
-        throw new Error('Error from simpleError field');
-      }
-
-      return 'ok';
-    },
-  }),
-  extendedError: t.string({
-    nullable: true,
-    args: {
-      throw: t.arg.string(),
-    },
-    errors: {
-      types: [Extended2Error, Error, ExtendedError],
-    },
-    resolve: (parent, args) => {
-      if (args.throw === 'other') {
-        // eslint-disable-next-line @typescript-eslint/no-throw-literal
-        throw new OtherError('Error from extendedError');
-      }
-
-      if (args.throw === 'extended') {
-        throw new ExtendedError('Error from extendedError');
-      }
-
-      if (args.throw === 'extended2') {
-        throw new Extended2Error('Error from extendedError');
-      }
-
-      if (args.throw) {
-        throw new Error('Error from extendedError');
-      }
-
-      return 'ok';
-    },
-  }),
-  extendedErrorList: t.stringList({
-    nullable: {
-      items: true,
-      list: true,
-    },
-    args: {
-      throw: t.arg.string(),
-    },
-    errors: {
-      types: [Extended2Error, Error, ExtendedError],
-    },
-    resolve: (parent, args) => {
-      if (args.throw === 'other') {
-        // eslint-disable-next-line @typescript-eslint/no-throw-literal
-        throw new OtherError('Error from extendedError');
-      }
-
-      if (args.throw === 'extended') {
-        throw new ExtendedError('Error from extendedError');
-      }
-
-      if (args.throw === 'extended2') {
-        throw new Extended2Error('Error from extendedError');
-      }
-
-      if (args.throw) {
-        throw new Error('Error from extendedError');
-      }
-
-      return ['ok'];
-    },
-  }),
-}));
-
-function flattenErrors(
-  error: ZodFormattedError<unknown>,
-  path: string[],
-): { path: string[]; message: string }[] {
-  // eslint-disable-next-line no-underscore-dangle
-  const errors = error._errors.map((message) => ({
-    path,
-    message,
-  }));
-
-  Object.keys(error).forEach((key) => {
-    if (key !== '_errors') {
-      errors.push(
-        ...flattenErrors((error as Record<string, unknown>)[key] as ZodFormattedError<unknown>, [
-          ...path,
-          key,
-        ]),
-      );
-    }
-  });
-
-  return errors;
-}
-
-const ZodFieldError = builder
-  .objectRef<{
-    message: string;
-    path: string[];
-  }>('ZodFieldError')
-  .implement({
+export function createSchema(builder: Builder) {
+  const ErrorInterface = builder.interfaceRef<Error>('Error').implement({
     fields: (t) => ({
       message: t.exposeString('message'),
-      path: t.exposeStringList('path'),
     }),
   });
 
-builder.objectType(ZodError, {
-  name: 'ZodError',
-  interfaces: [ErrorInterface],
-  fields: (t) => ({
-    fieldErrors: t.field({
-      type: [ZodFieldError],
-      resolve: (err) => flattenErrors(err.format(), []),
-    }),
-  }),
-});
+  builder.objectType(Error, {
+    name: 'BaseError',
+    interfaces: [ErrorInterface],
+  });
 
-builder.queryField('fieldWIthValidation', (t) =>
-  t.boolean({
-    errors: {
-      types: [ZodError],
-      dataField: { name: 'result' },
-    },
-    args: {
-      string: t.arg.string({
-        validate: {
-          type: 'string',
-          minLength: 3,
+  class LengthError extends Error {
+    minLength: number;
+
+    constructor(minLength: number) {
+      super(`string length should be at least ${minLength}`);
+
+      this.minLength = minLength;
+      this.name = 'LengthError';
+    }
+  }
+
+  builder.objectType(LengthError, {
+    name: 'LengthError',
+    interfaces: [ErrorInterface],
+    fields: (t) => ({
+      minLength: t.exposeInt('minLength'),
+    }),
+  });
+
+  builder.queryType({
+    fields: (t) => ({
+      // Simple error handling just using base error class
+      hello: t.string({
+        errors: {},
+        args: {
+          name: t.arg.string({ required: true }),
+        },
+        resolve: (parent, { name }) => {
+          if (!name.startsWith(name.slice(0, 1).toUpperCase())) {
+            throw new Error('name must be capitalized');
+          }
+
+          return `hello, ${name || 'World'}`;
         },
       }),
-    },
-    resolve: () => true,
-  }),
-);
+      // Handling custom errors
+      helloWithMinLength: t.string({
+        errors: {
+          types: [LengthError],
+        },
+        args: {
+          name: t.arg.string({ required: true }),
+        },
+        resolve: (parent, { name }) => {
+          if (name.length < 5) {
+            throw new LengthError(5);
+          }
 
-builder.queryField('validation2', (t) =>
-  t.boolean({
-    errors: {
-      types: [ZodError],
-      dataField: { name: 'result' },
-    },
-    args: {
-      stringList: t.arg.stringList({
-        validate: {
-          items: {
+          return `hello, ${name || 'World'}`;
+        },
+      }),
+    }),
+  });
+
+  class ExtendedError extends Error {
+    errorCode = 123;
+
+    constructor(message: string) {
+      super(message);
+      this.name = 'ExtendedError';
+    }
+  }
+
+  class Extended2Error extends Error {
+    errorCode = 123;
+
+    constructor(message: string) {
+      super(message);
+      this.name = 'Extended2Error';
+    }
+  }
+
+  class OtherError {
+    message: string;
+
+    constructor(message: string) {
+      this.message = message;
+    }
+  }
+
+  builder.objectType(ExtendedError, {
+    name: 'ExtendedError',
+    interfaces: [ErrorInterface],
+    isTypeOf: (obj) => obj instanceof ExtendedError,
+    fields: (t) => ({
+      message: t.exposeString('message'),
+      code: t.exposeInt('errorCode'),
+    }),
+  });
+
+  builder.objectType(Extended2Error, {
+    name: 'Extended2Error',
+    interfaces: [ErrorInterface],
+    fields: (t) => ({
+      message: t.exposeString('message'),
+      code: t.exposeInt('errorCode'),
+    }),
+  });
+
+  builder.queryFields((t) => ({
+    simpleError: t.string({
+      args: {
+        throw: t.arg.boolean(),
+      },
+      errors: {
+        types: [Error],
+      },
+      resolve: (parent, args) => {
+        if (args.throw) {
+          throw new Error('Error from simpleError field');
+        }
+
+        return 'ok';
+      },
+    }),
+    extendedError: t.string({
+      nullable: true,
+      args: {
+        throw: t.arg.string(),
+      },
+      errors: {
+        types: [Extended2Error, Error, ExtendedError],
+      },
+      resolve: (parent, args) => {
+        if (args.throw === 'other') {
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw new OtherError('Error from extendedError');
+        }
+
+        if (args.throw === 'extended') {
+          throw new ExtendedError('Error from extendedError');
+        }
+
+        if (args.throw === 'extended2') {
+          throw new Extended2Error('Error from extendedError');
+        }
+
+        if (args.throw) {
+          throw new Error('Error from extendedError');
+        }
+
+        return 'ok';
+      },
+    }),
+    extendedErrorList: t.stringList({
+      nullable: {
+        items: true,
+        list: true,
+      },
+      args: {
+        throw: t.arg.string(),
+      },
+      errors: {
+        types: [Extended2Error, Error, ExtendedError],
+      },
+      resolve: (parent, args) => {
+        if (args.throw === 'other') {
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw new OtherError('Error from extendedError');
+        }
+
+        if (args.throw === 'extended') {
+          throw new ExtendedError('Error from extendedError');
+        }
+
+        if (args.throw === 'extended2') {
+          throw new Extended2Error('Error from extendedError');
+        }
+
+        if (args.throw) {
+          throw new Error('Error from extendedError');
+        }
+
+        return ['ok'];
+      },
+    }),
+  }));
+
+  function flattenErrors(
+    error: ZodFormattedError<unknown>,
+    path: string[],
+  ): { path: string[]; message: string }[] {
+    // eslint-disable-next-line no-underscore-dangle
+    const errors = error._errors.map((message) => ({
+      path,
+      message,
+    }));
+
+    Object.keys(error).forEach((key) => {
+      if (key !== '_errors') {
+        errors.push(
+          ...flattenErrors((error as Record<string, unknown>)[key] as ZodFormattedError<unknown>, [
+            ...path,
+            key,
+          ]),
+        );
+      }
+    });
+
+    return errors;
+  }
+
+  const ZodFieldError = builder
+    .objectRef<{
+      message: string;
+      path: string[];
+    }>('ZodFieldError')
+    .implement({
+      fields: (t) => ({
+        message: t.exposeString('message'),
+        path: t.exposeStringList('path'),
+      }),
+    });
+
+  builder.objectType(ZodError, {
+    name: 'ZodError',
+    interfaces: [ErrorInterface],
+    fields: (t) => ({
+      fieldErrors: t.field({
+        type: [ZodFieldError],
+        resolve: (err) => flattenErrors(err.format(), []),
+      }),
+    }),
+  });
+
+  builder.queryField('fieldWIthValidation', (t) =>
+    t.boolean({
+      errors: {
+        types: [ZodError],
+        dataField: { name: 'result' },
+      },
+      args: {
+        string: t.arg.string({
+          validate: {
             type: 'string',
             minLength: 3,
           },
-        },
-      }),
-    },
-    validate: (err) => false,
-    resolve: () => true,
-  }),
-);
+        }),
+      },
+      resolve: () => true,
+    }),
+  );
 
-const DirectResult = builder.objectRef<{}>('DirectResult').implement({
-  fields: (t) => ({
-    id: t.id({ resolve: () => 123 }),
-  }),
-});
+  builder.queryField('validation2', (t) =>
+    t.boolean({
+      errors: {
+        types: [ZodError],
+        dataField: { name: 'result' },
+      },
+      args: {
+        stringList: t.arg.stringList({
+          validate: {
+            items: {
+              type: 'string',
+              minLength: 3,
+            },
+          },
+        }),
+      },
+      validate: (err) => false,
+      resolve: () => true,
+    }),
+  );
 
-builder.queryField('directResult', (t) =>
-  t.field({
-    type: DirectResult,
-    errors: {
-      directResult: true,
-    },
-    args: {
-      shouldThrow: t.arg.boolean(),
-    },
-    resolve: (root, args) => {
-      if (args.shouldThrow) {
-        throw new Error('Boom');
-      }
+  const DirectResult = builder.objectRef<{}>('DirectResult').implement({
+    fields: (t) => ({
+      id: t.id({ resolve: () => 123 }),
+    }),
+  });
 
-      return {};
-    },
-  }),
-);
+  builder.queryField('directResult', (t) =>
+    t.field({
+      type: DirectResult,
+      errors: {
+        directResult: true,
+      },
+      args: {
+        shouldThrow: t.arg.boolean(),
+      },
+      resolve: (root, args) => {
+        if (args.shouldThrow) {
+          throw new Error('Boom');
+        }
 
-const schema = builder.toSchema();
+        return {};
+      },
+    }),
+  );
 
-export default schema;
+  return builder.toSchema();
+}

--- a/packages/plugin-errors/tests/index.test.ts
+++ b/packages/plugin-errors/tests/index.test.ts
@@ -3,7 +3,7 @@ import { gql } from 'graphql-tag';
 import { builder, builderWithCustomErrorTypeNames } from './example/builder';
 import { createSchema } from './example/schema';
 
-const schema = createSchema(builder)
+const schema = createSchema(builder);
 
 describe('errors plugin', () => {
   it('generates expected schema', () => {
@@ -170,11 +170,11 @@ describe('errors plugin', () => {
   });
 
   it('supports generating custom names', () => {
-    const schema = createSchema(builderWithCustomErrorTypeNames)
-    expect(printSchema(schema)).toMatchSnapshot();
+    const schemaWithCustomTypeNames = createSchema(builderWithCustomErrorTypeNames);
+    expect(printSchema(schemaWithCustomTypeNames)).toMatchSnapshot();
 
     expect(() => {
       builderWithCustomErrorTypeNames.toSchema();
     }).not.toThrow();
-  })
+  });
 });

--- a/packages/plugin-errors/tests/index.test.ts
+++ b/packages/plugin-errors/tests/index.test.ts
@@ -1,7 +1,9 @@
 import { execute, printSchema } from 'graphql';
 import { gql } from 'graphql-tag';
-import builder from './example/builder';
-import schema from './example/schema';
+import { builder, builderWithCustomErrorTypeNames } from './example/builder';
+import { createSchema } from './example/schema';
+
+const schema = createSchema(builder)
 
 describe('errors plugin', () => {
   it('generates expected schema', () => {
@@ -166,4 +168,13 @@ describe('errors plugin', () => {
       }
     `);
   });
+
+  it('supports generating custom names', () => {
+    const schema = createSchema(builderWithCustomErrorTypeNames)
+    expect(printSchema(schema)).toMatchSnapshot();
+
+    expect(() => {
+      builderWithCustomErrorTypeNames.toSchema();
+    }).not.toThrow();
+  })
 });

--- a/website/pages/docs/plugins/errors.mdx
+++ b/website/pages/docs/plugins/errors.mdx
@@ -112,6 +112,38 @@ errors plugin will automatically resolve to the corresponding error object type.
 - `defaultTypes`: An array of Error classes to include in every field with error handling.
 - `directResult`: Sets the default for `directResult` option on fields (only affects non-list
   fields)
+- `defaultResultOptions`: Sets the defaults for `result` option on fields.
+  - `name`: Function to generate a custom name on the generated result types.
+    ```ts
+    export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
+      plugins: [ErrorPlugin, ValidationPlugin],
+      errorOptions: {
+        defaultTypes: [Error],
+        defaultResultOptions: {
+          name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+        },
+        defaultUnionOptions: {
+          name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+        },
+      },
+    });
+    ```
+- `defaultUnionOptions`: Sets the defaults for `result` option on fields.
+  - `name`: Function to generate a custom name on the generated union types.
+    ```ts
+    export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
+      plugins: [ErrorPlugin, ValidationPlugin],
+      errorOptions: {
+        defaultTypes: [Error],
+        defaultResultOptions: {
+          name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+        },
+        defaultUnionOptions: {
+          name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
+        },
+      },
+    });
+    ```
 
 ### Options on Fields
 


### PR DESCRIPTION
# Description

Adds an option for the `@pothos/plugin-errors` plugin to customize how type names are generated. 

This new option could be used like:

```typescript
export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
  plugins: [ErrorPlugin, ValidationPlugin],
  errorOptions: {
    defaultTypes: [Error],
    defaultGetTypeName: ({ fieldName, kind }) => `${fieldName}${kind}`,
  },
});
```

The above would get rid of the `Query|Mutation` prefix that is added automatically to these types, in case users want to modify these.

Resolves https://github.com/hayes/pothos/issues/566

Docs screenshot:
![CleanShot 2023-01-06 at 17 34 57](https://user-images.githubusercontent.com/11748696/211117442-bd0bcde8-aca5-4150-ad89-bc74ad1cb51f.png)

