### PR TITLE
Mention nexus to pothos codemod in the migration docs

### DIFF
--- a/website/pages/docs/migrations/index.mdx
+++ b/website/pages/docs/migrations/index.mdx
@@ -15,4 +15,4 @@ export const getStaticProps = () => ({ props: { nav: buildNav() } });
 
 - [GiraphQL (2.\*) to Pothos (3.0)](./migrations/giraphql-pothos)
 - [1.\* to 2.0](./migrations/2.0)
-- From Nexus to Pothos: https://github.com/villesau/nexus-to-pothos-codemod
+- [Nexus to Pothos](https://github.com/villesau/nexus-to-pothos-codemod)

--- a/website/pages/docs/migrations/index.mdx
+++ b/website/pages/docs/migrations/index.mdx
@@ -15,3 +15,4 @@ export const getStaticProps = () => ({ props: { nav: buildNav() } });
 
 - [GiraphQL (2.\*) to Pothos (3.0)](./migrations/giraphql-pothos)
 - [1.\* to 2.0](./migrations/2.0)
+- From Nexus to Pothos: https://github.com/villesau/nexus-to-pothos-codemod


### PR DESCRIPTION
Mention the codemod I built that enables to migrate from Nexus to Pothos. Further usage instructions resides in the readme of the repo.