### PR TITLE
docs(guide/args): fix args typo

### DIFF
--- a/website/pages/docs/guide/args.mdx
+++ b/website/pages/docs/guide/args.mdx
@@ -34,7 +34,7 @@ const Query = builder.queryType({
           description: 'String arg',
         }),
       },
-      resolve: (parent, args) => arg.string,
+      resolve: (parent, args) => args.string,
     }),
   }),
 });


### PR DESCRIPTION
The name should be `args` not `arg`.