### PR TITLE
Docs: Make details panel non-interactive when collapsed

### DIFF
--- a/.changeset/tall-planes-relax.md
+++ b/.changeset/tall-planes-relax.md
@@ -1,0 +1,5 @@
+---
+"@pothos/core": patch
+---
+
+make details panel non-interactive when collapsed

--- a/website/components/Layout.tsx
+++ b/website/components/Layout.tsx
@@ -72,7 +72,7 @@ export function Layout({ children, toc }: { children: ReactNode; toc: TableOfCon
             </li>
           </ul>
         </header>
-        <details className="xl:hidden absolute top-0 z-20 h-full">
+        <details className="xl:hidden absolute top-0 z-20 h-auto open:h-full">
           <summary className="p-4 text-white">
             <Bars3Icon className="h-8" />
           </summary>


### PR DESCRIPTION
Collapsed details panel covered content due to full height. 

The change makes details panel to be full height only when is open and thus improves UX of copying code snippets that would have been covered by the details panel (see gif below).

![code-select](https://github.com/hayes/pothos/assets/7008489/26a835dd-1fd1-4d21-a1e5-435c4986b626)
