### PR TITLE
Fix lazy interfaces on nodes

### DIFF
--- a/.changeset/fresh-eels-shop.md
+++ b/.changeset/fresh-eels-shop.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-relay': patch
+---
+
+Fix a bug where `builder.node` crashed when the `interfaces` was provided as a function

--- a/packages/plugin-relay/src/schema-builder.ts
+++ b/packages/plugin-relay/src/schema-builder.ts
@@ -218,9 +218,9 @@ schemaBuilderProto.nodeInterfaceRef = function nodeInterfaceRef() {
 
 schemaBuilderProto.node = function node(param, { interfaces, ...options }, fields) {
   verifyRef(param);
-  const interfacesWithNode: InterfaceParam<SchemaTypes>[] = [
+  const interfacesWithNode: () => InterfaceParam<SchemaTypes>[] = () => [
     this.nodeInterfaceRef(),
-    ...((interfaces ?? []) as InterfaceParam<SchemaTypes>[]),
+    ...(typeof interfaces === 'function' ? interfaces() : interfaces ?? []),
   ];
 
   let nodeName!: string;
@@ -256,7 +256,7 @@ schemaBuilderProto.node = function node(param, { interfaces, ...options }, field
               return false;
             }
           : undefined),
-      interfaces: interfacesWithNode as [],
+      interfaces: interfacesWithNode as () => [],
     },
     fields,
   );

--- a/packages/plugin-relay/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-relay/tests/__snapshots__/index.test.ts.snap
@@ -225,6 +225,28 @@ type SharedEdge {
 }"
 `;
 
+exports[`relay example schema > generates expected schema with additional interfaces 1`] = `
+"type Customer implements Node & User {
+  age: Int!
+  displayName: String!
+  id: ID!
+}
+
+interface Node {
+  id: ID!
+}
+
+type Query {
+  node(id: ID!): Node
+  nodes(ids: [ID!]!): [Node]!
+}
+
+interface User {
+  displayName: String!
+  id: ID!
+}"
+`;
+
 exports[`relay example schema > generates expected schema with globalConnectionFields 1`] = `
 "type Answer {
   count: Int!

--- a/packages/plugin-relay/tests/examples/node-with-interfaces/builder.ts
+++ b/packages/plugin-relay/tests/examples/node-with-interfaces/builder.ts
@@ -1,0 +1,16 @@
+import SchemaBuilder from '@pothos/core';
+import RelayPlugin from '../../../src';
+import { Customer, User } from './types';
+
+export default new SchemaBuilder<{
+  Interfaces: {
+    User: User;
+  };
+  Objects: {
+    Customer: Customer;
+  };
+  DefaultNodeNullability: true;
+}>({
+  plugins: [RelayPlugin],
+  relayOptions: {},
+});

--- a/packages/plugin-relay/tests/examples/node-with-interfaces/data.ts
+++ b/packages/plugin-relay/tests/examples/node-with-interfaces/data.ts
@@ -1,0 +1,9 @@
+import { Customer } from './types';
+
+export const customers: Customer[] = Array.from({ length: 10 })
+  .fill(0)
+  .map((_, index) => ({ id: index + 1, age: getAge(index), displayName: `User_${index}` }));
+
+function getAge(index: number): number {
+  return 100 - index * 10;
+}

--- a/packages/plugin-relay/tests/examples/node-with-interfaces/schema/index.ts
+++ b/packages/plugin-relay/tests/examples/node-with-interfaces/schema/index.ts
@@ -1,0 +1,27 @@
+import builder from '../builder';
+import { customers } from '../data';
+
+builder.interfaceType('User', {
+  fields: (t) => ({
+    id: t.id(),
+    displayName: t.string(),
+  }),
+});
+
+builder.node('Customer', {
+  id: {
+    resolve: (user) => user.id,
+  },
+  loadOne: (id) => customers[Number.parseInt(String(id), 10)],
+  isTypeOf: () => true,
+  // Objects that implement Node can also implement any additional
+  // interface
+  interfaces: () => ['User'],
+  fields: (t) => ({
+    age: t.exposeInt('age'),
+  }),
+});
+
+builder.queryType({});
+
+export default builder.toSchema();

--- a/packages/plugin-relay/tests/examples/node-with-interfaces/server.ts
+++ b/packages/plugin-relay/tests/examples/node-with-interfaces/server.ts
@@ -1,0 +1,10 @@
+import { createTestServer } from '@pothos/test-utils';
+import schema from './schema';
+
+const server = createTestServer({
+  schema,
+});
+
+server.listen(3000, () => {
+  console.log('🚀 Server started at http://127.0.0.1:3000');
+});

--- a/packages/plugin-relay/tests/examples/node-with-interfaces/types.ts
+++ b/packages/plugin-relay/tests/examples/node-with-interfaces/types.ts
@@ -1,0 +1,8 @@
+export interface User {
+  id: number;
+  displayName: string;
+}
+
+export interface Customer extends User {
+  age: number;
+}

--- a/packages/plugin-relay/tests/index.test.ts
+++ b/packages/plugin-relay/tests/index.test.ts
@@ -1,6 +1,7 @@
 import { execute, printSchema } from 'graphql';
 import { gql } from 'graphql-tag';
 import schemaWithGlobalConnectionFields from './examples/global-connection-fields/schema';
+import schemaWithAdditionalInterfaces from './examples/node-with-interfaces/schema';
 import schema from './examples/relay/schema';
 
 describe('relay example schema', () => {
@@ -10,6 +11,10 @@ describe('relay example schema', () => {
 
   it('generates expected schema with globalConnectionFields', () => {
     expect(printSchema(schemaWithGlobalConnectionFields)).toMatchSnapshot();
+  });
+
+  it('generates expected schema with additional interfaces', () => {
+    expect(printSchema(schemaWithAdditionalInterfaces)).toMatchSnapshot();
   });
 
   describe('queries', () => {


### PR DESCRIPTION
When passing the `interfaces` field to `builder.node` as a function that returns an array (rather than the array directly), a runtime error was occurring. 

The reason was that line `223` of the file changed in this PR was using the spread operator on the passed `interfaces`, which crashes if the value is a function. The compiler didn't catch this because the `as` operator was coercing the value as an array. 