### PR TITLE
Add Query type ref to type config

### DIFF
--- a/.changeset/tidy-needles-hang.md
+++ b/.changeset/tidy-needles-hang.md
@@ -1,0 +1,5 @@
+---
+"@pothos/core": patch
+---
+
+return a Ref from builder.queryType

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "rm -rf ./{packages/*,examples*,website}/{tsconfig.*tsbuildinfo,lib,esm,dts,.turbo,.next} && git checkout -- 'packages/*/esm/*'",
     "ci": "pnpm turbo run build generate test type --concurrency=4 && pnpm run lint:ci",
     "ci:version": "changeset version && pnpm install --frozen-lockfile false",
-    "coverage": "pnpm run test --coverage",
+    "coverage": "pnpm run test -- --coverage",
     "format": "prettier",
     "lint": "eslint --cache '{packages,examples}/*/{src,test}/**.{ts,js}'",
     "lint:ci": "eslint --cache  '{packages,examples}/*/{src,test}/**.{ts,js}'",
@@ -52,7 +52,8 @@
     "turbo": "^1.6.3",
     "typescript": "4.9.3",
     "typescript-json-schema": "^0.55.0",
-    "vitest": "^0.25.3"
+    "vitest": "^0.25.3",
+    "@vitest/coverage-c8": "^0.25.8"
   },
   "resolutions": {
     "graphql": "16.6.0"

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -216,7 +216,9 @@ export default class SchemaBuilder<Types extends SchemaTypes> {
       extensions: options.extensions,
     };
 
-    this.configStore.addTypeConfig(config);
+    const ref = new ObjectRef<OutputShape<Types, 'Query'>, ParentShape<Types, 'Query'>>('Query');
+
+    this.configStore.addTypeConfig(config, ref);
 
     if (fields) {
       this.configStore.addFields('Query', () => fields(new QueryFieldBuilder(this)));
@@ -225,6 +227,8 @@ export default class SchemaBuilder<Types extends SchemaTypes> {
     if (options.fields) {
       this.configStore.addFields('Query', () => options.fields!(new QueryFieldBuilder(this)));
     }
+
+    return ref;
   }
 
   queryFields(fields: QueryFieldsShape<Types>) {

--- a/packages/core/tests/__snapshots__/patterns.test.ts.snap
+++ b/packages/core/tests/__snapshots__/patterns.test.ts.snap
@@ -26,6 +26,7 @@ type Mutation {
 
 type Query {
   circular: A!
+  query: Query!
 }
 
 type WithCommonFields1 {

--- a/packages/core/tests/examples/patterns/builder.ts
+++ b/packages/core/tests/examples/patterns/builder.ts
@@ -1,6 +1,9 @@
 import SchemaBuilder from '../../../src';
 
 export interface SchemaTypes {
+  Objects: {
+    Query: {};
+  };
   Scalars: {
     ID: {
       Input: string;

--- a/packages/core/tests/examples/patterns/types/circular.ts
+++ b/packages/core/tests/examples/patterns/types/circular.ts
@@ -12,10 +12,14 @@ A.implement({
   }),
 });
 
-builder.queryType({
+const query = builder.queryType({
   fields: (t) => ({
     circular: t.field({
       type: A,
+      resolve: () => ({}),
+    }),
+    query: t.field({
+      type: query,
       resolve: () => ({}),
     }),
   }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ importers:
       '@swc/jest': ^0.2.23
       '@types/jest': ^29.2.3
       '@types/node': ^18.11.10
+      '@vitest/coverage-c8': ^0.25.8
       eslint: ^8.28.0
       eslint-config-moon: ^1.4.1
       eslint-plugin-import: ^2.26.0
@@ -39,6 +40,7 @@ importers:
       '@swc/jest': 0.2.23_@swc+core@1.3.21
       '@types/jest': 29.2.3
       '@types/node': 18.11.10
+      '@vitest/coverage-c8': 0.25.8
       eslint: 8.28.0
       eslint-config-moon: 1.4.1_hvxqdsjkjokmcg2b224742mf4q
       eslint-plugin-prettier: 4.2.1_5qrnzwqb344w6up62gv3safeoi
@@ -98,6 +100,9 @@ importers:
       '@graphql-codegen/introspection': 2.2.1_graphql@16.6.0
       '@graphql-codegen/schema-ast': 2.5.1_graphql@16.6.0
       typescript: 4.9.3
+
+  examples/complex-app/prisma/client:
+    specifiers: {}
 
   examples/envelope-helix-fastify:
     specifiers:
@@ -264,6 +269,9 @@ importers:
       graphql: 16.6.0
       prisma: 4.7.1
 
+  examples/prisma-federation/prisma/client:
+    specifiers: {}
+
   examples/prisma-relay:
     specifiers:
       '@faker-js/faker': ^7.6.0
@@ -283,6 +291,12 @@ importers:
       graphql: 16.6.0
       graphql-yoga: 3.1.1_graphql@16.6.0
       prisma: 4.7.1
+
+  examples/prisma-relay/prisma/client:
+    specifiers: {}
+
+  examples/prisma/prisma/client:
+    specifiers: {}
 
   examples/relay-windowed-pagination:
     specifiers:
@@ -568,7 +582,13 @@ importers:
   packages/plugin-prisma-utils/esm:
     specifiers: {}
 
+  packages/plugin-prisma-utils/tests/client:
+    specifiers: {}
+
   packages/plugin-prisma/esm:
+    specifiers: {}
+
+  packages/plugin-prisma/tests/client:
     specifiers: {}
 
   packages/plugin-relay:
@@ -611,6 +631,9 @@ importers:
       prisma: 4.7.1
 
   packages/plugin-scope-auth/esm:
+    specifiers: {}
+
+  packages/plugin-scope-auth/prisma/client:
     specifiers: {}
 
   packages/plugin-simple-objects:
@@ -719,6 +742,9 @@ importers:
       prisma: 4.7.1
 
   packages/plugin-with-input/esm:
+    specifiers: {}
+
+  packages/plugin-with-input/prisma/client:
     specifiers: {}
 
   packages/test-utils:
@@ -5221,6 +5247,25 @@ packages:
       wonka: 6.1.2
     dev: false
 
+  /@vitest/coverage-c8/0.25.8:
+    resolution: {integrity: sha512-fWgzQoK2KNzTTNnDcLCyibfO9/pbcpPOMtZ9Yvq/Eggpi2X8lewx/OcKZkO5ba5q9dl6+BBn6d5hTcS1709rZw==}
+    dependencies:
+      c8: 7.12.0
+      vitest: 0.25.8
+    transitivePeerDependencies:
+      - '@edge-runtime/vm'
+      - '@vitest/browser'
+      - '@vitest/ui'
+      - happy-dom
+      - jsdom
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /@whatwg-node/events/0.0.2:
     resolution: {integrity: sha512-WKj/lI4QjnLuPrim0cfO7i+HsDSXHxNv1y0CrJhdntuO3hxWZmnXCwNDnwOvry11OjRin6cgWNF+j/9Pn8TN4w==}
 
@@ -6118,6 +6163,25 @@ packages:
   /bytes/3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  /c8/7.12.0:
+    resolution: {integrity: sha512-CtgQrHOkyxr5koX1wEUmN/5cfDa2ckbHRA4Gy5LAL0zaCFtVWJS5++n+w4/sr2GWGerBxgTjpKeDclk/Qk6W/A==}
+    engines: {node: '>=10.12.0'}
+    hasBin: true
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@istanbuljs/schema': 0.1.3
+      find-up: 5.0.0
+      foreground-child: 2.0.0
+      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-report: 3.0.0
+      istanbul-reports: 3.1.5
+      rimraf: 3.0.2
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.0.1
+      yargs: 16.2.0
+      yargs-parser: 20.2.9
+    dev: true
 
   /cacache/17.0.2:
     resolution: {integrity: sha512-rYUs2x4OjSgCQND7nTrh21AHIBFgd7s/ctAYvU3a8u+nK+R5YaX/SFPDYz4Azz7SGL6+6L9ZZWI4Kawpb7grzQ==}
@@ -8631,6 +8695,14 @@ packages:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
       is-callable: 1.2.7
+
+  /foreground-child/2.0.0:
+    resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      cross-spawn: 7.0.3
+      signal-exit: 3.0.7
+    dev: true
 
   /form-data-encoder/1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
@@ -13756,6 +13828,12 @@ packages:
       acorn: 8.8.1
     dev: true
 
+  /strip-literal/1.0.0:
+    resolution: {integrity: sha512-5o4LsH1lzBzO9UFH63AJ2ad2/S2AVx6NtjOcaz+VTT2h1RiRvbipW72z8M/lxEhcPHDBQwpDrnTF7sXy/7OwCQ==}
+    dependencies:
+      acorn: 8.8.1
+    dev: true
+
   /strip-outer/1.0.1:
     resolution: {integrity: sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==}
     engines: {node: '>=0.10.0'}
@@ -15137,6 +15215,51 @@ packages:
       local-pkg: 0.4.2
       source-map: 0.6.1
       strip-literal: 0.4.2
+      tinybench: 2.3.1
+      tinypool: 0.3.0
+      tinyspy: 1.0.2
+      vite: 3.2.4_@types+node@18.11.10
+    transitivePeerDependencies:
+      - less
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vitest/0.25.8:
+    resolution: {integrity: sha512-X75TApG2wZTJn299E/TIYevr4E9/nBo1sUtZzn0Ci5oK8qnpZAZyhwg0qCeMSakGIWtc6oRwcQFyFfW14aOFWg==}
+    engines: {node: '>=v14.16.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.4
+      '@types/chai-subset': 1.3.3
+      '@types/node': 18.11.10
+      acorn: 8.8.1
+      acorn-walk: 8.2.0
+      chai: 4.3.7
+      debug: 4.3.4
+      local-pkg: 0.4.2
+      source-map: 0.6.1
+      strip-literal: 1.0.0
       tinybench: 2.3.1
       tinypool: 0.3.0
       tinyspy: 1.0.2


### PR DESCRIPTION
Fixes the following issue:

<img width="954" alt="image" src="https://user-images.githubusercontent.com/154748/208221292-bc80e47e-d440-4d89-b6d5-98c4503e6425.png">

When attempting to refer to `Query` as a ref. This isn't super common, but can be a useful pattern for cases where you want to return `Query` as a type off of a `Mutation` result.

Also fixes the `pnpm coverage` command

There's probably an opportunity to run `builder.queryType` through `builder.objectType` (what [nexus does](https://github.com/graphql-nexus/nexus/blob/1e6b9212d351e4c05504590ad70b65b2ee0c1f7a/src/definitions/queryType.ts#L42-L44)), allowing interfaces and such, since a `Query` object is just a regular object which also happens to be designated as the root type if another isn't specified.

Looking forward to digging in more here to figure out how this can play nicely with Nexus 😄 