### PR TITLE
feat: unwrap Promise fields for expose, fixes #793

### DIFF
--- a/.changeset/fifty-cooks-cheer.md
+++ b/.changeset/fifty-cooks-cheer.md
@@ -1,0 +1,6 @@
+---
+'@pothos/core': minor
+'@pothos/deno': minor
+---
+
+Allow / unwrap Promises in "expose" type fields

--- a/packages/converter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/converter/tests/__snapshots__/index.test.ts.snap
@@ -180,6 +180,10 @@ builder.objectType('Giraffe', {
             type: 'Int',
             resolve: (parent, args, context, info) => { throw new Error('Not implemented'); },
         }),
+        favoriteFood: t.field({
+            type: 'String',
+            resolve: (parent, args, context, info) => { throw new Error('Not implemented'); },
+        }),
         name: t.field({
             type: 'String',
             resolve: (parent, args, context, info) => { throw new Error('Not implemented'); },
@@ -393,6 +397,7 @@ input Example2 {
 
 type Giraffe implements Animal {
   age: Int!
+  favoriteFood: String!
   name: String!
   species: String
 }

--- a/packages/converter/tests/examples/random-stuff.ts
+++ b/packages/converter/tests/examples/random-stuff.ts
@@ -34,6 +34,10 @@ class Giraffe extends Animal {
     this.name = name;
     this.age = age;
   }
+
+  get favoriteFood() {
+    return Promise.resolve('acacia trees');
+  }
 }
 
 const builder = new SchemaBuilder<Types>({});
@@ -58,6 +62,7 @@ builder.objectType(Giraffe, {
   fields: (t) => ({
     name: t.exposeString('name', {}),
     age: t.exposeInt('age', {}),
+    favoriteFood: t.exposeString('favoriteFood'),
   }),
 });
 

--- a/packages/core/src/types/builder-options.ts
+++ b/packages/core/src/types/builder-options.ts
@@ -237,7 +237,11 @@ export type CompatibleTypes<
   Type extends TypeParam<Types>,
   Nullable extends FieldNullability<Type>,
 > = {
-  [K in keyof ParentShape]-?: ParentShape[K] extends ShapeFromTypeParam<Types, Type, Nullable>
+  [K in keyof ParentShape]-?: Awaited<ParentShape[K]> extends ShapeFromTypeParam<
+    Types,
+    Type,
+    Nullable
+  >
     ? K
     : never;
 }[keyof ParentShape] &
@@ -249,7 +253,7 @@ export type ExposeNullability<
   ParentShape,
   Name extends keyof ParentShape,
   Nullable extends FieldNullability<Type>,
-> = ParentShape[Name] extends ShapeFromTypeParam<Types, Type, Nullable>
+> = Awaited<ParentShape[Name]> extends ShapeFromTypeParam<Types, Type, Nullable>
   ? {
       nullable?: Nullable & ExposeNullableOption<Types, Type, ParentShape, Name>;
     }
@@ -264,15 +268,15 @@ export type ExposeNullableOption<
   Name extends keyof ParentShape,
 > = FieldNullability<Type> &
   (Type extends [unknown]
-    ? ParentShape[Name] extends readonly (infer T)[] | null | undefined
+    ? Awaited<ParentShape[Name]> extends readonly (infer T)[] | null | undefined
       ? [T] extends [NonNullable<T>]
-        ? ParentShape[Name] extends NonNullable<ParentShape[Name]>
+        ? Awaited<ParentShape[Name]> extends NonNullable<Awaited<ParentShape[Name]>>
           ? boolean | { items: boolean; list: boolean }
           : true | { items: boolean; list: true }
-        : ParentShape[Name] extends NonNullable<ParentShape[Name]>
+        : Awaited<ParentShape[Name]> extends NonNullable<Awaited<ParentShape[Name]>>
         ? { items: true; list: boolean }
         : { items: true; list: true }
       : never
-    : ParentShape[Name] extends NonNullable<ParentShape[Name]>
+    : Awaited<ParentShape[Name]> extends NonNullable<Awaited<ParentShape[Name]>>
     ? boolean
     : true);

--- a/packages/deno/packages/core/types/builder-options.ts
+++ b/packages/deno/packages/core/types/builder-options.ts
@@ -61,29 +61,29 @@ export type InputShapeFromField<Field extends InputFieldRef> = Field extends {
 export type FieldKind = keyof PothosSchemaTypes.FieldOptionsByKind<SchemaTypes, {}, TypeParam<SchemaTypes>, boolean, {}, {}, {}> & keyof PothosSchemaTypes.PothosKindToGraphQLType;
 export type InputFieldKind = keyof PothosSchemaTypes.InputFieldOptionsByKind<SchemaTypes, InputRef<unknown>, boolean>;
 export type CompatibleTypes<Types extends SchemaTypes, ParentShape, Type extends TypeParam<Types>, Nullable extends FieldNullability<Type>> = {
-    [K in keyof ParentShape]-?: ParentShape[K] extends ShapeFromTypeParam<Types, Type, Nullable> ? K : never;
+    [K in keyof ParentShape]-?: Awaited<ParentShape[K]> extends ShapeFromTypeParam<Types, Type, Nullable> ? K : never;
 }[keyof ParentShape] & string;
-export type ExposeNullability<Types extends SchemaTypes, Type extends TypeParam<Types>, ParentShape, Name extends keyof ParentShape, Nullable extends FieldNullability<Type>> = ParentShape[Name] extends ShapeFromTypeParam<Types, Type, Nullable> ? {
+export type ExposeNullability<Types extends SchemaTypes, Type extends TypeParam<Types>, ParentShape, Name extends keyof ParentShape, Nullable extends FieldNullability<Type>> = Awaited<ParentShape[Name]> extends ShapeFromTypeParam<Types, Type, Nullable> ? {
     nullable?: Nullable & ExposeNullableOption<Types, Type, ParentShape, Name>;
 } : {
     nullable: Nullable & ExposeNullableOption<Types, Type, ParentShape, Name>;
 };
 export type ExposeNullableOption<Types extends SchemaTypes, Type extends TypeParam<Types>, ParentShape, Name extends keyof ParentShape> = FieldNullability<Type> & (Type extends [
     unknown
-] ? ParentShape[Name] extends readonly (infer T)[] | null | undefined ? [
+] ? Awaited<ParentShape[Name]> extends readonly (infer T)[] | null | undefined ? [
     T
 ] extends [
     NonNullable<T>
-] ? ParentShape[Name] extends NonNullable<ParentShape[Name]> ? boolean | {
+] ? Awaited<ParentShape[Name]> extends NonNullable<Awaited<ParentShape[Name]>> ? boolean | {
     items: boolean;
     list: boolean;
 } : true | {
     items: boolean;
     list: true;
-} : ParentShape[Name] extends NonNullable<ParentShape[Name]> ? {
+} : Awaited<ParentShape[Name]> extends NonNullable<Awaited<ParentShape[Name]>> ? {
     items: true;
     list: boolean;
 } : {
     items: true;
     list: true;
-} : never : ParentShape[Name] extends NonNullable<ParentShape[Name]> ? boolean : true);
+} : never : Awaited<ParentShape[Name]> extends NonNullable<Awaited<ParentShape[Name]>> ? boolean : true);


### PR DESCRIPTION
Changes `ParentShape[K]` to `Awaited<ParentShape[K]>` for determining if a field can be exposed via `.expose*` and for nullability

Closes #793 