### PR TITLE
Make `PrismaTypesFromClient` able to infer composite types

### DIFF
--- a/.changeset/lovely-needles-explode.md
+++ b/.changeset/lovely-needles-explode.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-prisma': patch
+---
+
+Add support for composite types when inferring PrismaTypes from client (thanks to @2coo)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -104,6 +104,8 @@ const ignores = [
   'packages/plugin-prisma/prisma',
   'packages/plugin-prisma/tests/client',
   'packages/plugin-prisma/tests/generated.ts',
+  'packages/plugin-prisma/tests/*/generated.ts',
+  'packages/plugin-prisma/tests/*/client/',
   'scripts',
   'tests/client/*',
   'website/public',

--- a/packages/plugin-prisma/package.json
+++ b/packages/plugin-prisma/package.json
@@ -27,7 +27,7 @@
     }
   },
   "scripts": {
-    "generate": "prisma generate",
+    "generate": "prisma generate && prisma generate --schema=./tests/prisma-types-from-client/schema.prisma",
     "type": "tsc --project tsconfig.type.json",
     "build": "pnpm build:clean && pnpm build:cjs && pnpm build:dts && pnpm build:esm",
     "build:clean": "git clean -dfX esm lib",

--- a/packages/plugin-prisma/package.json
+++ b/packages/plugin-prisma/package.json
@@ -87,6 +87,7 @@
     "graphql": "^16.8.1",
     "graphql-scalars": "^1.23.0",
     "graphql-tag": "^2.12.6",
-    "prisma": "^5.16.2"
+    "prisma": "^5.16.2",
+    "vitest": "^2.0.1"
   }
 }

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -827,7 +827,7 @@ export type UniqueFieldsFromWhereUnique<T> = string &
       : K
     : never);
 
-export type Simplify<T> = {
+type Simplify<T> = {
   [K in keyof T]: T[K];
 } & {};
 
@@ -842,16 +842,14 @@ type CapitalizeFirst<S extends string> = S extends `${infer F}${infer R}`
   ? `${Uppercase<F>}${R}`
   : S;
 
-type InferShapeWithComposites<Model> = Simplify<
+type InferModelShape<Model> = Simplify<
   InferField<Model, 'scalars'> & InferComposites<InferField<Model, 'composites'>>
 >;
 
 // Infer relations for a given model
 type InferRelations<Model> = {
   [K in keyof Model]: {
-    Shape: Model[K] extends Array<any>
-      ? InferShapeWithComposites<Model[K][0]>[]
-      : InferShapeWithComposites<Model[K]>;
+    Shape: Model[K] extends Array<any> ? InferModelShape<Model[K][0]>[] : InferModelShape<Model[K]>;
     Name: InferField<InferItemOfArray<Model[K]>, 'name'>;
     Nullable: IsNullable<Model[K]>;
   };
@@ -920,7 +918,7 @@ type PrismaPayload<T> = T extends {
 export type PrismaTypesFromClient<ClientType, PrismaUtils extends boolean = false> = {
   [K in ExtractModelKeys<ClientType> as CapitalizeFirst<K & string>]: PrismaModelTypes & {
     Name: CapitalizeFirst<K & string>;
-    Shape: InferShapeWithComposites<PrismaPayload<ClientType[K]>>;
+    Shape: InferModelShape<PrismaPayload<ClientType[K]>>;
     Include: InferField<PrismaArgs<ClientType[K], 'findUnique'>, 'include'>;
     Select: InferField<PrismaArgs<ClientType[K], 'findUnique'>, 'select'>;
     OrderBy: InferItemOfArray<InferField<PrismaArgs<ClientType[K], 'findFirst'>, 'orderBy'>>;

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -827,6 +827,10 @@ export type UniqueFieldsFromWhereUnique<T> = string &
       : K
     : never);
 
+export type Simplify<T> = {
+  [K in keyof T]: T[K];
+} & {};
+
 // Infer the type of a specific field from a given type
 type InferField<T, N extends string> = T extends { [K in N]?: infer U | null } ? U : never;
 
@@ -838,17 +842,17 @@ type CapitalizeFirst<S extends string> = S extends `${infer F}${infer R}`
   ? `${Uppercase<F>}${R}`
   : S;
 
-// Find the field type in an object or array of objects
-type FindField<T, F extends string> =
-  T extends Array<any> ? T[0][F] : T extends Record<string, unknown> ? T[F] : never;
+type InferShapeWithComposites<Model> = Simplify<
+  InferField<Model, 'scalars'> & InferComposites<InferField<Model, 'composites'>>
+>;
 
 // Infer relations for a given model
 type InferRelations<Model> = {
   [K in keyof Model]: {
     Shape: Model[K] extends Array<any>
-      ? FindField<Model[K], 'scalars'>[]
-      : FindField<Model[K], 'scalars'>;
-    Name: FindField<Model[K], 'name'>;
+      ? InferShapeWithComposites<Model[K][0]>[]
+      : InferShapeWithComposites<Model[K]>;
+    Name: InferField<InferItemOfArray<Model[K]>, 'name'>;
     Nullable: IsNullable<Model[K]>;
   };
 };
@@ -856,6 +860,28 @@ type InferRelations<Model> = {
 // Create a list of keys that represent array relations
 type InferRelationList<Model> = {
   [K in keyof Model as Model[K] extends Array<any> ? K : never]: K;
+};
+
+// Make a type nullable if IsNullable is true
+type MakeNullable<T, IsNullable extends boolean> = IsNullable extends true ? T | null : T;
+
+// Infer the item of an array
+type InferItemOfArray<T> = T extends Array<infer U> ? U : T;
+
+// Infers the composites of a given model
+type InferComposites<Model> = {
+  [K in keyof Model]: Model[K] extends Array<any>
+    ? Simplify<
+        InferField<Model[K][0], 'scalars'> & InferComposites<InferField<Model[K][0], 'composites'>>
+      >[]
+    : 'composites' extends keyof Exclude<Model[K], null>
+      ? MakeNullable<
+          Simplify<
+            InferField<Model[K], 'scalars'> & InferComposites<InferField<Model[K], 'composites'>>
+          >,
+          IsNullable<Model[K]>
+        >
+      : InferField<Model[K], 'scalars'>;
 };
 
 type ExtractModelKeys<T> = {
@@ -891,20 +917,20 @@ type PrismaPayload<T> = T extends {
  * @example
  * `type PrismaTypes = PrismaTypesFromClient<typeof prisma>`
  **/
-export type PrismaTypesFromClient<ClientType> = {
+export type PrismaTypesFromClient<ClientType, PrismaUtils extends boolean = false> = {
   [K in ExtractModelKeys<ClientType> as CapitalizeFirst<K & string>]: PrismaModelTypes & {
     Name: CapitalizeFirst<K & string>;
-    Shape: InferField<PrismaPayload<ClientType[K]>, 'scalars'>;
+    Shape: InferShapeWithComposites<PrismaPayload<ClientType[K]>>;
     Include: InferField<PrismaArgs<ClientType[K], 'findUnique'>, 'include'>;
     Select: InferField<PrismaArgs<ClientType[K], 'findUnique'>, 'select'>;
-    OrderBy: InferField<PrismaArgs<ClientType[K], 'findMany'>, 'orderBy'>;
+    OrderBy: InferItemOfArray<InferField<PrismaArgs<ClientType[K], 'findFirst'>, 'orderBy'>>;
     WhereUnique: InferField<PrismaArgs<ClientType[K], 'findUnique'>, 'where'>;
     Where: InferField<PrismaArgs<ClientType[K], 'findFirst'>, 'where'>;
     ListRelations: keyof InferRelationList<InferField<PrismaPayload<ClientType[K]>, 'objects'>>;
     RelationName: keyof InferField<PrismaPayload<ClientType[K]>, 'objects'>;
     Relations: InferRelations<InferField<PrismaPayload<ClientType[K]>, 'objects'>>;
-    Create: InferField<PrismaArgs<ClientType[K], 'create'>, 'data'>;
-    Update: InferField<PrismaArgs<ClientType[K], 'update'>, 'data'>;
+    Create: PrismaUtils extends true ? InferField<PrismaArgs<ClientType[K], 'create'>, 'data'> : {};
+    Update: PrismaUtils extends true ? InferField<PrismaArgs<ClientType[K], 'update'>, 'data'> : {};
   };
 };
 

--- a/packages/plugin-prisma/tests/.gitignore
+++ b/packages/plugin-prisma/tests/.gitignore
@@ -1,2 +1,2 @@
 generated.ts
-client/*
+**/client/*

--- a/packages/plugin-prisma/tests/prisma-types-from-client/index.test-d.ts
+++ b/packages/plugin-prisma/tests/prisma-types-from-client/index.test-d.ts
@@ -1,0 +1,71 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import { PrismaTypesFromClient } from '../../src';
+import { PrismaClient } from './client';
+import PrismaTypes from './generated';
+
+describe('PrismaTypesFromClient', () => {
+  const db = new PrismaClient();
+  const prismaTypes = {} as unknown as PrismaTypes;
+  const prismaTypesFromClient = {} as unknown as PrismaTypesFromClient<typeof db, false>;
+
+  it('PrismaTypes and PrismaTypesFromClient are equal', () => {
+    expectTypeOf(prismaTypes).toMatchTypeOf<typeof prismaTypesFromClient>();
+  });
+
+  it('PrismaTypesFromClient and PrismaClient are equal', () => {
+    expectTypeOf(prismaTypesFromClient).toMatchTypeOf<typeof prismaTypes>();
+  });
+
+  it('User addresses is array', () => {
+    expectTypeOf(prismaTypesFromClient.User)
+      .toHaveProperty('Shape')
+      .toHaveProperty('addresses')
+      .toBeArray();
+  });
+
+  it('user.addresses[0].country?.capital?.name', () => {
+    expectTypeOf(prismaTypesFromClient.User)
+      .toHaveProperty('Shape')
+      .toHaveProperty('addresses')
+      .items.toHaveProperty('country')
+      .toMatchTypeOf<{
+        name: string;
+        code: string;
+        capital: {
+          name: string;
+        } | null;
+      } | null>();
+  });
+
+  it('user.addresses[0].country.capital.name', () => {
+    expectTypeOf(prismaTypesFromClient.User)
+      .toHaveProperty('Shape')
+      .toHaveProperty('addresses')
+      .items.toHaveProperty('country')
+      // @ts-expect-error Country nullable
+      .toHaveProperty('capital')
+      // @ts-expect-error Capital nullable
+      .toHaveProperty('name')
+      .toBeString();
+  });
+
+  it('user.addresses has street, city, zip', () => {
+    expectTypeOf(prismaTypesFromClient.User)
+      .toHaveProperty('Shape')
+      .toHaveProperty('addresses')
+      .items.toHaveProperty('street')
+      .toBeString();
+
+    expectTypeOf(prismaTypesFromClient.User)
+      .toHaveProperty('Shape')
+      .toHaveProperty('addresses')
+      .items.toHaveProperty('city')
+      .toBeString();
+
+    expectTypeOf(prismaTypesFromClient.User)
+      .toHaveProperty('Shape')
+      .toHaveProperty('addresses')
+      .items.toHaveProperty('zip')
+      .toBeString();
+  });
+});

--- a/packages/plugin-prisma/tests/prisma-types-from-client/schema.prisma
+++ b/packages/plugin-prisma/tests/prisma-types-from-client/schema.prisma
@@ -1,0 +1,52 @@
+generator client {
+    provider = "prisma-client-js"
+    output   = "./client"
+}
+
+datasource db {
+    provider = "mongodb"
+    url      = env("DATABASE_URL")
+}
+
+generator pothos {
+    provider          = "node -r @swc-node/register ./src/generator.ts"
+    clientOutput      = "./client"
+    pluginPath        = "../../src"
+    output            = "./generated.ts"
+    generateDatamodel = true
+    documentation     = true
+    prismaUtils       = false
+}
+
+model Book {
+    id     String @id @default(auto()) @map("_id") @db.ObjectId
+    title  String
+    author User   @relation(fields: [userId], references: [id])
+    userId String @db.ObjectId
+}
+
+type Capital {
+    name String
+}
+
+type Country {
+    name String
+    code String
+
+    capital Capital?
+}
+
+type Address {
+    street  String
+    city    String
+    zip     String
+    country Country?
+}
+
+model User {
+    id   String @id @default(auto()) @map("_id") @db.ObjectId
+    name String
+    Book Book[]
+
+    addresses Address[]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -851,6 +851,9 @@ importers:
       prisma:
         specifier: ^5.16.2
         version: 5.16.2
+      vitest:
+        specifier: ^2.0.1
+        version: 2.0.1(@types/node@20.14.10)
 
   packages/plugin-prisma-utils:
     dependencies:

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
     ],
     typecheck: {
       enabled: true,
+      tsconfig: 'tsconfig.type.json',
     },
   },
 });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -11,5 +11,8 @@ export default defineConfig({
       'packages/plugin-directives/**/*',
       '**/node_modules/**',
     ],
+    typecheck: {
+      enabled: true,
+    },
   },
 });


### PR DESCRIPTION
This PR makes `PrismaTypesFromClient` utility type able to infer [composite types](https://www.prisma.io/docs/orm/prisma-client/special-fields-and-types/composite-types) (which is only available with MongoDB)