### PR TITLE
chore(workspace): publish packages with provenance

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -11,6 +11,14 @@ jobs:
   version:
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      repository-projects: write
+      deployments: write
+      packages: write
+      pull-requests: write
 
     services:
       # Label used to access the service container

--- a/packages/converter/package.json
+++ b/packages/converter/package.json
@@ -38,7 +38,8 @@
     "converter"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "dependencies": {
     "graphql": "16.6.0",

--- a/packages/converter/package.json
+++ b/packages/converter/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/converter"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/core"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,7 +42,8 @@
     "deno"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "graphql": ">=15.1.0"

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -9,7 +9,8 @@
   "author": "Michael Hayes",
   "license": "ISC",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "devDependencies": {
     "@swc-node/register": "^1.6.2",

--- a/packages/deno/package.json
+++ b/packages/deno/package.json
@@ -4,7 +4,8 @@
   "description": "Deno compatible versions of Pothos packages",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/deno"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-add-graphql/package.json
+++ b/packages/plugin-add-graphql/package.json
@@ -40,7 +40,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-add-graphql/package.json
+++ b/packages/plugin-add-graphql/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-add-graphql"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-authz/package.json
+++ b/packages/plugin-authz/package.json
@@ -34,7 +34,8 @@
     "authorization"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@graphql-authz/core": "*",

--- a/packages/plugin-authz/package.json
+++ b/packages/plugin-authz/package.json
@@ -24,6 +24,11 @@
     "esm:extensions": "TS_NODE_PROJECT=../../tsconfig.json node -r @swc-node/register ../../scripts/esm-transformer.ts",
     "test": "pnpm jest --runInBand"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-authz"
+  },
   "author": "Michael Hayes",
   "license": "ISC",
   "keywords": [

--- a/packages/plugin-complexity/package.json
+++ b/packages/plugin-complexity/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-complexity"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-complexity/package.json
+++ b/packages/plugin-complexity/package.json
@@ -41,7 +41,8 @@
     "limit"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-dataloader/package.json
+++ b/packages/plugin-dataloader/package.json
@@ -34,7 +34,8 @@
     "dataloader"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-dataloader/package.json
+++ b/packages/plugin-dataloader/package.json
@@ -26,6 +26,11 @@
   },
   "author": "Michael Hayes",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-dataloader"
+  },
   "keywords": [
     "pothos",
     "graphql",

--- a/packages/plugin-directives/package.json
+++ b/packages/plugin-directives/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-directives"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-directives/package.json
+++ b/packages/plugin-directives/package.json
@@ -41,7 +41,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "graphql": ">=15.1.0"

--- a/packages/plugin-errors/package.json
+++ b/packages/plugin-errors/package.json
@@ -40,7 +40,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-errors/package.json
+++ b/packages/plugin-errors/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-errors"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-example/package.json
+++ b/packages/plugin-example/package.json
@@ -25,7 +25,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-example"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-example/package.json
+++ b/packages/plugin-example/package.json
@@ -37,7 +37,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-federation/package.json
+++ b/packages/plugin-federation/package.json
@@ -36,7 +36,8 @@
     "subgraph"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@apollo/subgraph": "^2.0.0",

--- a/packages/plugin-federation/package.json
+++ b/packages/plugin-federation/package.json
@@ -21,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-federation"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-mocks/package.json
+++ b/packages/plugin-mocks/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-mocks"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-mocks/package.json
+++ b/packages/plugin-mocks/package.json
@@ -41,7 +41,8 @@
     "stub"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-prisma-utils/package.json
+++ b/packages/plugin-prisma-utils/package.json
@@ -40,7 +40,8 @@
     "prisma"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "prisma": {
     "seed": "node prisma/seed.mjs"

--- a/packages/plugin-prisma-utils/package.json
+++ b/packages/plugin-prisma-utils/package.json
@@ -28,7 +28,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-prisma-utils"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-prisma/package.json
+++ b/packages/plugin-prisma/package.json
@@ -58,7 +58,8 @@
     "mongo"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "dependencies": {
     "@prisma/generator-helper": "^4.11.0"

--- a/packages/plugin-prisma/package.json
+++ b/packages/plugin-prisma/package.json
@@ -37,7 +37,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-prisma"
   },
   "bin": {
     "prisma-pothos-types": "./bin/generator.js"

--- a/packages/plugin-relay/package.json
+++ b/packages/plugin-relay/package.json
@@ -43,7 +43,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-relay/package.json
+++ b/packages/plugin-relay/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-relay"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-scope-auth/package.json
+++ b/packages/plugin-scope-auth/package.json
@@ -27,7 +27,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-scope-auth"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-scope-auth/package.json
+++ b/packages/plugin-scope-auth/package.json
@@ -47,7 +47,8 @@
     "seed": "node prisma/seed.mjs"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-simple-objects/package.json
+++ b/packages/plugin-simple-objects/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-simple-objects"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-simple-objects/package.json
+++ b/packages/plugin-simple-objects/package.json
@@ -41,7 +41,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-smart-subscriptions/package.json
+++ b/packages/plugin-smart-subscriptions/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-smart-subscriptions"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-smart-subscriptions/package.json
+++ b/packages/plugin-smart-subscriptions/package.json
@@ -41,7 +41,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-sub-graph/package.json
+++ b/packages/plugin-sub-graph/package.json
@@ -44,7 +44,8 @@
     "private"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-sub-graph/package.json
+++ b/packages/plugin-sub-graph/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-sub-graph"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-tracing/package.json
+++ b/packages/plugin-tracing/package.json
@@ -43,7 +43,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-tracing/package.json
+++ b/packages/plugin-tracing/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-tracing"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/plugin-validation/package.json
+++ b/packages/plugin-validation/package.json
@@ -36,7 +36,8 @@
     "validate"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-validation/package.json
+++ b/packages/plugin-validation/package.json
@@ -26,6 +26,11 @@
   },
   "author": "Michael Hayes",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-validation"
+  },
   "keywords": [
     "pothos",
     "graphql",

--- a/packages/plugin-with-input/package.json
+++ b/packages/plugin-with-input/package.json
@@ -40,7 +40,8 @@
     "input"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-with-input/package.json
+++ b/packages/plugin-with-input/package.json
@@ -27,7 +27,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/plugin-with-input"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -25,7 +25,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/test-utils"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -30,7 +30,8 @@
   "author": "Michael Hayes",
   "license": "ISC",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "dependencies": {
     "graphql": "16.6.0",

--- a/packages/tracing-newrelic/package.json
+++ b/packages/tracing-newrelic/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/tracing-newrelic"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/tracing-newrelic/package.json
+++ b/packages/tracing-newrelic/package.json
@@ -41,7 +41,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/tracing-opentelemetry/package.json
+++ b/packages/tracing-opentelemetry/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/tracing-opentelemetry"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/tracing-opentelemetry/package.json
+++ b/packages/tracing-opentelemetry/package.json
@@ -42,7 +42,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@opentelemetry/api": "*",

--- a/packages/tracing-sentry/package.json
+++ b/packages/tracing-sentry/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/tracing-sentry"
   },
   "author": "Michael Hayes",
   "license": "ISC",

--- a/packages/tracing-sentry/package.json
+++ b/packages/tracing-sentry/package.json
@@ -42,7 +42,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/tracing-xray/package.json
+++ b/packages/tracing-xray/package.json
@@ -43,7 +43,8 @@
     "plugin"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/tracing-xray/package.json
+++ b/packages/tracing-xray/package.json
@@ -26,7 +26,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hayes/pothos.git"
+    "url": "git+https://github.com/hayes/pothos.git",
+    "directory": "packages/tracing-xray"
   },
   "author": "Michael Hayes",
   "license": "ISC",


### PR DESCRIPTION
A while ago npm released [provenance](https://docs.npmjs.com/generating-provenance-statements) which allows us to automate a proof that a version was published from an authorized CI, this to provide an initial tool against supply-chain attacks.

The premise to make this work is

- publish from Github Actions
- have the `repository` field set correctly in packages
- add `permissions` to the action

An example of how this looks on npm can be seen [here](https://www.npmjs.com/package/hoofd) at the bottom of the page.