### PR TITLE
Remove @sentry/tracing from @pothos/sentry-tracing

### DIFF
--- a/.changeset/swift-yaks-shake.md
+++ b/.changeset/swift-yaks-shake.md
@@ -1,0 +1,5 @@
+---
+"@pothos/tracing-sentry": patch
+---
+
+Remove @sentry/tracing from @pothos/sentry-tracing

--- a/packages/tracing-sentry/package.json
+++ b/packages/tracing-sentry/package.json
@@ -50,7 +50,6 @@
 		"@pothos/core": "*",
 		"@pothos/plugin-tracing": "*",
 		"@sentry/node": "*",
-		"@sentry/tracing": "*",
 		"graphql": ">=16.6.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1184,10 +1184,6 @@ importers:
         version: 5.6.2(graphql@16.9.0)
 
   packages/tracing-sentry:
-    dependencies:
-      '@sentry/tracing':
-        specifier: '*'
-        version: 7.114.0
     devDependencies:
       '@pothos/core':
         specifier: workspace:*
@@ -4082,14 +4078,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@sentry-internal/tracing@7.114.0':
-    resolution: {integrity: sha512-dOuvfJN7G+3YqLlUY4HIjyWHaRP8vbOgF+OsE5w2l7ZEn1rMAaUbPntAR8AF9GBA6j2zWNoSo8e7GjbJxVofSg==}
-    engines: {node: '>=8'}
-
-  '@sentry/core@7.114.0':
-    resolution: {integrity: sha512-YnanVlmulkjgZiVZ9BfY9k6I082n+C+LbZo52MTvx3FY6RE5iyiPMpaOh67oXEZRWcYQEGm+bKruRxLVP6RlbA==}
-    engines: {node: '>=8'}
-
   '@sentry/core@8.22.0':
     resolution: {integrity: sha512-fYPnxp7UkY2tckaOtivIySxnJvlbekuxs+Qi6rkUv9JpF+TYKpt7OPNUAbgVIhS0xazAEN6iKTfmnmpUbFRLmQ==}
     engines: {node: '>=14.18'}
@@ -4108,21 +4096,9 @@ packages:
       '@opentelemetry/sdk-trace-base': ^1.25.1
       '@opentelemetry/semantic-conventions': ^1.25.1
 
-  '@sentry/tracing@7.114.0':
-    resolution: {integrity: sha512-eldEYGADReZ4jWdN5u35yxLUSTOvjsiZAYd4KBEpf+Ii65n7g/kYOKAjNl7tHbrEG1EsMW4nDPWStUMk1w+tfg==}
-    engines: {node: '>=8'}
-
-  '@sentry/types@7.114.0':
-    resolution: {integrity: sha512-tsqkkyL3eJtptmPtT0m9W/bPLkU7ILY7nvwpi1hahA5jrM7ppoU0IMaQWAgTD+U3rzFH40IdXNBFb8Gnqcva4w==}
-    engines: {node: '>=8'}
-
   '@sentry/types@8.22.0':
     resolution: {integrity: sha512-1MLK3xO+uF2oJaa+M98aLIrQsEHzV7xnVWPfE3MhejYLNQebj4rQnQKTut/xZNIF9W0Q+bRcakLarC3ce2a74g==}
     engines: {node: '>=14.18'}
-
-  '@sentry/utils@7.114.0':
-    resolution: {integrity: sha512-319N90McVpupQ6vws4+tfCy/03AdtsU0MurIE4+W5cubHME08HtiEWlfacvAxX+yuKFhvdsO4K4BB/dj54ideg==}
-    engines: {node: '>=8'}
 
   '@sentry/utils@8.22.0':
     resolution: {integrity: sha512-0ITG2+3EtyMtyc/nQG8aB9z9eIQ4L43nM/KuNgYSnM1vPl/zegbaLT0Ek/xkQB1OLIOLkEPQ6x9GWe+248/n3g==}
@@ -13585,17 +13561,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.19.2':
     optional: true
 
-  '@sentry-internal/tracing@7.114.0':
-    dependencies:
-      '@sentry/core': 7.114.0
-      '@sentry/types': 7.114.0
-      '@sentry/utils': 7.114.0
-
-  '@sentry/core@7.114.0':
-    dependencies:
-      '@sentry/types': 7.114.0
-      '@sentry/utils': 7.114.0
-
   '@sentry/core@8.22.0':
     dependencies:
       '@sentry/types': 8.22.0
@@ -13647,17 +13612,7 @@ snapshots:
       '@sentry/types': 8.22.0
       '@sentry/utils': 8.22.0
 
-  '@sentry/tracing@7.114.0':
-    dependencies:
-      '@sentry-internal/tracing': 7.114.0
-
-  '@sentry/types@7.114.0': {}
-
   '@sentry/types@8.22.0': {}
-
-  '@sentry/utils@7.114.0':
-    dependencies:
-      '@sentry/types': 7.114.0
 
   '@sentry/utils@8.22.0':
     dependencies:


### PR DESCRIPTION
The dependency on @sentry/tracing has been removed in this PR:
https://github.com/hayes/pothos/pull/1220/files#diff-ebc36762ab958f662687f4e52e77f8e99c4765d7bffea474d5936f2890f8e893L53

It seems it was mistakenly added during the v4 release:
https://github.com/hayes/pothos/pull/855/files#diff-ebc36762ab958f662687f4e52e77f8e99c4765d7bffea474d5936f2890f8e893R53

Since Sentry v8, @sentry/tracing has been removed, so it is correct to not have this dependency.


