### PR TITLE
[plugin-prisma] Fix prisma generator not creating the ESM build on windows

### DIFF
--- a/.changeset/sharp-phones-work.md
+++ b/.changeset/sharp-phones-work.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-prisma": patch
+---
+
+[plugin-prisma] Fix prisma generator not creating the ESM build on windows

--- a/packages/plugin-prisma/src/generator.ts
+++ b/packages/plugin-prisma/src/generator.ts
@@ -51,8 +51,8 @@ generatorHandler({
       await generateOutput(
         options.dmmf,
         prismaTypes,
-        join(prismaLocation.replace('../', '../../'), 'index.js'),
-        outputLocation.replace('/generated.ts', '/esm/generated.ts'),
+        join(prismaLocation, 'index.js'),
+        join(outputLocation, '../esm/generated.ts'),
       );
     }
   },


### PR DESCRIPTION
Running `prisma generate` on windows won't generate the `esm/generated.ts` file, which results in the error

> Cannot find module '@pothos/plugin-prisma/generated' or its corresponding type declarations

when trying to import the pothos prisma types in an ESM project. The underlying problem is that the location replacements use unix-style path seperators (`/`), but `outputLocation` and `prismaLocation` use `\` on windows.
Instead of doing string replacements, I changed the code to use the `join` method from `node:path` which handles platform specific path delimiters.

Tested on windows with pnpm. Need to test wether generation still works on unix-like systems and with other package managers.