### PR TITLE
Allow `mode` in generated Prisma scalar filter types

### DIFF
--- a/.changeset/smooth-oranges-drive.md
+++ b/.changeset/smooth-oranges-drive.md
@@ -2,4 +2,4 @@
 '@pothos/plugin-prisma-utils': minor
 ---
 
-Allow `mode` field in generated Prisma scalar filter types
+Allow `mode` field in generated Prisma filter types

--- a/.changeset/smooth-oranges-drive.md
+++ b/.changeset/smooth-oranges-drive.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-prisma-utils': minor
+---
+
+Allow `mode` field in generated Prisma scalar filter types

--- a/packages/plugin-prisma-utils/src/global-types.ts
+++ b/packages/plugin-prisma-utils/src/global-types.ts
@@ -68,6 +68,8 @@ declare global {
         >
       >;
 
+      prismaQueryModeEnum: () => EnumRef<'default' | 'insensitive'>;
+
       prismaOrderBy: <
         Name extends keyof Types['PrismaTypes'],
         Model extends PrismaModelTypes = Types['PrismaTypes'][Name] extends PrismaModelTypes

--- a/packages/plugin-prisma-utils/src/global-types.ts
+++ b/packages/plugin-prisma-utils/src/global-types.ts
@@ -68,7 +68,7 @@ declare global {
         >
       >;
 
-      prismaQueryModeEnum: () => EnumRef<'default' | 'insensitive'>;
+      prismaStringFilterModeEnum: () => EnumRef<'default' | 'insensitive'>;
 
       prismaOrderBy: <
         Name extends keyof Types['PrismaTypes'],

--- a/packages/plugin-prisma-utils/src/schema-builder.ts
+++ b/packages/plugin-prisma-utils/src/schema-builder.ts
@@ -39,7 +39,7 @@ const OrderByRefMap = new WeakMap<
   EnumRef<'asc' | 'desc'>
 >();
 
-const PrismaQueryModeRefMap = new WeakMap<
+const PrismaStringFilterModeRefMap = new WeakMap<
   PothosSchemaTypes.SchemaBuilder<SchemaTypes>,
   EnumRef<'default' | 'insensitive'>
 >();
@@ -87,7 +87,7 @@ schemaBuilder.prismaFilter = function prismaFilter<
             fieldType = [type];
             break;
           case 'mode':
-            fieldType = this.prismaQueryModeEnum();
+            fieldType = this.prismaStringFilterModeEnum();
             break;
           default:
             fieldType = type;
@@ -107,19 +107,19 @@ schemaBuilder.prismaFilter = function prismaFilter<
   return ref as never;
 };
 
-schemaBuilder.prismaQueryModeEnum = function prismaQueryModeEnum() {
-  if (PrismaQueryModeRefMap.has(this)) {
-    return PrismaQueryModeRefMap.get(this)!;
+schemaBuilder.prismaStringFilterModeEnum = function prismaStringFilterModeEnum() {
+  if (PrismaStringFilterModeRefMap.has(this)) {
+    return PrismaStringFilterModeRefMap.get(this)!;
   }
 
-  const ref = this.enumType('PrismaQueryMode', {
+  const ref = this.enumType('StringFilterMode', {
     values: {
       Default: { value: 'default' as const },
       Insensitive: { value: 'insensitive' as const },
     },
   });
 
-  PrismaQueryModeRefMap.set(this, ref);
+  PrismaStringFilterModeRefMap.set(this, ref);
 
   return ref;
 };

--- a/packages/plugin-prisma-utils/src/types.ts
+++ b/packages/plugin-prisma-utils/src/types.ts
@@ -28,6 +28,7 @@ export interface FilterShape<T> {
   is?: T;
   isNot?: T;
   search?: T;
+  mode?: 'default' | 'insensitive';
 }
 
 export interface ScalarListFilterShape<T> {

--- a/packages/plugin-prisma-utils/tests/__snapshots__/codegen.test.ts.snap
+++ b/packages/plugin-prisma-utils/tests/__snapshots__/codegen.test.ts.snap
@@ -1017,11 +1017,6 @@ input PostWithoutAuthorFilter {
   updatedAt: DateTimeFilter
 }
 
-enum PrismaQueryMode {
-  Default
-  Insensitive
-}
-
 type Profile {
   bio: String
   id: ID!
@@ -1098,10 +1093,15 @@ input StringFilter {
   isNot: String
   lt: String
   lte: String
-  mode: PrismaQueryMode
+  mode: StringFilterMode
   not: StringFilter
   notIn: [String!]
   startsWith: String
+}
+
+enum StringFilterMode {
+  Default
+  Insensitive
 }
 
 input StringListFilter {

--- a/packages/plugin-prisma-utils/tests/__snapshots__/codegen.test.ts.snap
+++ b/packages/plugin-prisma-utils/tests/__snapshots__/codegen.test.ts.snap
@@ -1017,6 +1017,11 @@ input PostWithoutAuthorFilter {
   updatedAt: DateTimeFilter
 }
 
+enum PrismaQueryMode {
+  Default
+  Insensitive
+}
+
 type Profile {
   bio: String
   id: ID!
@@ -1093,6 +1098,7 @@ input StringFilter {
   isNot: String
   lt: String
   lte: String
+  mode: PrismaQueryMode
   not: StringFilter
   notIn: [String!]
   startsWith: String

--- a/packages/plugin-prisma-utils/tests/codegen.test.ts
+++ b/packages/plugin-prisma-utils/tests/codegen.test.ts
@@ -382,4 +382,35 @@ describe('codegen', () => {
       ]
     `);
   });
+
+  it('returns filtered user with mode: Insensitive', async () => {
+    await prisma.user.create({
+      data: {
+        email: 'test@example.com',
+      },
+    });
+    const query = await execute({
+      schema,
+      contextValue: {},
+      document: gql`
+        query {
+          users(filter: { email: { contains: "EXAMPLE", mode: Insensitive } }) {
+            email
+          }
+        }
+      `,
+    });
+
+    expect(query).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "users": [
+            {
+              "email": "test@example.com",
+            },
+          ],
+        },
+      }
+    `);
+  });
 });

--- a/packages/plugin-prisma-utils/tests/examples/codegen/generator.ts
+++ b/packages/plugin-prisma-utils/tests/examples/codegen/generator.ts
@@ -18,7 +18,7 @@ import {
 
 const filterOps = ['equals', 'in', 'notIn', 'not', 'is', 'isNot'] as const;
 const sortableFilterProps = ['lt', 'lte', 'gt', 'gte'] as const;
-const stringFilterOps = [...filterOps, 'contains', 'startsWith', 'endsWith'] as const;
+const stringFilterOps = [...filterOps, 'contains', 'startsWith', 'endsWith', 'mode'] as const;
 const sortableTypes = ['String', 'Int', 'Float', 'DateTime', 'BigInt'] as const;
 const listOps = ['every', 'some', 'none'] as const;
 const scalarListOps = ['has', 'hasSome', 'hasEvery', 'isEmpty', 'equals'] as const;

--- a/packages/plugin-prisma-utils/tests/examples/codegen/schema.graphql
+++ b/packages/plugin-prisma-utils/tests/examples/codegen/schema.graphql
@@ -1014,6 +1014,11 @@ input PostWithoutAuthorFilter {
   updatedAt: DateTimeFilter
 }
 
+enum PrismaQueryMode {
+  Default
+  Insensitive
+}
+
 type Profile {
   bio: String
   id: ID!
@@ -1090,6 +1095,7 @@ input StringFilter {
   isNot: String
   lt: String
   lte: String
+  mode: PrismaQueryMode
   not: StringFilter
   notIn: [String!]
   startsWith: String

--- a/packages/plugin-prisma-utils/tests/examples/codegen/schema.graphql
+++ b/packages/plugin-prisma-utils/tests/examples/codegen/schema.graphql
@@ -1014,11 +1014,6 @@ input PostWithoutAuthorFilter {
   updatedAt: DateTimeFilter
 }
 
-enum PrismaQueryMode {
-  Default
-  Insensitive
-}
-
 type Profile {
   bio: String
   id: ID!
@@ -1095,10 +1090,15 @@ input StringFilter {
   isNot: String
   lt: String
   lte: String
-  mode: PrismaQueryMode
+  mode: StringFilterMode
   not: StringFilter
   notIn: [String!]
   startsWith: String
+}
+
+enum StringFilterMode {
+  Default
+  Insensitive
 }
 
 input StringListFilter {

--- a/packages/plugin-prisma-utils/tests/examples/codegen/schema/prisma-inputs.ts
+++ b/packages/plugin-prisma-utils/tests/examples/codegen/schema/prisma-inputs.ts
@@ -52,11 +52,11 @@ export const StringFilter = builder.prismaFilter('String', {
     'contains',
     'startsWith',
     'endsWith',
+    'mode',
     'lt',
     'lte',
     'gt',
     'gte',
-    'mode',
   ],
 });
 export const BooleanFilter = builder.prismaFilter('Boolean', {

--- a/packages/plugin-prisma-utils/tests/examples/codegen/schema/prisma-inputs.ts
+++ b/packages/plugin-prisma-utils/tests/examples/codegen/schema/prisma-inputs.ts
@@ -56,6 +56,7 @@ export const StringFilter = builder.prismaFilter('String', {
     'lte',
     'gt',
     'gte',
+    'mode',
   ],
 });
 export const BooleanFilter = builder.prismaFilter('Boolean', {


### PR DESCRIPTION
With this change, the `mode` field can be added to scalar filter types, which allows to do queries like this:

```graphql
{
  users(filter: {email: {contains: "GMAIL", mode: Insensitive}}) {
    id
    email
  }
}
```

I tested the query with the "codegen" example:

```sh
node -r @swc-node/register packages/plugin-prisma-utils/tests/examples/codegen/server.ts
```

Fixes #937 