### PR TITLE
In SubGraph Plugin: deprecation hints in InputTypes and Args

### DIFF
--- a/packages/plugin-sub-graph/src/index.ts
+++ b/packages/plugin-sub-graph/src/index.ts
@@ -226,9 +226,9 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
           description: fieldConfig.description,
           resolve: fieldConfig.resolve,
           subscribe: fieldConfig.subscribe,
+          deprecationReason: fieldConfig.deprecationReason,
           extensions: fieldConfig.extensions,
           astNode: fieldConfig.astNode,
-          deprecationReason: fieldConfig.deprecationReason,
           type: replaceType(
             fieldConfig.type,
             newTypes,

--- a/packages/plugin-sub-graph/src/index.ts
+++ b/packages/plugin-sub-graph/src/index.ts
@@ -212,6 +212,7 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
             defaultValue: argConfig.defaultValue,
             extensions: argConfig.extensions,
             astNode: argConfig.astNode,
+            deprecationReason: fieldConfig.deprecationReason,
             type: replaceType(
               argConfig.type,
               newTypes,
@@ -271,6 +272,7 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
           extensions: fieldConfig.extensions,
           astNode: fieldConfig.astNode,
           defaultValue: fieldConfig.defaultValue,
+          deprecationReason: fieldConfig.deprecationReason,
           type: replaceType(
             fieldConfig.type,
             newTypes,

--- a/packages/plugin-sub-graph/src/index.ts
+++ b/packages/plugin-sub-graph/src/index.ts
@@ -212,7 +212,7 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
             defaultValue: argConfig.defaultValue,
             extensions: argConfig.extensions,
             astNode: argConfig.astNode,
-            deprecationReason: fieldConfig.deprecationReason,
+            deprecationReason: argConfig.deprecationReason,
             type: replaceType(
               argConfig.type,
               newTypes,
@@ -226,9 +226,9 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
           description: fieldConfig.description,
           resolve: fieldConfig.resolve,
           subscribe: fieldConfig.subscribe,
-          deprecationReason: fieldConfig.deprecationReason,
           extensions: fieldConfig.extensions,
           astNode: fieldConfig.astNode,
+          deprecationReason: fieldConfig.deprecationReason,
           type: replaceType(
             fieldConfig.type,
             newTypes,


### PR DESCRIPTION
Partial Fix for #856 

Sorry but I could not fix `deprecated` for query input args. Just did not find it.