### PR TITLE
feat: add bigint to DefaultScalars ID value

### DIFF
--- a/packages/core/src/types/schema-types.ts
+++ b/packages/core/src/types/schema-types.ts
@@ -41,7 +41,7 @@ export type MergedScalars<PartialTypes extends Partial<PothosSchemaTypes.UserSch
 
 export interface DefaultScalars {
   String: { Input: string; Output: string };
-  ID: { Input: number | string; Output: number | string };
+  ID: { Input: number | string | bigint; Output: number | string | bigint };
   Int: { Input: number; Output: number };
   Float: { Input: number; Output: number };
   Boolean: { Input: boolean; Output: boolean };

--- a/packages/plugin-relay/package.json
+++ b/packages/plugin-relay/package.json
@@ -57,5 +57,8 @@
     "graphql-subscriptions": "^2.0.0",
     "graphql-tag": "^2.12.6"
   },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "gitHead": "9dfe52f1975f41a111e01bf96a20033a914e2acc"
 }

--- a/packages/plugin-relay/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-relay/tests/__snapshots__/index.test.ts.snap
@@ -12,6 +12,11 @@ type BatchNumber implements Node {
   number: Int!
 }
 
+type BigIntExample implements Node {
+  id: ID!
+  rawId: String!
+}
+
 type CursorObject {
   id: ID!
 }
@@ -139,6 +144,7 @@ type PollAnswersUsingOffsetConnectionEdge {
 
 type Query {
   batchNumbers(after: ID, before: ID, first: Int, last: Int): QueryBatchNumbersConnection!
+  bigIntExample(id: ID!): BigIntExample!
   cursorConnection(after: ID, before: ID, first: Int, last: Int): QueryCursorConnection!
   echoIDs(genericNumberThingID: ID!, globalID: ID!, numberThingID: ID!): [IDResult!]!
   extraNode: Node

--- a/packages/plugin-relay/tests/examples/relay/builder.ts
+++ b/packages/plugin-relay/tests/examples/relay/builder.ts
@@ -8,6 +8,7 @@ export default new SchemaBuilder<{
   Objects: {
     Poll: Poll;
     Answer: { id: number; value: string; count: number };
+    BigIntExample: { id: bigint };
   };
   Context: ContextType;
 }>({

--- a/packages/plugin-relay/tests/examples/relay/schema/numbers.ts
+++ b/packages/plugin-relay/tests/examples/relay/schema/numbers.ts
@@ -36,6 +36,30 @@ class BatchLoadableNumberThing {
   }
 }
 
+const BigIntExampleRef = builder.node('BigIntExample', {
+  id: {
+    resolve: (n) => n.id,
+    parse: BigInt,
+  },
+  fields: (t) => ({
+    rawId: t.string({
+      resolve: (o) => o.id.toString(),
+    }),
+  }),
+});
+
+builder.queryField('bigIntExample', (t) =>
+  t.field({
+    type: BigIntExampleRef,
+    args: {
+      id: t.arg.globalID({ required: true, for: [BigIntExampleRef] }),
+    },
+    resolve: (root, args) => ({
+      id: args.id.id,
+    }),
+  }),
+);
+
 const IDWithColonRef = builder.node(IDWithColon, {
   name: 'IDWithColon',
   id: {

--- a/packages/plugin-relay/tests/index.test.ts
+++ b/packages/plugin-relay/tests/index.test.ts
@@ -513,6 +513,10 @@ describe('relay example schema', () => {
     it('parses ids', async () => {
       const query = gql`
         query {
+          bigIntExample(id: "QmlnSW50RXhhbXBsZToxMDAwMDAwMDAwMDAwMDAwMDAwMA==") {
+            id
+            rawId
+          }
           idWithColon(id: "SURXaXRoQ29sb246MTp0ZXN0") {
             id
             idString
@@ -559,6 +563,10 @@ describe('relay example schema', () => {
       expect(result).toMatchInlineSnapshot(`
         {
           "data": {
+            "bigIntExample": {
+              "id": "QmlnSW50RXhhbXBsZToxMDAwMDAwMDAwMDAwMDAwMDAwMA==",
+              "rawId": "10000000000000000000",
+            },
             "echoIDs": [
               {
                 "arg": "globalID",


### PR DESCRIPTION
Adds `bigint` to the DefaultScalars definition for the ID field, so the return value of `id.resolve` in the `node` / `loadableNode` helper can be a `BigInt`

<img width="995" alt="image" src="https://user-images.githubusercontent.com/154748/222998848-fdce4063-bf15-45ec-bc06-e0d9625ce3d4.png">
<img width="726" alt="image" src="https://user-images.githubusercontent.com/154748/222998878-213f566b-9d3d-457a-86cf-d0fcb02beb3c.png">
