### PR TITLE
docs: add docs for using object as const for enumType

### DIFF
--- a/packages/core/tests/enums.test.ts
+++ b/packages/core/tests/enums.test.ts
@@ -22,6 +22,15 @@ describe('ways to add enums', () => {
     King = 'K',
   }
 
+  const ChessPieceObject = {
+    Pawn: 'P',
+    Knight: 'N',
+    Bishop: 'B',
+    Rook: 'R',
+    Queen: 'Q',
+    King: 'K',
+  } as const;
+
   /**
    * Each enumType should act the same way
    */
@@ -35,6 +44,19 @@ describe('ways to add enums', () => {
       'Typescript string enum uses keys',
       (builder: SchemaBuilder<SchemaTypes>) =>
         builder.enumType(ChessPieceString, { name: 'ChessPiece' }),
+    ],
+    [
+      'Object entries',
+      (builder: SchemaBuilder<SchemaTypes>) => {
+        const e = builder.enumType('ChessPiece', {
+          // eslint-disable-next-line node/no-unsupported-features/es-builtins
+          values: Object.fromEntries(
+            Object.entries(ChessPieceObject).map(([name, value]) => [name, { value }]),
+          ),
+        });
+
+        return e;
+      },
     ],
     [
       'Array of strings uses values',
@@ -114,6 +136,40 @@ describe('ways to add enums', () => {
       Q: 'Queen',
       K: 'King',
     });
+  });
+
+  /** Validate docs for an object with `as const` (values) {@link website/pages/docs/guide/enums.mdx} */
+  it('Object as const enum (entries)', async () => {
+    const builder = new SchemaBuilder({});
+    const VehicleType = {
+      sedan: 'SEDAN',
+      suv: 'SUV',
+      truck: 'TRUCK',
+      motorcycle: 'MOTORCYCLE',
+    } as const;
+    const VehicleTypeEnum = builder.enumType('VehicleType', {
+      // eslint-disable-next-line node/no-unsupported-features/es-builtins
+      values: Object.fromEntries(
+        Object.entries(VehicleType).map(([name, value]) => [name, { value }]),
+      ),
+    });
+    builder.queryType({
+      fields: (t) => ({
+        vroom: t.field({
+          type: VehicleTypeEnum,
+          resolve: () => VehicleType.motorcycle,
+        }),
+      }),
+    });
+    const result = await execute({
+      schema: builder.toSchema(),
+      document: gql`
+        query {
+          vroom
+        }
+      `,
+    });
+    expect(result.data).toMatchObject({ vroom: 'motorcycle' });
   });
 
   /** Validate docs for an object with `as const` (values) {@link website/pages/docs/guide/enums.mdx} */

--- a/packages/core/tests/enums.test.ts
+++ b/packages/core/tests/enums.test.ts
@@ -115,4 +115,66 @@ describe('ways to add enums', () => {
       K: 'King',
     });
   });
+
+  /** Validate docs for an object with `as const` (values) {@link website/pages/docs/guide/enums.mdx} */
+  it('Object as const enum (values)', async () => {
+    const builder = new SchemaBuilder({});
+    const VehicleType = {
+      sedan: 'SEDAN',
+      suv: 'SUV',
+      truck: 'TRUCK',
+      motorcycle: 'MOTORCYCLE',
+    } as const;
+    const VehicleTypeEnum = builder.enumType('VehicleType', {
+      values: Object.values(VehicleType),
+    });
+    builder.queryType({
+      fields: (t) => ({
+        vroom: t.field({
+          type: VehicleTypeEnum,
+          resolve: () => VehicleType.motorcycle,
+        }),
+      }),
+    });
+    const result = await execute({
+      schema: builder.toSchema(),
+      document: gql`
+        query {
+          vroom
+        }
+      `,
+    });
+    expect(result.data).toMatchObject({ vroom: VehicleType.motorcycle });
+  });
+
+  /** Validate docs for an object with `as const` (keys) {@link website/pages/docs/guide/enums.mdx} */
+  it('Object as const enum (keys)', async () => {
+    const builder = new SchemaBuilder({});
+    const VehicleType = {
+      sedan: 'SEDAN',
+      suv: 'SUV',
+      truck: 'TRUCK',
+      motorcycle: 'MOTORCYCLE',
+    } as const;
+    const VehicleTypeEnum = builder.enumType('VehicleType', {
+      values: Object.keys(VehicleType) as (keyof typeof VehicleType)[],
+    });
+    builder.queryType({
+      fields: (t) => ({
+        vroom: t.field({
+          type: VehicleTypeEnum,
+          resolve: () => 'motorcycle' as const,
+        }),
+      }),
+    });
+    const result = await execute({
+      schema: builder.toSchema(),
+      document: gql`
+        query {
+          vroom
+        }
+      `,
+    });
+    expect(result.data).toMatchObject({ vroom: 'motorcycle' });
+  });
 });

--- a/website/pages/docs/guide/enums.mdx
+++ b/website/pages/docs/guide/enums.mdx
@@ -71,8 +71,8 @@ Enums can be defined a number of different ways:
    Using a values object like this enables defining additional options like a description for each
    enum value.
 
-   Using a values object allows the name of the enum value to be different from the typescript value
-   used internally in your resolvers.
+   Using a values object also allows the name of the enum value to be different from the typescript
+   value used internally in your resolvers.
 
    The keys (eg `Southern`) are used as the name of the enum value in you GraphQL schema, and the
    `value` (eg. `'giraffa'`) property is used as the value you will receive in the arguments for

--- a/website/pages/docs/guide/enums.mdx
+++ b/website/pages/docs/guide/enums.mdx
@@ -71,7 +71,42 @@ Enums can be defined a number of different ways:
    Using a values object like this enables defining additional options like a description for each
    enum value.
 
+   Using a values object allows the name of the enum value to be different from the typescript value
+   used internally in your resolvers.
+
+   The keys (eg `Southern`) are used as the name of the enum value in you GraphQL schema, and the
+   `value` (eg. `'giraffa'`) property is used as the value you will receive in the arguments for
+   your resolvers, or the value you need to return from your resolvers. This is similar to how
+   typescript enum values can be assigned string or numeric values.
+
 1. Using an object with `as const`
+
+   ```ts
+   const VehicleType = {
+     sedan: 'SEDAN',
+     suv: 'SUV',
+     truck: 'TRUCK',
+     motorcycle: 'MOTORCYCLE',
+   } as const;
+
+   const VehicleTypeEnum = builder.enumType('VehicleType', {
+     values: Object.fromEntries(
+       Object.entries(VehicleType).map(([name, value]) => [name, { value }]),
+     ),
+   });
+   ```
+
+   Modern TypeScript may prefer using objects with as const over enums to align with JavaScript
+   standards. This approach essentially mirrors the "array of strings" method. You can use
+   `Object.toEntries` and `Object.fromEntries` to turn convert to Object values form described
+   above.
+
+   For more detailed information, you can refer to the TypeScript handbook on
+   [Objects vs Enums](https://www.typescriptlang.org/docs/handbook/enums.html#objects-vs-enums).
+
+   Alternatively, using `Object.keys` or `Object.values` will allow you to produce an enum that uses
+   just the keys or values of the object for both the internal typescript and name in the GraphQL
+   schema.
 
    ```ts
    const VehicleType = {
@@ -84,30 +119,11 @@ Enums can be defined a number of different ways:
    const VehicleTypeEnum = builder.enumType('VehicleType', {
      values: Object.values(VehicleType),
    });
-   ```
-
-   Modern TypeScript may prefer using objects with as const over enums to align with JavaScript
-   standards. This approach essentially mirrors the "array of strings" method. By utilizing
-   Object.values(VehicleType), we create an array of strings from the VehicleType object
-
-   Alternatively, using `Object.keys` instead of `Object.values` is possible but requires additional
-   type handling:
-
-   ```ts
-   const VehicleType = {
-     sedan: 'SEDAN',
-     suv: 'SUV',
-     truck: 'TRUCK',
-     motorcycle: 'MOTORCYCLE',
-   } as const;
-
+   // Or
    const VehicleTypeEnum = builder.enumType('VehicleType', {
      values: Object.keys(VehicleType) as (keyof typeof VehicleType)[],
    });
    ```
-
-   For more detailed information, you can refer to the TypeScript handbook on
-   [Objects vs Enums](https://www.typescriptlang.org/docs/handbook/enums.html#objects-vs-enums).
 
 ## Using Enum Types
 

--- a/website/pages/docs/guide/enums.mdx
+++ b/website/pages/docs/guide/enums.mdx
@@ -71,6 +71,44 @@ Enums can be defined a number of different ways:
    Using a values object like this enables defining additional options like a description for each
    enum value.
 
+1. Using an object with `as const`
+
+   ```ts
+   const VehicleType = {
+     sedan: 'SEDAN',
+     suv: 'SUV',
+     truck: 'TRUCK',
+     motorcycle: 'MOTORCYCLE',
+   } as const;
+
+   const VehicleTypeEnum = builder.enumType('VehicleType', {
+     values: Object.values(VehicleType),
+   });
+   ```
+
+   Modern TypeScript may prefer using objects with as const over enums to align with JavaScript
+   standards. This approach essentially mirrors the "array of strings" method. By utilizing
+   Object.values(VehicleType), we create an array of strings from the VehicleType object
+
+   Alternatively, using `Object.keys` instead of `Object.values` is possible but requires additional
+   type handling:
+
+   ```ts
+   const VehicleType = {
+     sedan: 'SEDAN',
+     suv: 'SUV',
+     truck: 'TRUCK',
+     motorcycle: 'MOTORCYCLE',
+   } as const;
+
+   const VehicleTypeEnum = builder.enumType('VehicleType', {
+     values: Object.keys(VehicleType) as (keyof typeof VehicleType)[],
+   });
+   ```
+
+   For more detailed information, you can refer to the TypeScript handbook on
+   [Objects vs Enums](https://www.typescriptlang.org/docs/handbook/enums.html#objects-vs-enums).
+
 ## Using Enum Types
 
 Enums can be referenced either by the `Ref` that was returned by calling `builder.enumType` or by


### PR DESCRIPTION
Modern TypeScript may prefer using objects with as const over enums to align with JavaScript
standards. (or my personal preference `Object.freeze`).

Added a primary example using `Object.values` and a secondary example with `Object.keys`
with `enumType`

Added tests for both to prove documented method works

Closes #591