### PR TITLE
Add ability to configure meta for builder.enumType(<ts enum>)

### DIFF
--- a/.changeset/twenty-years-search.md
+++ b/.changeset/twenty-years-search.md
@@ -1,0 +1,5 @@
+---
+'@pothos/core': minor
+---
+
+Ability to configure meta (description, deprecationReason, extensions) for TS-based enum types

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -458,8 +458,11 @@ export default class SchemaBuilder<Types extends SchemaTypes> {
 
     const values =
       typeof param === 'object'
-        ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-          valuesFromEnum<Types>(param as BaseEnum, options?.values as any)
+        ? valuesFromEnum<Types>(
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+            param as BaseEnum,
+            options?.values as Record<string, PothosSchemaTypes.EnumValueConfig<Types>>,
+          )
         : normalizeEnumValues<Types>((options as { values: EnumValues<Types> }).values);
 
     const config: PothosEnumTypeConfig = {

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -459,7 +459,7 @@ export default class SchemaBuilder<Types extends SchemaTypes> {
     const values =
       typeof param === 'object'
         ? // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-          valuesFromEnum<Types>(param as BaseEnum)
+          valuesFromEnum<Types>(param as BaseEnum, options?.values as any)
         : normalizeEnumValues<Types>((options as { values: EnumValues<Types> }).values);
 
     const config: PothosEnumTypeConfig = {

--- a/packages/core/src/types/builder-options.ts
+++ b/packages/core/src/types/builder-options.ts
@@ -180,6 +180,9 @@ export type EnumTypeOptions<
   ? Merge<
       Omit<PothosSchemaTypes.EnumTypeOptions<Types, Values>, 'values'> & {
         name: string;
+        values?: Partial<
+          Record<keyof Param, Omit<PothosSchemaTypes.EnumValueConfig<Types>, 'value'>>
+        >;
       }
     >
   : PothosSchemaTypes.EnumTypeOptions<Types, Values>;

--- a/packages/core/src/utils/enums.ts
+++ b/packages/core/src/utils/enums.ts
@@ -32,7 +32,7 @@ export function normalizeEnumValues<Types extends SchemaTypes>(
 
 export function valuesFromEnum<Types extends SchemaTypes>(
   Enum: BaseEnum,
-  values?: Partial<Record<string, Omit<PothosSchemaTypes.EnumValueConfig<Types>, 'value'>>>,
+  values?: Record<string, Omit<PothosSchemaTypes.EnumValueConfig<Types>, 'value'>>,
 ): Record<string, PothosEnumValueConfig<Types>> {
   const result: Record<string, PothosEnumValueConfig<Types>> = {};
 

--- a/packages/core/src/utils/enums.ts
+++ b/packages/core/src/utils/enums.ts
@@ -32,6 +32,7 @@ export function normalizeEnumValues<Types extends SchemaTypes>(
 
 export function valuesFromEnum<Types extends SchemaTypes>(
   Enum: BaseEnum,
+  values?: Partial<Record<string, Omit<PothosSchemaTypes.EnumValueConfig<Types>, 'value'>>>,
 ): Record<string, PothosEnumValueConfig<Types>> {
   const result: Record<string, PothosEnumValueConfig<Types>> = {};
 
@@ -41,6 +42,7 @@ export function valuesFromEnum<Types extends SchemaTypes>(
       result[key] = {
         value: Enum[key],
         pothosOptions: {},
+        ...values?.[key],
       };
     });
 

--- a/packages/core/tests/__snapshots__/index.test.ts.snap
+++ b/packages/core/tests/__snapshots__/index.test.ts.snap
@@ -45,8 +45,10 @@ type Giraffe implements Animal {
 
 enum MyEnum {
   Bar
+
+  \\"\\"\\"Some description here\\"\\"\\"
   Foo
-  Num
+  Num @deprecated(reason: \\"Not used anymore..\\")
 }
 
 type Query {

--- a/packages/core/tests/examples/random-stuff.ts
+++ b/packages/core/tests/examples/random-stuff.ts
@@ -74,6 +74,14 @@ enum MyEnum {
 
 builder.enumType(MyEnum, {
   name: 'MyEnum',
+  values: {
+    Foo: {
+      description: 'Some description here',
+    },
+    Num: {
+      deprecationReason: 'Not used anymore..',
+    },
+  },
 });
 
 // Create input types


### PR DESCRIPTION
Hey!

I'm working on a pull request to add the ability to also optionally specify graphql metadata (description, deprecationReason, and extensions) for an enum type, even if the enum type is provided as a TypeScript enum. Because currently, you cannot do this:

```ts
enum SomeTypescriptEnum {
  bla = "bla",
  yeah = "yeah",
}

builder.enumType(SomeTypescriptEnum, {
  name: "SomeTypescriptEnum",

  // not currently possible:
  values: {
    bla: {
      deprecationReason: "We don't use this anymore for some reason",
    },
  }.
});
```

The actual JS fix is simple, but the TypeScript typings are a bit more complicated, and then it'll also require some changes in the other packages and docs I think, before this PR can be complete.

The first commit I just added allows the core package to build successfully, although I'm not 100% sure that the typings are as they're supposed to be.


If anyone wants to pitch in to help with the additional work, I'd be super happy! :)

Also, @hayes, I'm not 100% sure how all the tooling of your repo works, e.g. the changesets etc. So maybe you could help me out here :)