### PR TITLE
Improve typings when registering existing scalars/types

### DIFF
--- a/examples/complex-app/src/builder.ts
+++ b/examples/complex-app/src/builder.ts
@@ -50,4 +50,4 @@ export const builder = new SchemaBuilder<{
 builder.queryType();
 builder.mutationType();
 
-builder.addScalarType('DateTime', DateTimeResolver, {});
+builder.addScalarType('DateTime', DateTimeResolver);

--- a/packages/core/src/builder.ts
+++ b/packages/core/src/builder.ts
@@ -520,7 +520,7 @@ export default class SchemaBuilder<Types extends SchemaTypes> {
       'serialize'
     > & {
       serialize?: GraphQLScalarSerializer<OutputShape<Types, Name>>;
-    },
+    } = {},
   ) {
     const config = scalar.toConfig();
 
@@ -594,7 +594,7 @@ export default class SchemaBuilder<Types extends SchemaTypes> {
     const scalars = [GraphQLID, GraphQLInt, GraphQLFloat, GraphQLString, GraphQLBoolean];
     scalars.forEach((scalar) => {
       if (!this.configStore.hasConfig(scalar.name as OutputType<Types>)) {
-        this.addScalarType(scalar.name as ScalarName<Types>, scalar, {});
+        this.addScalarType(scalar.name as ScalarName<Types>, scalar);
       }
     });
 

--- a/packages/core/tests/examples/giraffes/scalars.ts
+++ b/packages/core/tests/examples/giraffes/scalars.ts
@@ -1,7 +1,7 @@
 import { DateResolver } from 'graphql-scalars';
 import builder from './builder';
 
-builder.addScalarType('Date', DateResolver, {});
+builder.addScalarType('Date', DateResolver);
 
 builder.scalarType('PositiveInt', {
   serialize: (n) => n as number,

--- a/packages/deno/packages/core/builder.ts
+++ b/packages/deno/packages/core/builder.ts
@@ -314,7 +314,7 @@ export default class SchemaBuilder<Types extends SchemaTypes> {
     }
     addScalarType<Name extends ScalarName<Types>>(name: Name, scalar: GraphQLScalarType, options: Omit<PothosSchemaTypes.ScalarTypeOptions<Types, InputShape<Types, Name>, OutputShape<Types, Name>>, "serialize"> & {
         serialize?: GraphQLScalarSerializer<OutputShape<Types, Name>>;
-    }) {
+    } = {}) {
         const config = scalar.toConfig();
         return this.scalarType<Name>(name, {
             ...config,
@@ -363,7 +363,7 @@ export default class SchemaBuilder<Types extends SchemaTypes> {
         const scalars = [GraphQLID, GraphQLInt, GraphQLFloat, GraphQLString, GraphQLBoolean];
         scalars.forEach((scalar) => {
             if (!this.configStore.hasConfig(scalar.name as OutputType<Types>)) {
-                this.addScalarType(scalar.name as ScalarName<Types>, scalar, {});
+                this.addScalarType(scalar.name as ScalarName<Types>, scalar);
             }
         });
         const buildCache = new BuildCache(this, options);

--- a/packages/deno/packages/plugin-add-graphql/global-types.ts
+++ b/packages/deno/packages/plugin-add-graphql/global-types.ts
@@ -16,11 +16,11 @@ declare global {
             };
         }
         export interface SchemaBuilder<Types extends SchemaTypes> {
-            addGraphQLObject: <Shape>(type: GraphQLObjectType<Shape>, options: AddGraphQLObjectTypeOptions<Types, Shape>) => ObjectRef<Shape>;
-            addGraphQLInterface: <Shape>(type: GraphQLInterfaceType, options: AddGraphQLInterfaceTypeOptions<Types, Shape>) => InterfaceRef<Shape>;
-            addGraphQLUnion: <Shape>(type: GraphQLUnionType, options: AddGraphQLUnionTypeOptions<Types, ObjectRef<Shape>>) => UnionRef<Shape>;
-            addGraphQLEnum: <Shape extends number | string>(type: GraphQLEnumType, options: AddGraphQLEnumTypeOptions<Types, EnumValuesWithShape<Types, Shape>>) => EnumRef<Shape>;
-            addGraphQLInput: <Shape extends {}>(type: GraphQLInputObjectType, options: AddGraphQLInputTypeOptions<Types, Shape>) => InputTypeRef<Shape>;
+            addGraphQLObject: <Shape>(type: GraphQLObjectType<Shape>, options?: AddGraphQLObjectTypeOptions<Types, Shape>) => ObjectRef<Shape>;
+            addGraphQLInterface: <Shape>(type: GraphQLInterfaceType, options?: AddGraphQLInterfaceTypeOptions<Types, Shape>) => InterfaceRef<Shape>;
+            addGraphQLUnion: <Shape>(type: GraphQLUnionType, options?: AddGraphQLUnionTypeOptions<Types, ObjectRef<Shape>>) => UnionRef<Shape>;
+            addGraphQLEnum: <Shape extends number | string>(type: GraphQLEnumType, options?: AddGraphQLEnumTypeOptions<Types, EnumValuesWithShape<Types, Shape>>) => EnumRef<Shape>;
+            addGraphQLInput: <Shape extends {}>(type: GraphQLInputObjectType, options?: AddGraphQLInputTypeOptions<Types, Shape>) => InputTypeRef<Shape>;
         }
     }
 }

--- a/packages/deno/packages/plugin-add-graphql/schema-builder.ts
+++ b/packages/deno/packages/plugin-add-graphql/schema-builder.ts
@@ -59,7 +59,7 @@ function resolveInputType(builder: PothosSchemaTypes.SchemaBuilder<SchemaTypes>,
         } as unknown as boolean,
     };
 }
-proto.addGraphQLObject = function addGraphQLObject<Shape>(type: GraphQLObjectType<Shape>, { fields, extensions, ...options }: AddGraphQLObjectTypeOptions<SchemaTypes, Shape>) {
+proto.addGraphQLObject = function addGraphQLObject<Shape>(type: GraphQLObjectType<Shape>, { fields, extensions, ...options }: AddGraphQLObjectTypeOptions<SchemaTypes, Shape> = {}) {
     const typeOptions = {
         ...options,
         description: type.description ?? undefined,
@@ -116,7 +116,7 @@ proto.addGraphQLObject = function addGraphQLObject<Shape>(type: GraphQLObjectTyp
             return this.objectRef<Shape>(options?.name ?? type.name).implement(typeOptions as never);
     }
 };
-proto.addGraphQLInterface = function addGraphQLInterface<Shape = unknown>(type: GraphQLInterfaceType, { fields, extensions, ...options }: AddGraphQLInterfaceTypeOptions<SchemaTypes, Shape>) {
+proto.addGraphQLInterface = function addGraphQLInterface<Shape = unknown>(type: GraphQLInterfaceType, { fields, extensions, ...options }: AddGraphQLInterfaceTypeOptions<SchemaTypes, Shape> = {}) {
     const ref = this.interfaceRef<Shape>(options?.name ?? type.name);
     ref.implement({
         ...options,
@@ -161,7 +161,7 @@ proto.addGraphQLInterface = function addGraphQLInterface<Shape = unknown>(type: 
     });
     return ref;
 };
-proto.addGraphQLUnion = function addGraphQLUnion<Shape>(type: GraphQLUnionType, { types, extensions, ...options }: AddGraphQLUnionTypeOptions<SchemaTypes, ObjectRef<Shape>>) {
+proto.addGraphQLUnion = function addGraphQLUnion<Shape>(type: GraphQLUnionType, { types, extensions, ...options }: AddGraphQLUnionTypeOptions<SchemaTypes, ObjectRef<Shape>> = {}) {
     return this.unionType<ObjectParam<SchemaTypes>, Shape>(options?.name ?? type.name, {
         ...options,
         description: type.description ?? undefined,
@@ -171,7 +171,7 @@ proto.addGraphQLUnion = function addGraphQLUnion<Shape>(type: GraphQLUnionType, 
         ]),
     });
 };
-proto.addGraphQLEnum = function addGraphQLEnum<Shape extends number | string>(type: GraphQLEnumType, { values, extensions, ...options }: AddGraphQLEnumTypeOptions<SchemaTypes, EnumValuesWithShape<SchemaTypes, Shape>>) {
+proto.addGraphQLEnum = function addGraphQLEnum<Shape extends number | string>(type: GraphQLEnumType, { values, extensions, ...options }: AddGraphQLEnumTypeOptions<SchemaTypes, EnumValuesWithShape<SchemaTypes, Shape>> = {}) {
     const newValues = values ??
         type.getValues().reduce<EnumValueConfigMap<SchemaTypes>>((acc, value) => {
             acc[value.name] = {
@@ -190,7 +190,7 @@ proto.addGraphQLEnum = function addGraphQLEnum<Shape extends number | string>(ty
     } as never);
     return ref;
 };
-proto.addGraphQLInput = function addGraphQLInput<Shape extends {}>(type: GraphQLInputObjectType, { name = type.name, fields, extensions, ...options }: AddGraphQLInputTypeOptions<SchemaTypes, Shape>) {
+proto.addGraphQLInput = function addGraphQLInput<Shape extends {}>(type: GraphQLInputObjectType, { name = type.name, fields, extensions, ...options }: AddGraphQLInputTypeOptions<SchemaTypes, Shape> = {}) {
     const ref = this.inputRef<Shape>(name);
     return ref.implement({
         ...options,

--- a/packages/deno/packages/plugin-add-graphql/utils.ts
+++ b/packages/deno/packages/plugin-add-graphql/utils.ts
@@ -7,22 +7,22 @@ export function addTypeToSchema<Types extends SchemaTypes>(builder: PothosSchema
         return;
     }
     if (isObjectType(type)) {
-        builder.addGraphQLObject(type, {});
+        builder.addGraphQLObject(type);
     }
     else if (isInterfaceType(type)) {
-        builder.addGraphQLInterface(type, {});
+        builder.addGraphQLInterface(type);
     }
     else if (isUnionType(type)) {
-        builder.addGraphQLUnion(type, {});
+        builder.addGraphQLUnion(type);
     }
     else if (isEnumType(type)) {
-        builder.addGraphQLEnum(type, {});
+        builder.addGraphQLEnum(type);
     }
     else if (isInputObjectType(type)) {
-        builder.addGraphQLInput(type, {});
+        builder.addGraphQLInput(type);
     }
     else if (isScalarType(type)) {
-        builder.addScalarType(type.name as never, type, {});
+        builder.addScalarType(type.name as never, type);
     }
 }
 export function addReferencedType<Types extends SchemaTypes>(builder: PothosSchemaTypes.SchemaBuilder<Types>, type: GraphQLNamedType) {

--- a/packages/plugin-add-graphql/src/global-types.ts
+++ b/packages/plugin-add-graphql/src/global-types.ts
@@ -36,27 +36,27 @@ declare global {
     export interface SchemaBuilder<Types extends SchemaTypes> {
       addGraphQLObject: <Shape>(
         type: GraphQLObjectType<Shape>,
-        options: AddGraphQLObjectTypeOptions<Types, Shape>,
+        options?: AddGraphQLObjectTypeOptions<Types, Shape>,
       ) => ObjectRef<Shape>;
 
       addGraphQLInterface: <Shape>(
         type: GraphQLInterfaceType,
-        options: AddGraphQLInterfaceTypeOptions<Types, Shape>,
+        options?: AddGraphQLInterfaceTypeOptions<Types, Shape>,
       ) => InterfaceRef<Shape>;
 
       addGraphQLUnion: <Shape>(
         type: GraphQLUnionType,
-        options: AddGraphQLUnionTypeOptions<Types, ObjectRef<Shape>>,
+        options?: AddGraphQLUnionTypeOptions<Types, ObjectRef<Shape>>,
       ) => UnionRef<Shape>;
 
       addGraphQLEnum: <Shape extends number | string>(
         type: GraphQLEnumType,
-        options: AddGraphQLEnumTypeOptions<Types, EnumValuesWithShape<Types, Shape>>,
+        options?: AddGraphQLEnumTypeOptions<Types, EnumValuesWithShape<Types, Shape>>,
       ) => EnumRef<Shape>;
 
       addGraphQLInput: <Shape extends {}>(
         type: GraphQLInputObjectType,
-        options: AddGraphQLInputTypeOptions<Types, Shape>,
+        options?: AddGraphQLInputTypeOptions<Types, Shape>,
       ) => InputTypeRef<Shape>;
     }
   }

--- a/packages/plugin-add-graphql/src/schema-builder.ts
+++ b/packages/plugin-add-graphql/src/schema-builder.ts
@@ -110,7 +110,7 @@ function resolveInputType(
 
 proto.addGraphQLObject = function addGraphQLObject<Shape>(
   type: GraphQLObjectType<Shape>,
-  { fields, extensions, ...options }: AddGraphQLObjectTypeOptions<SchemaTypes, Shape>,
+  { fields, extensions, ...options }: AddGraphQLObjectTypeOptions<SchemaTypes, Shape> = {},
 ) {
   const typeOptions = {
     ...options,
@@ -178,7 +178,7 @@ proto.addGraphQLObject = function addGraphQLObject<Shape>(
 
 proto.addGraphQLInterface = function addGraphQLInterface<Shape = unknown>(
   type: GraphQLInterfaceType,
-  { fields, extensions, ...options }: AddGraphQLInterfaceTypeOptions<SchemaTypes, Shape>,
+  { fields, extensions, ...options }: AddGraphQLInterfaceTypeOptions<SchemaTypes, Shape> = {},
 ) {
   const ref = this.interfaceRef<Shape>(options?.name ?? type.name);
 
@@ -234,7 +234,7 @@ proto.addGraphQLInterface = function addGraphQLInterface<Shape = unknown>(
 
 proto.addGraphQLUnion = function addGraphQLUnion<Shape>(
   type: GraphQLUnionType,
-  { types, extensions, ...options }: AddGraphQLUnionTypeOptions<SchemaTypes, ObjectRef<Shape>>,
+  { types, extensions, ...options }: AddGraphQLUnionTypeOptions<SchemaTypes, ObjectRef<Shape>> = {},
 ) {
   return this.unionType<ObjectParam<SchemaTypes>, Shape>(options?.name ?? type.name, {
     ...options,
@@ -251,7 +251,7 @@ proto.addGraphQLEnum = function addGraphQLEnum<Shape extends number | string>(
     values,
     extensions,
     ...options
-  }: AddGraphQLEnumTypeOptions<SchemaTypes, EnumValuesWithShape<SchemaTypes, Shape>>,
+  }: AddGraphQLEnumTypeOptions<SchemaTypes, EnumValuesWithShape<SchemaTypes, Shape>> = {},
 ) {
   const newValues =
     values ??
@@ -286,7 +286,7 @@ proto.addGraphQLInput = function addGraphQLInput<Shape extends {}>(
     fields,
     extensions,
     ...options
-  }: AddGraphQLInputTypeOptions<SchemaTypes, Shape>,
+  }: AddGraphQLInputTypeOptions<SchemaTypes, Shape> = {},
 ) {
   const ref = this.inputRef<Shape>(name);
 

--- a/packages/plugin-add-graphql/src/utils.ts
+++ b/packages/plugin-add-graphql/src/utils.ts
@@ -20,17 +20,17 @@ export function addTypeToSchema<Types extends SchemaTypes>(
   }
 
   if (isObjectType(type)) {
-    builder.addGraphQLObject(type, {});
+    builder.addGraphQLObject(type);
   } else if (isInterfaceType(type)) {
-    builder.addGraphQLInterface(type, {});
+    builder.addGraphQLInterface(type);
   } else if (isUnionType(type)) {
-    builder.addGraphQLUnion(type, {});
+    builder.addGraphQLUnion(type);
   } else if (isEnumType(type)) {
-    builder.addGraphQLEnum(type, {});
+    builder.addGraphQLEnum(type);
   } else if (isInputObjectType(type)) {
-    builder.addGraphQLInput(type, {});
+    builder.addGraphQLInput(type);
   } else if (isScalarType(type)) {
-    builder.addScalarType(type.name as never, type, {});
+    builder.addScalarType(type.name as never, type);
   }
 }
 export function addReferencedType<Types extends SchemaTypes>(

--- a/packages/plugin-prisma-utils/tests/examples/codegen/schema/index.ts
+++ b/packages/plugin-prisma-utils/tests/examples/codegen/schema/index.ts
@@ -19,7 +19,7 @@ import {
   UserUpdate,
 } from './prisma-inputs';
 
-builder.addScalarType('DateTime', DateTimeResolver, {});
+builder.addScalarType('DateTime', DateTimeResolver);
 
 builder.queryType({
   fields: (t) => ({

--- a/website/pages/docs/guide/scalars.mdx
+++ b/website/pages/docs/guide/scalars.mdx
@@ -30,7 +30,7 @@ const builder = new SchemaBuilder<{
   };
 }>({});
 
-builder.addScalarType('Date', CustomDateScalar, {});
+builder.addScalarType('Date', CustomDateScalar);
 ```
 
 The Input type is the type that will be used when the type is used in an argument or `InputObject`.
@@ -88,8 +88,8 @@ const builder = new SchemaBuilder<{
   };
 }>({});
 
-builder.addScalarType('JSON', JSONResolver, {});
-builder.addScalarType('Date', DateResolver, {});
+builder.addScalarType('JSON', JSONResolver);
+builder.addScalarType('Date', DateResolver);
 ```
 
 ## Defining your own scalars


### PR DESCRIPTION
Minor improvement in existing types making options optional when registering existing types or scalars. 

In practice, it turns out that most of the types do not require overwriting any options. For example, we have a large existing scheme implemented with [graphql-js](https://github.com/graphql/graphql-js)

```typescript
export const BooleanFilterInput: GraphQLInputObjectType = new GraphQLInputObjectType({
  name: "BooleanFilter",
  fields: () => ({
    equals: { type: GraphQLBoolean },
    not: { type: BooleanFilter },
  }),
});
```

How it was before

```typescript
import { GraphQLJSON } from "graphql-scalars";
import { BooleanFilterInput } from "./schema";

builder.addScalarType("Json", GraphQLJSON, {});
builder.addGraphQLInput(BooleanFilterInput, {});
```

And this is what it will look like now

```typescript
import { GraphQLJSON } from "graphql-scalars";
import { BooleanFilterInput } from "./schema";

builder.addScalarType("Json", GraphQLJSON);
builder.addGraphQLInput(BooleanFilterInput);
```