### PR TITLE
Fix plugin names missing as const

### DIFF
--- a/packages/plugin-errors/src/index.ts
+++ b/packages/plugin-errors/src/index.ts
@@ -15,7 +15,7 @@ import { GetTypeName } from './types';
 
 export * from './types';
 
-const pluginName = 'errors';
+const pluginName = 'errors' as const;
 
 export default pluginName;
 

--- a/packages/plugin-federation/src/index.ts
+++ b/packages/plugin-federation/src/index.ts
@@ -15,7 +15,7 @@ import { entityMapping, keyDirective, mergeDirectives } from './util';
 
 export * from './types';
 
-const pluginName = 'federation';
+const pluginName = 'federation' as const;
 
 export default pluginName;
 

--- a/packages/plugin-relay/src/index.ts
+++ b/packages/plugin-relay/src/index.ts
@@ -16,7 +16,7 @@ export * from './node-ref';
 export * from './types';
 export * from './utils';
 
-const pluginName = 'relay';
+const pluginName = 'relay' as const;
 
 export default pluginName;
 


### PR DESCRIPTION
From https://pothos-graphql.dev/docs/guide/writing-plugins#indexts:
> The plugins name, which should be typed as a string literal rather than as a generic string:
> const pluginName = 'example' as const;

