### PR TITLE
[auth] Add RequestCache.clearForContext and export RequestCache class

### DIFF
--- a/.changeset/clever-numbers-jog.md
+++ b/.changeset/clever-numbers-jog.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-scope-auth': minor
+---
+
+[auth] Allow clearing/resetting scope cache in the middle of a request

--- a/packages/plugin-scope-auth/src/index.ts
+++ b/packages/plugin-scope-auth/src/index.ts
@@ -17,6 +17,7 @@ import SchemaBuilder, {
   SchemaTypes,
 } from '@pothos/core';
 import { isTypeOfHelper } from './is-type-of-helper';
+import RequestCache from './request-cache';
 import { resolveHelper } from './resolve-helper';
 import {
   createFieldAuthScopesStep,
@@ -27,6 +28,7 @@ import {
 } from './steps';
 import { ResolveStep, TypeAuthScopes, TypeGrantScopes } from './types';
 
+export { RequestCache };
 export * from './errors';
 export * from './types';
 

--- a/packages/plugin-scope-auth/src/request-cache.ts
+++ b/packages/plugin-scope-auth/src/request-cache.ts
@@ -57,6 +57,10 @@ export default class RequestCache<Types extends SchemaTypes> {
     return requestCache.get(context)!;
   }
 
+  static clearForContext<T extends SchemaTypes>(context: T['Context']): void {
+    requestCache.delete(context);
+  }
+
   getScopes(): MaybePromise<ScopeLoaderMap<Types>> {
     if (!this.scopes) {
       const scopes = this.builder.options.authScopes(this.context);

--- a/packages/plugin-scope-auth/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-scope-auth/tests/__snapshots__/index.test.ts.snap
@@ -111,6 +111,7 @@ type Post {
 }
 
 type Query {
+  ClearCache: ObjForSyncPermFn
   IfaceBooleanFn(result: Boolean!): IfaceBooleanFn
   IfaceForAdmin: IfaceForAdmin
   ObjAdminIface: ObjAdminIface

--- a/packages/plugin-scope-auth/tests/caching.test.ts
+++ b/packages/plugin-scope-auth/tests/caching.test.ts
@@ -226,4 +226,40 @@ describe('caching', () => {
       `);
     });
   });
+
+  it('clears cache during request', async () => {
+    const query = gql`
+      query {
+        obj: ClearCache {
+          field
+        }
+      }
+    `;
+
+    const counter = new Counter();
+
+    const result = await execute({
+      schema,
+      document: query,
+      contextValue: {
+        count: counter.count,
+        user: new User({
+          'x-user-id': '1',
+          'x-permissions': 'a',
+        }),
+      },
+    });
+
+    expect(counter.counts.get('authScopes')).toBe(2);
+
+    expect(result).toMatchInlineSnapshot(`
+        {
+          "data": {
+            "obj": {
+              "field": "ok",
+            },
+          },
+        }
+      `);
+  });
 });

--- a/packages/plugin-scope-auth/tests/example/builder.ts
+++ b/packages/plugin-scope-auth/tests/example/builder.ts
@@ -42,20 +42,28 @@ const builder = new SchemaBuilder<{
     authorizeOnSubscribe: true,
     defaultStrategy: 'all',
   },
-  authScopes: async (context) => ({
-    loggedIn: !!context.user,
-    admin: !!context.user?.roles.includes('admin'),
-    syncPermission: (perm) => {
-      context.count?.('syncPermission');
+  authScopes: async (context) => {
+    context.count?.('authScopes');
 
-      return !!context.user?.permissions.includes(perm);
-    },
-    asyncPermission: async (perm) => {
-      context.count?.('asyncPermission');
+    // locally reference use to simulate data loaded in this authScopes fn that depends on incoming
+    // context data and is not modifiable from resolvers
+    const { user } = context;
 
-      return !!context.user?.permissions.includes(perm);
-    },
-  }),
+    return {
+      loggedIn: !!user,
+      admin: !!user?.roles.includes('admin'),
+      syncPermission: (perm) => {
+        context.count?.('syncPermission');
+
+        return !!user?.permissions.includes(perm);
+      },
+      asyncPermission: async (perm) => {
+        context.count?.('asyncPermission');
+
+        return !!user?.permissions.includes(perm);
+      },
+    };
+  },
 });
 
 export default builder;

--- a/packages/plugin-scope-auth/tests/example/schema/index.ts
+++ b/packages/plugin-scope-auth/tests/example/schema/index.ts
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/require-await */
 import './custom-errors';
 import './with-auth';
+import { RequestCache } from '../../../src';
 import builder from '../builder';
+import User from '../user';
 
 builder.queryField('currentId', (t) =>
   t.authField({
@@ -846,6 +848,23 @@ builder.queryType({
       nullable: true,
 
       resolve: () => ({}),
+    }),
+    ClearCache: t.field({
+      type: ObjForSyncPermFn,
+      nullable: true,
+      authScopes: {
+        syncPermission: 'a',
+      },
+      resolve: (parent, args, context) => {
+        context.user = new User({
+          'x-user-id': '1',
+          'x-permissions': 'b',
+        });
+
+        RequestCache.clearForContext(context);
+
+        return { permission: 'b' };
+      },
     }),
   }),
 });


### PR DESCRIPTION
If the scope initializer loads data that may change during a request for example due to a new user session or permission change then we need a way to clear the cache such that the scope initializer can be re-executed based on the new context state.


@hayes this contribution is based on our discord discussion: https://discord.com/channels/625400653321076807/868135255616417834/1227683491492135092

To be honest, I didn't fully grasp your message [I'd probably also update...](https://discord.com/channels/625400653321076807/868135255616417834/1227684722218631340) in terms of what you wanted to update. I will note that I ended up adding a new static method instead of a `clearCache()` instance method you were proposing as it seemed easier than to manually reset/reinitialize each of the instances internal caches. That said, I'm happy to update this PR as much as needed to get it to your liking.