### PR TITLE
Change `Github` to `GitHub` in the docs

### DIFF
--- a/website/components/Docs/Toc.tsx
+++ b/website/components/Docs/Toc.tsx
@@ -131,7 +131,7 @@ export function Toc({
         <Link href={currentPage.githubFile} className="flex space-x-2 mb-8 dark:text-white">
           <GithubLogo height={20} width={20} />
 
-          <span>Edit on Github</span>
+          <span>Edit on GitHub</span>
         </Link>
       )}
       <ol className="border-l border-darkGreen flex-shrink max-w-sm pr-2">

--- a/website/components/Layout.tsx
+++ b/website/components/Layout.tsx
@@ -58,7 +58,7 @@ export function Layout({ children, toc }: { children: ReactNode; toc: TableOfCon
             <li>
               <a className="flex space-x-2 hover:underline" href="https://github.com/hayes/pothos">
                 <GithubLogo height={24} width={24} />
-                <span>Github</span>
+                <span>GitHub</span>
               </a>
             </li>
             <li className="hidden sm:block hover:underline">


### PR DESCRIPTION
Thank you for the useful library.
I noticed a small discomfort while reading the documentation.
`GitHub` recommends capitalizing the "H"
This has nothing to do with the core of the library, but it would be a shame to suffer from a slight discomfort in the documentation. Please consider incorporating this change if possible.😃