### PR TITLE
fix: remove duplicate word typo

### DIFF
--- a/packages/core/src/config-store.ts
+++ b/packages/core/src/config-store.ts
@@ -197,7 +197,7 @@ export default class ConfigStore<Types extends SchemaTypes> {
         );
       }
 
-      throw new Error(`Missing definition for for ${String(ref)}`);
+      throw new Error(`Missing definition for ${String(ref)}`);
     }
 
     const config = this.fieldRefs.get(ref)!(name, parentField, typeConfig);


### PR DESCRIPTION
Changed "for for" to "for" in a custom error message.

The typo also appears in `packages/deno/packages/core/config-store.ts`, however it appears this is a generated artifact based on the core package config store file. With that being said, I'm not exactly sure if it needs to be manually fixed in that file as well (I assume not, but let me know).