### PR TITLE
plugin-complexity: fix bug when limits are zero

### DIFF
--- a/.changeset/wild-swans-heal.md
+++ b/.changeset/wild-swans-heal.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-complexity': minor
+---
+
+fix bug when limits are zero

--- a/packages/plugin-complexity/src/index.ts
+++ b/packages/plugin-complexity/src/index.ts
@@ -112,11 +112,11 @@ export class PothosComplexityPlugin<Types extends SchemaTypes> extends BasePlugi
 
     let errorKind: ComplexityErrorKind | null = null;
 
-    if (max.depth && max.depth < depth) {
+    if (typeof max.depth === 'number' && max.depth < depth) {
       errorKind = ComplexityErrorKind.Depth;
-    } else if (max.breadth && max.breadth < breadth) {
+    } else if (typeof max.breadth === 'number' && max.breadth < breadth) {
       errorKind = ComplexityErrorKind.Breadth;
-    } else if (max.complexity && max.complexity < complexity) {
+    } else if (typeof max.complexity === 'number' && max.complexity < complexity) {
       errorKind = ComplexityErrorKind.Complexity;
     }
 

--- a/packages/plugin-complexity/src/validator.ts
+++ b/packages/plugin-complexity/src/validator.ts
@@ -78,7 +78,7 @@ export function createComplexityRule({
               reportError(error);
             });
           } else {
-            if (maxComplexity && state.complexity > maxComplexity) {
+            if (typeof maxComplexity === 'number' && state.complexity > maxComplexity) {
               reportError(
                 new GraphQLError(
                   `Query complexity of ${state.complexity} exceeds max complexity of ${maxComplexity}`,
@@ -95,7 +95,7 @@ export function createComplexityRule({
               );
             }
 
-            if (maxDepth && state.depth > maxDepth) {
+            if (typeof maxDepth === 'number' && state.depth > maxDepth) {
               reportError(
                 new GraphQLError(`Query depth of ${state.depth} exceeds max depth of ${maxDepth}`, {
                   extensions: {
@@ -109,7 +109,7 @@ export function createComplexityRule({
               );
             }
 
-            if (maxBreadth && state.breadth > maxBreadth) {
+            if (typeof maxBreadth === 'number' && state.breadth > maxBreadth) {
               reportError(
                 new GraphQLError(
                   `Query breadth of ${state.breadth} exceeds max breadth of ${maxBreadth}`,

--- a/packages/plugin-complexity/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-complexity/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,21 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`createComplexityRule > negative limits 1`] = `
+[
+  [GraphQLError: Query complexity of 2 exceeds max complexity of -1],
+  [GraphQLError: Query depth of 2 exceeds max depth of -1],
+  [GraphQLError: Query breadth of 2 exceeds max breadth of -1],
+]
+`;
+
+exports[`createComplexityRule > zero limits 1`] = `
+[
+  [GraphQLError: Query complexity of 2 exceeds max complexity of 0],
+  [GraphQLError: Query depth of 2 exceeds max depth of 0],
+  [GraphQLError: Query breadth of 2 exceeds max breadth of 0],
+]
+`;
+
 exports[`simple objects example schema > complexity from query > as string 1`] = `
 {
   "breadth": 7,
@@ -99,6 +115,33 @@ type Query {
   ): Human!
   r2d2: Droid!
 }"
+`;
+
+exports[`simple objects example schema > negative limits > negative breadth 1`] = `
+{
+  "data": null,
+  "errors": [
+    [GraphQLError: Query exceeds maximum breadth (breadth: 2, max: -1)],
+  ],
+}
+`;
+
+exports[`simple objects example schema > negative limits > negative complexity 1`] = `
+{
+  "data": null,
+  "errors": [
+    [GraphQLError: Query exceeds maximum complexity (complexity: 2, max: -1)],
+  ],
+}
+`;
+
+exports[`simple objects example schema > negative limits > negative depth 1`] = `
+{
+  "data": null,
+  "errors": [
+    [GraphQLError: Query exceeds maximum depth (depth: 2, max: -1)],
+  ],
+}
 `;
 
 exports[`simple objects example schema > queries > complexity based on args 1`] = `
@@ -417,5 +460,32 @@ exports[`simple objects example schema > queries > valid query 1`] = `
       ],
     },
   },
+}
+`;
+
+exports[`simple objects example schema > zero limits > zero breadth 1`] = `
+{
+  "data": null,
+  "errors": [
+    [GraphQLError: Query exceeds maximum breadth (breadth: 2, max: 0)],
+  ],
+}
+`;
+
+exports[`simple objects example schema > zero limits > zero complexity 1`] = `
+{
+  "data": null,
+  "errors": [
+    [GraphQLError: Query exceeds maximum complexity (complexity: 2, max: 0)],
+  ],
+}
+`;
+
+exports[`simple objects example schema > zero limits > zero depth 1`] = `
+{
+  "data": null,
+  "errors": [
+    [GraphQLError: Query exceeds maximum depth (depth: 2, max: 0)],
+  ],
 }
 `;

--- a/packages/plugin-complexity/tests/index.test.ts
+++ b/packages/plugin-complexity/tests/index.test.ts
@@ -240,6 +240,66 @@ describe('simple objects example schema', () => {
       expect(result).toMatchSnapshot();
     });
   });
+
+  describe('negative limits', () => {
+    const limitTypes = ['depth', 'breadth', 'complexity'] as const;
+
+    limitTypes.map((limit) => {
+      it(`negative ${limit}`, async () => {
+        const query = gql`
+          query {
+            hero(episode: EMPIRE) {
+              name
+            }
+          }
+        `;
+
+        const result = await execute({
+          schema: exampleSchema,
+          document: query,
+          contextValue: {
+            complexity: {
+              depth: limit === 'depth' ? -1 : 10,
+              breadth: limit === 'breadth' ? -1 : 10,
+              complexity: limit === 'complexity' ? -1 : 10,
+            },
+          },
+        });
+
+        expect(result).toMatchSnapshot();
+      });
+    });
+  });
+
+  describe('zero limits', () => {
+    const limitTypes = ['depth', 'breadth', 'complexity'] as const;
+
+    limitTypes.map((limit) => {
+      it(`zero ${limit}`, async () => {
+        const query = gql`
+          query {
+            hero(episode: EMPIRE) {
+              name
+            }
+          }
+        `;
+
+        const result = await execute({
+          schema: exampleSchema,
+          document: query,
+          contextValue: {
+            complexity: {
+              depth: limit === 'depth' ? 0 : 10,
+              breadth: limit === 'breadth' ? 0 : 10,
+              complexity: limit === 'complexity' ? 0 : 10,
+            },
+          },
+        });
+
+        expect(result).toMatchSnapshot();
+      });
+    });
+  });
 });
 
 describe('createComplexityRule', () => {
@@ -309,5 +369,53 @@ describe('createComplexityRule', () => {
         },
       ]
     `);
+  });
+
+  it('negative limits', async () => {
+    const results = validate(
+      exampleSchema,
+      gql`
+        query {
+          hero(episode: EMPIRE) {
+            name
+          }
+        }
+      `,
+      [
+        createComplexityRule({
+          maxDepth: -1,
+          maxBreadth: -1,
+          maxComplexity: -1,
+          variableValues: {},
+          context: {},
+        }),
+      ],
+    );
+
+    expect(results).toMatchSnapshot();
+  });
+
+  it('zero limits', async () => {
+    const results = validate(
+      exampleSchema,
+      gql`
+        query {
+          hero(episode: EMPIRE) {
+            name
+          }
+        }
+      `,
+      [
+        createComplexityRule({
+          maxDepth: 0,
+          maxBreadth: 0,
+          maxComplexity: 0,
+          variableValues: {},
+          context: {},
+        }),
+      ],
+    );
+
+    expect(results).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
hi all!

thanks for that awesome library. it's way easier to implement a graphql api using it!

while experimenting with it, i noticed that the plugin `@pothos/plugin-complexity` interprets zero-values as just an undefined limit.

i expect that a zero-value means that a limit is reached, just like a negative value.

i've changed the truthy comparison to a `typeof <limit name> === 'number'` where applicable. i've also added some test cases that cover zero-values and negatives (already supported, but just in case...).

i'd be glad if you consider incorporating this change.