### PR TITLE
Expose prismaModelKey

### DIFF
--- a/.changeset/nice-crabs-melt.md
+++ b/.changeset/nice-crabs-melt.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-prisma': patch
+---
+
+Expose prismaModelKey

--- a/packages/plugin-prisma/src/index.ts
+++ b/packages/plugin-prisma/src/index.ts
@@ -21,7 +21,7 @@ import { queryFromInfo } from './util/map-query';
 export { prismaConnectionHelpers } from './connection-helpers';
 export { PrismaInterfaceRef } from './interface-ref';
 export { PrismaNodeRef } from './node-ref';
-export { PrismaObjectRef } from './object-ref';
+export { prismaModelKey, PrismaObjectRef } from './object-ref';
 export * from './types';
 
 const pluginName = 'prisma' as const;


### PR DESCRIPTION
**Description**
- Expose `prismaModelKey` symbol from `@pothos/plugin-prisma`

**Context**

Hi, I'm author of pothos-plugin-effect which a Pothos plugin for integration with Effect ecosystem. Recently, I've been working on integrate with prisma plugin and realized that I needed to access `prismaModelKey` to resovle typing.

Here is my pull reqeust: https://github.com/iamchanii/pothos-plugin-effect/pull/19. (I will be glad if you can review about it especially [here](https://github.com/iamchanii/pothos-plugin-effect/blob/29d4709889d614ca68c07e3c8736371eb583fa5c/src/global-types.ts#L159-L167) :wink:)

I temporarily worked through the `pnpm patch`. I hope to see this PR merged then I'll release `t.prismaEffect` feature with new prisma-plugin depends.