### PR TITLE
feat: allow prismaFilters to filter for null values with not

### DIFF
--- a/.changeset/small-ads-cover.md
+++ b/.changeset/small-ads-cover.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-prisma-utils': minor
+---
+
+Allow filters to set null for not

--- a/packages/plugin-prisma-utils/src/schema-builder.ts
+++ b/packages/plugin-prisma-utils/src/schema-builder.ts
@@ -45,7 +45,7 @@ const PrismaStringFilterModeRefMap = new WeakMap<
   EnumRef<'default' | 'insensitive'>
 >();
 
-const nullableOps = new Set(['equals', 'is', 'isNot']);
+const nullableOps = new Set(['equals', 'is', 'isNot', 'not']);
 
 schemaBuilder.prismaFilter = function prismaFilter<
   Type extends InputType<SchemaTypes>,

--- a/packages/plugin-prisma-utils/tests/index.test.ts
+++ b/packages/plugin-prisma-utils/tests/index.test.ts
@@ -24,7 +24,7 @@ describe('prisma utils', () => {
       query {
         posts(
           order: { author: { name: Desc, profile: null } }
-          filter: { id: { not: { equals: 11, not: null } } }
+          filter: { id: { not: { equals: 11 } } }
         ) {
           id
           author {
@@ -86,7 +86,6 @@ describe('prisma utils', () => {
               "id": {
                 "not": {
                   "equals": 11,
-                  "not": undefined,
                 },
               },
             },


### PR DESCRIPTION
`isNot` is used only for relation filter conditions.