### PR TITLE
Fix types on connection fields on interfaces

### DIFF
--- a/.changeset/twelve-tables-itch.md
+++ b/.changeset/twelve-tables-itch.md
@@ -1,0 +1,6 @@
+---
+'@pothos/plugin-relay': patch
+---
+
+Fix a bug where the `t.connection` helper wasn't correctly inferring the shape of the returned
+connection object when used on interfaces.

--- a/packages/deno/packages/plugin-relay/global-types.ts
+++ b/packages/deno/packages/plugin-relay/global-types.ts
@@ -90,7 +90,7 @@ declare global {
             connection: <Type extends OutputType<Types>, Args extends InputFieldMap, Nullable extends boolean, ResolveShape, ResolveReturnShape, EdgeNullability extends FieldNullability<[
                 unknown
             ]> = Types["DefaultEdgesNullability"], NodeNullability extends boolean = Types["DefaultNodeNullability"]>(options: FieldOptionsFromKind<Types, ParentShape, Type, Nullable, (InputFieldMap extends Args ? {} : Args) & InputFieldsFromShape<DefaultConnectionArguments>, Kind, ResolveShape, ResolveReturnShape> extends infer FieldOptions ? ConnectionFieldOptions<Types, FieldOptions extends {
-                resolve: (parent: infer P, ...args: any[]) => unknown;
+                resolve?: (parent: infer P, ...args: any[]) => unknown;
             } ? P : unknown extends ResolveShape ? ParentShape : ResolveShape, Type, Nullable, EdgeNullability, NodeNullability, Args, ResolveReturnShape> & Omit<FieldOptions, "args" | "resolve" | "type"> : never, ...args: NormalizeArgs<[
                 connectionOptions: ObjectRef<ConnectionShapeForType<Types, Type, false, EdgeNullability, NodeNullability>> | Omit<ConnectionObjectOptions<Types, Type, EdgeNullability, NodeNullability, ResolveReturnShape>, "edgesNullable">,
                 edgeOptions: ObjectRef<{

--- a/packages/plugin-relay/src/global-types.ts
+++ b/packages/plugin-relay/src/global-types.ts
@@ -253,7 +253,7 @@ declare global {
         > extends infer FieldOptions
           ? ConnectionFieldOptions<
               Types,
-              FieldOptions extends { resolve: (parent: infer P, ...args: any[]) => unknown }
+              FieldOptions extends { resolve?: (parent: infer P, ...args: any[]) => unknown }
                 ? P
                 : unknown extends ResolveShape
                 ? ParentShape


### PR DESCRIPTION
**Original Problem:** I noticed this because I was trying to create a connection with additional fields. Something along the lines of:
```typescript
  users: t.connection(
    {
      type: GraphQLUser,
      resolve: (users, args) => {
        const connection = resolveArrayConnection({ args }, users)
        return <typeof connection & { totalCount: number }>{
          totalCount: recipients.length,
          ...connection,
        }
      },
    },
    {
      fields: tc => ({
        totalCount: tc.int({ resolve: x => x.totalCount }),
      }),
    }
  ),

```
This worked fine on object types, but when I tried this on an interface, the resolver for the `totalCount` int field wasn't aware that the return value of the connection's resolve included a `totalCount` field, so I wasn't able to resolve the value for the `int`. 

**Cause:** I realized that the conditional type changed in this diff didn't match interfaces, as fields there have an optional `resolve` property. This is why it was only matching objects, while interfaces were eventually assigned a default connection shape. 


**Solution:** I changed the conditional type to match an optional `resolve?` property which is the common lowest denominator. 

**Note:** I ran `pnpm` build and noticed that the `deno` package was automatically updated. I included the matching `deno` change caused by this PR, but noticed that the `build` command produced two additional changes that were related to other PRs. (One of them being caused by _my_ previous PR.) You might want to run `build` and put all the changes in master to bring `deno` up to date.
