### PR TITLE
docs: update documentation about onFirstUse method

### DIFF
--- a/website/content/docs/guide/writing-plugins.mdx
+++ b/website/content/docs/guide/writing-plugins.mdx
@@ -582,8 +582,7 @@ Removing whole types from the schema needs to be done by transforming the schema
 - `builder.configStore.onTypeConfig`: Takes a type ref and a callback, and will invoke the callback
   with the config for the referenced type once available.
 
-- `builder.configStore.onFieldUse` Takes a field ref \(returned by a field builder\) and a callback
-  to invoke once the config for the field is available.
+- `fieldRef.onFirstUse` Takes a callback to invoke once the config for the field is available.
 
 - `buildCache.getTypeConfig` Gets the config for a given type after it has been passed through any
   modifications applied by plugins.


### PR DESCRIPTION
First of all, I'd like to congrats on the release of v4!

While migrates some codes, I found `builer.configStore.onFieldUse` has been removed, and instead the `onFirstUse` method on `FieldRef` has been added. so I made a little change in Writing Plugins document.