### PR TITLE
[Fix]: Add defaultValue for args and input fields

### DIFF
--- a/.changeset/nasty-trainers-remember.md
+++ b/.changeset/nasty-trainers-remember.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-directives": patch
+---
+
+Add ast nodes for defaultalues for args and input fields

--- a/packages/deno/packages/core/config-store.ts
+++ b/packages/deno/packages/core/config-store.ts
@@ -296,19 +296,23 @@ export default class ConfigStore<Types extends SchemaTypes> {
     prepareForBuild() {
         this.pending = false;
         const fns = this.addFieldFns;
+        const interfaces = this.pendingInterfaces;
+        const unions = this.pendingUnionTypes;
         this.addFieldFns = [];
+        this.pendingInterfaces = new Map();
+        this.pendingUnionTypes = new Map();
         fns.forEach((fn) => void fn());
         if (this.pendingRefResolutions.size > 0) {
             throw new PothosSchemaError(`Missing implementations for some references (${[...this.pendingRefResolutions.keys()]
                 .map((ref) => this.describeRef(ref))
                 .join(", ")}).`);
         }
-        for (const [typeName, unionFns] of this.pendingUnionTypes) {
+        for (const [typeName, unionFns] of unions) {
             for (const fn of unionFns) {
                 this.addUnionTypes(typeName, fn);
             }
         }
-        for (const [typeName, interfacesFns] of this.pendingInterfaces) {
+        for (const [typeName, interfacesFns] of interfaces) {
             for (const fn of interfacesFns) {
                 this.addInterfaces(typeName, fn);
             }

--- a/packages/deno/packages/plugin-directives/mock-ast.ts
+++ b/packages/deno/packages/plugin-directives/mock-ast.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 /* eslint-disable no-param-reassign */
 import './global-types.ts';
-import { ArgumentNode, ConstDirectiveNode, DirectiveNode, EnumValueDefinitionNode, FieldDefinitionNode, GraphQLArgument, GraphQLEnumType, GraphQLEnumValue, GraphQLField, GraphQLFieldMap, GraphQLInputField, GraphQLInputFieldMap, GraphQLInputObjectType, GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLScalarType, GraphQLSchema, GraphQLType, GraphQLUnionType, InputValueDefinitionNode, Kind, ListTypeNode, NamedTypeNode, OperationTypeNode, parseValue, TypeNode, ValueNode, } from 'https://cdn.skypack.dev/graphql?dts';
+import { ArgumentNode, astFromValue, ConstDirectiveNode, ConstValueNode, DirectiveNode, EnumValueDefinitionNode, FieldDefinitionNode, GraphQLArgument, GraphQLEnumType, GraphQLEnumValue, GraphQLField, GraphQLFieldMap, GraphQLInputField, GraphQLInputFieldMap, GraphQLInputObjectType, GraphQLInterfaceType, GraphQLList, GraphQLNonNull, GraphQLObjectType, GraphQLScalarType, GraphQLSchema, GraphQLType, GraphQLUnionType, InputValueDefinitionNode, Kind, ListTypeNode, NamedTypeNode, OperationTypeNode, parseValue, TypeNode, ValueNode, } from 'https://cdn.skypack.dev/graphql?dts';
 import type { DirectiveList } from './types.ts';
 export default function mockAst(schema: GraphQLSchema) {
     const types = schema.getTypeMap();
@@ -175,11 +175,13 @@ function fieldNodes(fields: GraphQLFieldMap<unknown, unknown>): FieldDefinitionN
 function inputFieldNodes(fields: GraphQLInputFieldMap): InputValueDefinitionNode[] {
     return Object.keys(fields).map((fieldName) => {
         const field: GraphQLInputField = fields[fieldName];
+        const defaultValueNode = astFromValue(field.defaultValue, field.type) as ConstValueNode;
         field.astNode = {
             kind: Kind.INPUT_VALUE_DEFINITION,
             description: field.description ? { kind: Kind.STRING, value: field.description } : undefined,
             name: { kind: Kind.NAME, value: fieldName },
             type: typeNode(field.type),
+            defaultValue: field.defaultValue === undefined ? undefined : defaultValueNode,
             directives: directiveNodes(field.extensions?.directives as DirectiveList, field.deprecationReason),
         };
         return field.astNode!;
@@ -187,11 +189,13 @@ function inputFieldNodes(fields: GraphQLInputFieldMap): InputValueDefinitionNode
 }
 function argumentNodes(args: readonly GraphQLArgument[]): InputValueDefinitionNode[] {
     return args.map((arg): InputValueDefinitionNode => {
+        const defaultValueNode = astFromValue(arg.defaultValue, arg.type) as ConstValueNode;
         arg.astNode = {
             kind: Kind.INPUT_VALUE_DEFINITION,
             description: arg.description ? { kind: Kind.STRING, value: arg.description } : undefined,
             name: { kind: Kind.NAME, value: arg.name },
             type: typeNode(arg.type),
+            defaultValue: arg.defaultValue === undefined ? undefined : defaultValueNode,
             directives: directiveNodes(arg.extensions?.directives as DirectiveList, arg.deprecationReason),
         };
         return arg.astNode;

--- a/packages/deno/packages/plugin-relay/README.md
+++ b/packages/deno/packages/plugin-relay/README.md
@@ -178,7 +178,7 @@ builder.node(NumberThing, {
 the `Node` interface the first time it is used. The `resolve` function for `id` should return a
 number or string, which will be converted to a globalID. The relay plugin adds to new query fields
 `node` and `nodes` which can be used to directly fetch nodes using global IDs by calling the
-provided `loadOne` or `laodMany` method. Each node will only be loaded once by id, and cached if the
+provided `loadOne` or `loadMany` method. Each node will only be loaded once by id, and cached if the
 same node is loaded multiple times inn the same request. You can provide `loadWithoutCache` or
 `loadManyWithoutCache` instead if caching is not desired, or you are already using a caching
 datasource like a dataloader.

--- a/packages/plugin-directives/src/mock-ast.ts
+++ b/packages/plugin-directives/src/mock-ast.ts
@@ -4,7 +4,9 @@
 import './global-types';
 import {
   ArgumentNode,
+  astFromValue,
   ConstDirectiveNode,
+  ConstValueNode,
   DirectiveNode,
   EnumValueDefinitionNode,
   FieldDefinitionNode,
@@ -237,11 +239,14 @@ function inputFieldNodes(fields: GraphQLInputFieldMap): InputValueDefinitionNode
   return Object.keys(fields).map((fieldName) => {
     const field: GraphQLInputField = fields[fieldName];
 
+    const defaultValueNode = astFromValue(field.defaultValue, field.type) as ConstValueNode;
+
     field.astNode = {
       kind: Kind.INPUT_VALUE_DEFINITION,
       description: field.description ? { kind: Kind.STRING, value: field.description } : undefined,
       name: { kind: Kind.NAME, value: fieldName },
       type: typeNode(field.type),
+      defaultValue: field.defaultValue === undefined ? undefined : defaultValueNode,
       directives: directiveNodes(
         field.extensions?.directives as DirectiveList,
         field.deprecationReason,
@@ -254,11 +259,14 @@ function inputFieldNodes(fields: GraphQLInputFieldMap): InputValueDefinitionNode
 
 function argumentNodes(args: readonly GraphQLArgument[]): InputValueDefinitionNode[] {
   return args.map((arg): InputValueDefinitionNode => {
+    const defaultValueNode = astFromValue(arg.defaultValue, arg.type) as ConstValueNode;
+
     arg.astNode = {
       kind: Kind.INPUT_VALUE_DEFINITION,
       description: arg.description ? { kind: Kind.STRING, value: arg.description } : undefined,
       name: { kind: Kind.NAME, value: arg.name },
       type: typeNode(arg.type),
+      defaultValue: arg.defaultValue === undefined ? undefined : defaultValueNode,
       directives: directiveNodes(
         arg.extensions?.directives as DirectiveList,
         arg.deprecationReason,

--- a/packages/plugin-directives/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-directives/tests/__snapshots__/index.test.ts.snap
@@ -5,6 +5,7 @@ exports[`extends example schema generates expected schema 1`] = `
 
 enum EN {
   ONE
+  TWO
 }
 
 interface IF {
@@ -15,12 +16,26 @@ input In {
   test: String
 }
 
+input MyInput {
+  booleanWithDefault: Boolean = false
+  enumWithDefault: EN = TWO
+  id: ID!
+  idWithDefault: ID = 123
+  ids: [ID!]!
+  idsWithDefault: [ID!] = [123, 456]
+  stringWithDefault: String = "default string"
+}
+
+input MyOtherInput {
+  booleanWithDefault: Boolean = false
+}
+
 type Obj {
   field: String!
 }
 
 type Query {
-  test(arg1: String): String!
+  test(arg1: String, myInput: MyInput, myOtherInput: MyOtherInput = {}): String!
 }
 
 union UN = Obj"

--- a/packages/plugin-directives/tests/example/schema/index.ts
+++ b/packages/plugin-directives/tests/example/schema/index.ts
@@ -1,6 +1,44 @@
 import { rateLimitDirective } from 'graphql-rate-limit-directive';
 import builder from '../builder';
 
+const myInput = builder.inputType('MyInput', {
+  fields: (t) => ({
+    id: t.id({ required: true }),
+    idWithDefault: t.id({ required: false, defaultValue: '123' }),
+    booleanWithDefault: t.boolean({ required: false, defaultValue: false }),
+    enumWithDefault: t.field({
+      defaultValue: 2,
+      type: myEnum,
+    }),
+    stringWithDefault: t.string({ required: false, defaultValue: 'default string' }),
+    ids: t.idList({ required: true }),
+    idsWithDefault: t.idList({ required: false, defaultValue: ['123', '456'] }),
+  }),
+});
+
+const myOtherInput = builder.inputType('MyOtherInput', {
+  fields: (t) => ({
+    booleanWithDefault: t.boolean({ required: false, defaultValue: false }),
+  }),
+});
+
+const myEnum = builder.enumType('EN', {
+  directives: {
+    e: { foo: 123 },
+  },
+  values: {
+    ONE: {
+      value: 1,
+      directives: {
+        ev: { foo: 123 },
+      },
+    },
+    TWO: {
+      value: 2,
+    },
+  },
+});
+
 builder.queryType({
   directives: {
     o: {
@@ -27,6 +65,8 @@ builder.queryType({
             a: { foo: 123 },
           },
         }),
+        myOtherInput: t.arg({ type: myOtherInput, required: false, defaultValue: {} }),
+        myInput: t.arg({ type: myInput, required: false }),
       },
       resolve: () => 'hi',
     }),
@@ -72,20 +112,6 @@ builder.unionType('UN', {
     throw new Error('Not implemented');
   },
   types: [Obj],
-});
-
-builder.enumType('EN', {
-  directives: {
-    e: { foo: 123 },
-  },
-  values: {
-    ONE: {
-      value: 1,
-      directives: {
-        ev: { foo: 123 },
-      },
-    },
-  },
 });
 
 builder.scalarType('Date', {

--- a/packages/plugin-directives/tests/index.test.ts
+++ b/packages/plugin-directives/tests/index.test.ts
@@ -1,8 +1,12 @@
 import {
   execute,
   GraphQLEnumType,
+  GraphQLInputField,
+  GraphQLInputFieldMap,
   GraphQLInputObjectType,
   GraphQLObjectType,
+  InputValueDefinitionNode,
+  Kind,
   lexicographicSortSchema,
   printSchema,
 } from 'graphql';
@@ -40,6 +44,50 @@ describe('extends example schema', () => {
     expect(
       (types.In as GraphQLInputObjectType).getFields().test.extensions?.directives,
     ).toStrictEqual({ if: { foo: 123 } });
+  });
+
+  it('constructs the astNode with defaultValue for inputs and args', () => {
+    const types = schema.getTypeMap();
+
+    const testField = (types.Query as GraphQLObjectType).getFields().test;
+
+    const arg1 = testField.args[0];
+    const myInput = testField.args[1];
+    const myOtherInput = testField.args[2];
+
+    expect(arg1.astNode?.defaultValue).toBeUndefined();
+    expect(myInput.astNode?.defaultValue).toBeUndefined();
+    expect(myOtherInput.astNode?.defaultValue).toBeDefined();
+    expect(myOtherInput.astNode?.defaultValue).toStrictEqual({
+      kind: Kind.OBJECT,
+      fields: [],
+    });
+
+    const MyInput = (types.MyInput as GraphQLInputObjectType).getFields();
+
+    expect(MyInput.booleanWithDefault.astNode?.defaultValue).toStrictEqual({
+      kind: Kind.BOOLEAN,
+      value: false,
+    });
+    expect(MyInput.enumWithDefault.astNode?.defaultValue).toStrictEqual({
+      kind: Kind.ENUM,
+      value: 'TWO',
+    });
+    expect(MyInput.idWithDefault.astNode?.defaultValue).toStrictEqual({
+      kind: Kind.INT,
+      value: '123',
+    });
+    expect(MyInput.stringWithDefault.astNode?.defaultValue).toStrictEqual({
+      kind: Kind.STRING,
+      value: 'default string',
+    });
+    expect(MyInput.idsWithDefault.astNode?.defaultValue).toStrictEqual({
+      kind: Kind.LIST,
+      values: [
+        { kind: Kind.INT, value: '123' },
+        { kind: Kind.INT, value: '456' },
+      ],
+    });
   });
 
   it('gatsby format', () => {


### PR DESCRIPTION
### Context
We are migrating from Federation v1 spec to Federation v2, and for that, we need to change from using `printSchema` from `graphql` to `printSubgraphSchema` from `@apollo/subgraph`. Unfortunately, `printSubgraphSchema` is relying on the `astNode` to get the `defaultValue`s for inputs and arguments, so when printing the schema to the disk, we are missing those defaults from the schema. This is causing breaking changes when pushing the new schema (now with Fed v2+) to the registry.

### Description
* This PR makes sure we add the `defaultValue` to the `astNode` for both the arguments and the input fields.

### References
https://github.com/apollographql/federation/issues/2438