### PR TITLE
bug: failing tests & fixes for id coercion

### DIFF
--- a/packages/deno/packages/plugin-relay/field-builder.ts
+++ b/packages/deno/packages/plugin-relay/field-builder.ts
@@ -80,7 +80,7 @@ fieldBuilderProto.nodeList = function nodeList({ ids, ...options }) {
             const globalIds = rawIds.map((id) => typeof id === "string"
                 ? internalDecodeGlobalID(this.builder, id, context, info, true)
                 : id && {
-                    id: String(id.id),
+                    id: id.id,
                     typename: this.builder.configStore.getTypeConfig(id.type).name,
                 });
             return resolveNodes(this.builder, context, info, globalIds);

--- a/packages/deno/packages/plugin-relay/field-builder.ts
+++ b/packages/deno/packages/plugin-relay/field-builder.ts
@@ -55,7 +55,7 @@ fieldBuilderProto.node = function node({ id, ...options }) {
             const globalID = typeof rawID === "string"
                 ? internalDecodeGlobalID(this.builder, rawID, context, info, true)
                 : rawID && {
-                    id: String(rawID.id),
+                    id: rawID.id,
                     typename: this.builder.configStore.getTypeConfig(rawID.type).name,
                 };
             return (await resolveNodes(this.builder, context, info, [globalID]))[0];

--- a/packages/deno/packages/plugin-relay/index.ts
+++ b/packages/deno/packages/plugin-relay/index.ts
@@ -25,7 +25,7 @@ export class PothosRelayPlugin<Types extends SchemaTypes> extends BasePlugin<Typ
         if (!argMappings) {
             return resolver;
         }
-        const argMapper = createInputValueMapper(argMappings, (globalID, mappings, ctx: Types["Context"], info: GraphQLResolveInfo) => internalDecodeGlobalID(this.builder, String(globalID), ctx, info, Array.isArray(mappings.value) ? mappings.value : false));
+        const argMapper = createInputValueMapper(argMappings, (globalID, mappings, ctx: Types["Context"], info: GraphQLResolveInfo) => internalDecodeGlobalID(this.builder, String(globalID), ctx, info, Array.isArray(mappings.value) ? mappings.value : true));
         return (parent, args, context, info) => resolver(parent, argMapper(args, undefined, context, info), context, info);
     }
     override wrapSubscribe(subscribe: GraphQLFieldResolver<unknown, Types["Context"], object> | undefined, fieldConfig: PothosOutputFieldConfig<Types>): GraphQLFieldResolver<unknown, Types["Context"], object> | undefined {

--- a/packages/deno/packages/plugin-relay/input-field-builder.ts
+++ b/packages/deno/packages/plugin-relay/input-field-builder.ts
@@ -15,7 +15,7 @@ inputFieldBuilder.globalIDList = function globalIDList<Req extends FieldRequired
             relayGlobalIDFor: ((forTypes &&
                 (Array.isArray(forTypes) ? forTypes : [forTypes])) as ObjectRef<SchemaTypes>[])?.map((type: ObjectRef<SchemaTypes>) => ({
                 typename: this.builder.configStore.getTypeConfig(type).name,
-                parse: type instanceof NodeRef ? type.parseId : undefined,
+                parseId: type instanceof NodeRef ? type.parseId : undefined,
             })) ?? null,
         },
     }) as never;
@@ -29,7 +29,7 @@ inputFieldBuilder.globalID = function globalID<Req extends boolean>({ for: forTy
             relayGlobalIDFor: ((forTypes &&
                 (Array.isArray(forTypes) ? forTypes : [forTypes])) as ObjectRef<SchemaTypes>[])?.map((type: ObjectRef<SchemaTypes>) => ({
                 typename: this.builder.configStore.getTypeConfig(type).name,
-                parse: type instanceof NodeRef ? type.parseId : undefined,
+                parseId: type instanceof NodeRef ? type.parseId : undefined,
             })) ?? null,
         },
     }) as unknown as InputFieldRef<InputShapeFromTypeParam<DefaultSchemaTypes, GlobalIDInputShape, Req>> as never;

--- a/packages/deno/packages/plugin-tracing/README.md
+++ b/packages/deno/packages/plugin-tracing/README.md
@@ -767,13 +767,7 @@ import { schema } from './schema';
 
 const yoga = createYoga({
   schema,
-  plugins: [
-    useSentry({
-      // Disable resolver tracking since this is covered by the pothos tracing plugin
-      // If all resolvers are being traced, you could use the Sentry envelop plug instead of the pothos tracing plugin
-      trackResolvers: false,
-    }),
-  ],
+  plugins: [useSentry({})],
 });
 
 const server = createServer(yoga);

--- a/packages/plugin-relay/src/field-builder.ts
+++ b/packages/plugin-relay/src/field-builder.ts
@@ -165,7 +165,7 @@ fieldBuilderProto.nodeList = function nodeList({ ids, ...options }) {
         typeof id === 'string'
           ? internalDecodeGlobalID(this.builder, id, context, info, true)
           : id && {
-              id: String(id.id),
+              id: id.id,
               typename: this.builder.configStore.getTypeConfig(id.type).name,
             },
       );

--- a/packages/plugin-relay/src/field-builder.ts
+++ b/packages/plugin-relay/src/field-builder.ts
@@ -128,7 +128,7 @@ fieldBuilderProto.node = function node({ id, ...options }) {
         typeof rawID === 'string'
           ? internalDecodeGlobalID(this.builder, rawID, context, info, true)
           : rawID && {
-              id: String(rawID.id),
+              id: rawID.id,
               typename: this.builder.configStore.getTypeConfig(rawID.type).name,
             };
 

--- a/packages/plugin-relay/src/index.ts
+++ b/packages/plugin-relay/src/index.ts
@@ -47,7 +47,7 @@ export class PothosRelayPlugin<Types extends SchemaTypes> extends BasePlugin<Typ
           String(globalID),
           ctx,
           info,
-          Array.isArray(mappings.value) ? mappings.value : false,
+          Array.isArray(mappings.value) ? mappings.value : true,
         ),
     );
 

--- a/packages/plugin-relay/src/input-field-builder.ts
+++ b/packages/plugin-relay/src/input-field-builder.ts
@@ -37,7 +37,7 @@ inputFieldBuilder.globalIDList = function globalIDList<Req extends FieldRequired
             (Array.isArray(forTypes) ? forTypes : [forTypes])) as ObjectRef<SchemaTypes>[]
         )?.map((type: ObjectRef<SchemaTypes>) => ({
           typename: this.builder.configStore.getTypeConfig(type).name,
-          parse: type instanceof NodeRef ? type.parseId : undefined,
+          parseId: type instanceof NodeRef ? type.parseId : undefined,
         })) ?? null,
     },
   }) as never;
@@ -60,7 +60,7 @@ inputFieldBuilder.globalID = function globalID<Req extends boolean>(
             (Array.isArray(forTypes) ? forTypes : [forTypes])) as ObjectRef<SchemaTypes>[]
         )?.map((type: ObjectRef<SchemaTypes>) => ({
           typename: this.builder.configStore.getTypeConfig(type).name,
-          parse: type instanceof NodeRef ? type.parseId : undefined,
+          parseId: type instanceof NodeRef ? type.parseId : undefined,
         })) ?? null,
     },
   }) as unknown as InputFieldRef<

--- a/packages/plugin-relay/tests/examples/global-connection-fields/schema/numbers.ts
+++ b/packages/plugin-relay/tests/examples/global-connection-fields/schema/numbers.ts
@@ -6,7 +6,7 @@ class NumberThing {
 
   constructor(n: number) {
     if (typeof n !== 'number') {
-      throw new Error(`Expected NumberThing to receive number, saw ${typeof n} ${n}`);
+      throw new TypeError(`Expected NumberThing to receive number, saw ${typeof n} ${n}`);
     }
     this.id = n;
   }
@@ -17,7 +17,9 @@ class BatchLoadableNumberThing {
 
   constructor(n: number) {
     if (typeof n !== 'number') {
-      throw new Error(`Expected BatchLoadableNumberThing to receive number, saw ${typeof n} ${n}`);
+      throw new TypeError(
+        `Expected BatchLoadableNumberThing to receive number, saw ${typeof n} ${n}`,
+      );
     }
     this.id = n;
   }

--- a/packages/plugin-relay/tests/examples/global-connection-fields/schema/numbers.ts
+++ b/packages/plugin-relay/tests/examples/global-connection-fields/schema/numbers.ts
@@ -5,6 +5,9 @@ class NumberThing {
   id: number;
 
   constructor(n: number) {
+    if (typeof n !== 'number') {
+      throw new Error(`Expected NumberThing to receive number, saw ${typeof n} ${n}`);
+    }
     this.id = n;
   }
 }
@@ -13,6 +16,9 @@ class BatchLoadableNumberThing {
   id: number;
 
   constructor(n: number) {
+    if (typeof n !== 'number') {
+      throw new Error(`Expected BatchLoadableNumberThing to receive number, saw ${typeof n} ${n}`);
+    }
     this.id = n;
   }
 }

--- a/packages/plugin-relay/tests/examples/relay/schema/numbers.ts
+++ b/packages/plugin-relay/tests/examples/relay/schema/numbers.ts
@@ -5,6 +5,9 @@ class NumberThing {
   id: number;
 
   constructor(n: number) {
+    if (typeof n !== 'number') {
+      throw new TypeError(`Expected NumberThing to receive number, saw ${typeof n} ${n}`);
+    }
     this.id = n;
   }
 }
@@ -13,6 +16,11 @@ class BatchLoadableNumberThing {
   id: number;
 
   constructor(n: number) {
+    if (typeof n !== 'number') {
+      throw new TypeError(
+        `Expected BatchLoadableNumberThing to receive number, saw ${typeof n} ${n}`,
+      );
+    }
     this.id = n;
   }
 }


### PR DESCRIPTION
Was working on adding `parse` to `loadableNode` - got pretty close to having it correct, but while working through the implementation I ran into a few bugs that seemed better to address separately before changing things around a bit for that.

The inferred types for `parse` are not properly reflecting the runtime coercion.

One of the issues was because `parse` was supposed to be `parseId` in the `relayGlobalIDFor`. The other issue is that it wasn't decoding the ids when passed to a field like `node`.

Not sure if this is 100% correct, the `parse` -> `parseId` seemed to just be an oversight, but wasn't sure if there was something else I was missing in the other changes.