### PR TITLE
stop using unavailable prisma CreateInput objects

### DIFF
--- a/.changeset/few-turtles-tell.md
+++ b/.changeset/few-turtles-tell.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-prisma": patch
+---
+
+Prevent unavailable prisma CreateInput types from being referenced by pothos generated types.

--- a/packages/plugin-prisma/src/generator.ts
+++ b/packages/plugin-prisma/src/generator.ts
@@ -144,6 +144,10 @@ function buildTypes(dmmf: DMMF.Document, config: { prismaUtils?: string }) {
     const relations = model.fields.filter((field) => !!field.relationName);
     const listRelations = model.fields.filter((field) => !!field.relationName && field.isList);
 
+    const createInputUnavailable = !dmmf.schema.inputObjectTypes.prisma.some(
+      (input) => input.name === `${model.name}CreateInput`,
+    );
+
     return ts.factory.createPropertySignature(
       [],
       model.name,
@@ -200,7 +204,9 @@ function buildTypes(dmmf: DMMF.Document, config: { prismaUtils?: string }) {
                 [],
                 'Create',
                 undefined,
-                ts.factory.createTypeReferenceNode(`Prisma.${model.name}CreateInput`),
+                createInputUnavailable
+                  ? ts.factory.createTypeLiteralNode([])
+                  : ts.factory.createTypeReferenceNode(`Prisma.${model.name}CreateInput`),
               ),
               ts.factory.createPropertySignature(
                 [],


### PR DESCRIPTION
### Problem

When you have a Prisma model where one of the required fields are of an unsupported type, Prisma does not generate a `prisma.modelName.create` function, so rows of this type can only be created through raw queries. A problem behind this is that the `generated.ts` file gets an error trying to reference a non-existent type from Prisma, and we're not able to compile with `tsc` (even with skipLibCheck).

### Solution

This PR makes necessary adjustments on Pothos' prisma plugin generator in order to not try to use the `Prisma.${modelName}CreateInput` when it is not available.