### PR TITLE
feat: handle string contining ':' in global ID

### DIFF
--- a/.changeset/early-chefs-end.md
+++ b/.changeset/early-chefs-end.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-relay': minor
+---
+
+handle string contining ':' in global ID

--- a/packages/deno/packages/plugin-relay/utils/global-ids.ts
+++ b/packages/deno/packages/plugin-relay/utils/global-ids.ts
@@ -4,9 +4,10 @@ export function encodeGlobalID(typename: string, id: bigint | number | string) {
     return encodeBase64(`${typename}:${id}`);
 }
 export function decodeGlobalID(globalID: string) {
-    const [typename, id] = decodeBase64(globalID).split(":");
+    const decoded = decodeBase64(globalID).split(":");
+    const [typename, id] = decoded;
     if (!typename || !id) {
         throw new PothosValidationError(`Invalid global ID: ${globalID}`);
     }
-    return { typename, id };
+    return { typename, id: decoded.length > 2 ? decoded.slice(1).join(":") : id };
 }

--- a/packages/plugin-relay/src/utils/global-ids.ts
+++ b/packages/plugin-relay/src/utils/global-ids.ts
@@ -5,11 +5,12 @@ export function encodeGlobalID(typename: string, id: bigint | number | string) {
 }
 
 export function decodeGlobalID(globalID: string) {
-  const [typename, id] = decodeBase64(globalID).split(':');
+  const decoded = decodeBase64(globalID).split(':');
+  const [typename, id] = decoded;
 
   if (!typename || !id) {
     throw new PothosValidationError(`Invalid global ID: ${globalID}`);
   }
 
-  return { typename, id };
+  return { typename, id: decoded.length > 2 ? decoded.slice(1).join(':') : id };
 }

--- a/packages/plugin-relay/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-relay/tests/__snapshots__/index.test.ts.snap
@@ -46,6 +46,11 @@ input GlobalIDInput {
   otherList: [OtherInput!] = [{someField: \\"abc\\"}]
 }
 
+type IDWithColon implements Node {
+  id: ID!
+  idString: String!
+}
+
 type Mutation {
   answerPoll(answer: Int!, id: ID!): Poll!
   createPoll(answers: [String!]!, question: String!): Poll!
@@ -129,6 +134,8 @@ type Query {
   batchNumbers(after: ID, before: ID, first: Int, last: Int): QueryBatchNumbersConnection!
   cursorConnection(after: ID, before: ID, first: Int, last: Int): QueryCursorConnection!
   extraNode: Node
+  idWithColon(id: ID!): IDWithColon!
+  idsWithColon(ids: [ID!]!): [IDWithColon!]!
   inputGlobalID(id: ID!, inputObj: GlobalIDInput!, normalId: ID!): String!
   moreNodes: [Node]!
   node(id: ID!): Node

--- a/packages/plugin-relay/tests/index.test.ts
+++ b/packages/plugin-relay/tests/index.test.ts
@@ -513,6 +513,14 @@ describe('relay example schema', () => {
     it('parses ids', async () => {
       const query = gql`
         query {
+          idWithColon(id: "SURXaXRoQ29sb246MTp0ZXN0") {
+            id
+            idString
+          }
+          idsWithColon(ids: ["SURXaXRoQ29sb246MTp0ZXN0", "SURXaXRoQ29sb246Mjp0ZXN0OmV4YW1wbGU="]) {
+            id
+            idString
+          }
           numberThingByID(id: "TnVtYmVyOjE=") {
             id
             number
@@ -541,6 +549,20 @@ describe('relay example schema', () => {
       expect(result).toMatchInlineSnapshot(`
         {
           "data": {
+            "idWithColon": {
+              "id": "SURXaXRoQ29sb246MTp0ZXN0",
+              "idString": "1:test",
+            },
+            "idsWithColon": [
+              {
+                "id": "SURXaXRoQ29sb246MTp0ZXN0",
+                "idString": "1:test",
+              },
+              {
+                "id": "SURXaXRoQ29sb246Mjp0ZXN0OmV4YW1wbGU=",
+                "idString": "2:test:example",
+              },
+            ],
             "invalid": null,
             "invalidList": null,
             "numberThingByID": {


### PR DESCRIPTION
It's an edge case, but if an ID were to have a `:` in it for some reason, this change ensures that it gets included rather than splitting and only including the first value after the typename `:` delimiter