### PR TITLE
fix(plugins/relay.mdx): typo

### DIFF
--- a/website/pages/docs/plugins/relay.mdx
+++ b/website/pages/docs/plugins/relay.mdx
@@ -386,12 +386,12 @@ builder.relayMutationField(
         return { success: true };
       }
 
-      return { sucess: false };
+      return { success: false };
     },
   },
   {
     outputFields: (t) => ({
-      sucess: t.boolean({
+      success: t.boolean({
         resolve: (result) => result.success,
       }),
     }),


### PR DESCRIPTION
Yeah, this is one of those PRs. but I couldn't just let `sucess` live on