### PR TITLE
In SubGraph plugin, use a Set to avoid duplicate interfaces

### DIFF
--- a/packages/plugin-sub-graph/src/index.ts
+++ b/packages/plugin-sub-graph/src/index.ts
@@ -122,10 +122,13 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
           type.name,
           new GraphQLObjectType({
             ...typeConfig,
-            interfaces: () =>
-              typeConfig.interfaces
-                .filter((iface) => newTypes.has(iface.name))
-                .map((iface) => replaceType(iface, newTypes, typeConfig.name, subGraphs)),
+            interfaces: () => [
+              ...new Set(
+                typeConfig.interfaces
+                  .filter((iface) => newTypes.has(iface.name))
+                  .map((iface) => replaceType(iface, newTypes, typeConfig.name, subGraphs)),
+              ),
+            ],
             fields: this.filterFields(type, newTypes, subGraphs),
           }),
         );


### PR DESCRIPTION
Attempts to fix #818

This --does-- repair the behavior of the repro at https://github.com/hayes/pothos/commit/ad5d4853148dc1ddfa50593af8405c9dda503288

<img width="729" alt="Screen Shot 2023-02-28 at 11 41 14 AM" src="https://user-images.githubusercontent.com/489896/221924961-aecaed05-721a-4466-9872-15c5783de8e1.png">

But, this is probably not the best way to do it. Seems like the problem is originating elsewhere in the interface assembly, and this is just an incomplete patch.

Also, the filter is applied to Object types only, but there is similar code for Interface types
https://github.com/hayes/pothos/blob/feafaa64ad4f9fe7827b45908745f883a4238279/packages/plugin-sub-graph/src/index.ts#L138-L141

---

Happy to run with any guidance you have here, investigate more, add tests etc :)