### PR TITLE
Fix typos on website's plugin pages, and in corresponding READMEs

### DIFF
--- a/packages/plugin-mocks/README.md
+++ b/packages/plugin-mocks/README.md
@@ -1,6 +1,6 @@
 # Mocks Plugin for Pothos
 
-A simple plugin for adding resolver mocks to a graphQL schema.
+A simple plugin for adding resolver mocks to a GraphQL schema.
 
 ## Usage
 
@@ -21,7 +21,7 @@ const builder = new SchemaBuilder({
 
 ### Adding mocks
 
-You can mock any field by adding a mock in the options passed to `builder.builSchema` under
+You can mock any field by adding a mock in the options passed to `builder.toSchema` under
 `mocks.{typeName}.{fieldName}`.
 
 ```typescript
@@ -44,7 +44,7 @@ builder.toSchema({
 });
 ```
 
-Mocks will replace the resolve functions any time a mocked field is executed. A schema can be build
+Mocks will replace the resolve functions any time a mocked field is executed. A schema can be built
 multiple times with different mocks.
 
 ### Adding mocks for subscribe functions

--- a/packages/plugin-sub-graph/README.md
+++ b/packages/plugin-sub-graph/README.md
@@ -1,6 +1,6 @@
 # SubGraph Plugin for Pothos
 
-A plugin for creating sub-selections of your graph. This Allows you to use the same code/types for
+A plugin for creating sub-selections of your graph. This allows you to use the same code/types for
 multiple variants of your API.
 
 One common use case for this is to share implementations between your public and internal APIs, by
@@ -63,7 +63,7 @@ const combinedSchema = builder.toSchema({ subGraph: ['Internal', 'Public'] });
   to being part of the same sub-graph as their parent type. Only applies when type does not have
   `defaultSubGraphsForFields` set.
 
-You can mock any field by adding a mock in the options passed to `builder.buildSchema` under
+You can mock any field by adding a mock in the options passed to `builder.toSchema` under
 `mocks.{typeName}.{fieldName}`.
 
 ### Usage
@@ -92,10 +92,10 @@ builder.queryType({
 When creating a sub-graph, the plugin will only copy in types that are included in the sub-graph,
 either by explicitly setting it on the type, or because the sub-graph is included in the default
 list. Like types, output fields that are not included in a sub-graph will also be omitted. Arguments
-and fields on Input types can not be removed because that would break assumptions about arguments
-types in resolves.
+and fields on Input types can not be removed because that would break assumptions about argument
+types in resolvers.
 
 If a type that is not included in the sub-graph is referenced by another part of the graph that is
 included in the graph, a runtime error will be thrown when the sub graph is constructed. This can
 happen in a number of cases including cases where a removed type is used in the interfaces of an
-object, a member of a union, or the type of an field argument.
+object, a member of a union, or the type of a field argument.

--- a/packages/plugin-sub-graph/README.md
+++ b/packages/plugin-sub-graph/README.md
@@ -63,9 +63,6 @@ const combinedSchema = builder.toSchema({ subGraph: ['Internal', 'Public'] });
   to being part of the same sub-graph as their parent type. Only applies when type does not have
   `defaultSubGraphsForFields` set.
 
-You can mock any field by adding a mock in the options passed to `builder.toSchema` under
-`mocks.{typeName}.{fieldName}`.
-
 ### Usage
 
 ```typescript

--- a/website/pages/docs/plugins/mocks.mdx
+++ b/website/pages/docs/plugins/mocks.mdx
@@ -14,7 +14,7 @@ export const getStaticProps = () => ({ props: { nav: buildNav() }})
 
 # Mocks Plugin
 
-A simple plugin for adding resolver mocks to a graphQL schema.
+A simple plugin for adding resolver mocks to a GraphQL schema.
 
 ## Usage
 
@@ -35,7 +35,7 @@ const builder = new SchemaBuilder({
 
 ### Adding mocks
 
-You can mock any field by adding a mock in the options passed to `builder.builSchema` under
+You can mock any field by adding a mock in the options passed to `builder.toSchema` under
 `mocks.{typeName}.{fieldName}`.
 
 ```typescript
@@ -58,7 +58,7 @@ builder.toSchema({
 });
 ```
 
-Mocks will replace the resolve functions any time a mocked field is executed. A schema can be build
+Mocks will replace the resolve functions any time a mocked field is executed. A schema can be built
 multiple times with different mocks.
 
 ### Adding mocks for subscribe functions

--- a/website/pages/docs/plugins/sub-graph.mdx
+++ b/website/pages/docs/plugins/sub-graph.mdx
@@ -77,9 +77,6 @@ const combinedSchema = builder.toSchema({ subGraph: ['Internal', 'Public'] });
   to being part of the same sub-graph as their parent type. Only applies when type does not have
   `defaultForFields` set.
 
-You can mock any field by adding a mock in the options passed to `builder.toSchema` under
-`mocks.{typeName}.{fieldName}`.
-
 ### Usage
 
 ```typescript

--- a/website/pages/docs/plugins/sub-graph.mdx
+++ b/website/pages/docs/plugins/sub-graph.mdx
@@ -14,7 +14,7 @@ export const getStaticProps = () => ({ props: { nav: buildNav() } });
 
 # SubGraph Plugin
 
-A plugin for creating sub-selections of your graph. This Allows you to use the same code/types for
+A plugin for creating sub-selections of your graph. This allows you to use the same code/types for
 multiple variants of your API.
 
 One common use case for this is to share implementations between your public and internal APIs, by
@@ -77,7 +77,7 @@ const combinedSchema = builder.toSchema({ subGraph: ['Internal', 'Public'] });
   to being part of the same sub-graph as their parent type. Only applies when type does not have
   `defaultForFields` set.
 
-You can mock any field by adding a mock in the options passed to `builder.buildSchema` under
+You can mock any field by adding a mock in the options passed to `builder.toSchema` under
 `mocks.{typeName}.{fieldName}`.
 
 ### Usage
@@ -106,10 +106,10 @@ builder.queryType({
 When creating a sub-graph, the plugin will only copy in types that are included in the sub-graph,
 either by explicitly setting it on the type, or because the sub-graph is included in the default
 list. Like types, output fields that are not included in a sub-graph will also be omitted. Arguments
-and fields on Input types can not be removed because that would break assumptions about arguments
-types in resolves.
+and fields on Input types can not be removed because that would break assumptions about argument
+types in resolvers.
 
 If a type that is not included in the sub-graph is referenced by another part of the graph that is
 included in the graph, a runtime error will be thrown when the sub graph is constructed. This can
 happen in a number of cases including cases where a removed type is used in the interfaces of an
-object, a member of a union, or the type of an field argument.
+object, a member of a union, or the type of a field argument.


### PR DESCRIPTION
## Summary
Make website and README changes for plugins:
1. Fix typos in the **SubGraph plugin**, making sure to make the same changes in the corresponding README.
2. Fix typos in the **Mocks plugin**, making sure to make the same changes in the corresponding README.
3. Remove Mocks plugin info from **SubGraph plugin** documentation.

Ignore anything that could change meaning.