### PR TITLE
Include `idFieldOptions` in the Node interface ID field

### DIFF
--- a/.changeset/pink-falcons-rule.md
+++ b/.changeset/pink-falcons-rule.md
@@ -1,0 +1,6 @@
+---
+'@pothos/plugin-relay': minor
+'@pothos/deno': minor
+---
+
+Included `idFieldOptions` when creating the Node interface’s ID field.

--- a/packages/deno/packages/plugin-relay/schema-builder.ts
+++ b/packages/deno/packages/plugin-relay/schema-builder.ts
@@ -86,6 +86,7 @@ schemaBuilderProto.nodeInterfaceRef = function nodeInterfaceRef() {
         ...this.options.relayOptions.nodeTypeOptions,
         fields: (t) => ({
             [this.options.relayOptions?.idFieldName ?? "id"]: t.globalID({
+                ...this.options.relayOptions?.idFieldOptions,
                 nullable: false,
                 resolve: (parent) => {
                     throw new PothosValidationError("id field not implemented");

--- a/packages/plugin-relay/src/schema-builder.ts
+++ b/packages/plugin-relay/src/schema-builder.ts
@@ -139,6 +139,7 @@ schemaBuilderProto.nodeInterfaceRef = function nodeInterfaceRef() {
     ...this.options.relayOptions.nodeTypeOptions,
     fields: (t) => ({
       [this.options.relayOptions?.idFieldName ?? 'id']: t.globalID({
+        ...this.options.relayOptions?.idFieldOptions,
         nullable: false,
         resolve: (parent) => {
           throw new PothosValidationError('id field not implemented');


### PR DESCRIPTION
This will also apply `idFieldOptions` to the Node interface. My goal was to give the Node interface's ID field a description:

```ts
const schemaBuilder = new SchemaBuilder({
  plugins: [RelayPlugin],
  relayOptions: {
    idFieldOptions: {
      description: "The node’s globally unique identifier.",
    },
  },
};
```

```graphql
interface Node {
  "The node’s globally unique identifier."
  id: ID!
}
```