### PR TITLE
add missing swc option

### DIFF
--- a/packages/plugin-drizzle/package.json
+++ b/packages/plugin-drizzle/package.json
@@ -18,8 +18,8 @@
     "type": "tsc --project tsconfig.type.json",
     "build": "pnpm build:clean && pnpm build:cjs && pnpm build:dts && pnpm build:esm",
     "build:clean": "git clean -dfX esm lib",
-    "build:cjs": "swc src -d lib --config-file ../../.swcrc -C module.type=commonjs",
-    "build:esm": "cp -r dts/* esm/ && swc src -d esm --config-file ../../.swcrc -C module.type=es6 && pnpm esm:extensions",
+    "build:cjs": "swc src -d lib --config-file ../../.swcrc -C module.type=commonjs --strip-leading-paths",
+    "build:esm": "cp -r dts/* esm/ && swc src -d esm --config-file ../../.swcrc -C module.type=es6 --strip-leading-paths && pnpm esm:extensions",
     "build:dts": "tsc",
     "esm:extensions": "TS_NODE_PROJECT=../../tsconfig.json node -r @swc-node/register ../../scripts/esm-transformer.ts",
     "test": "pnpm vitest --run"


### PR DESCRIPTION
hi @hayes, 

As said this week i would checkout the newly created drizzle plugin for pothos. 
However when i installed it next threw me an error that the module was missing. 
The following change should fix the output not being `lib/src/...` but just `lib/...` as described in the [package.json](https://github.com/hayes/pothos/blob/main/packages/plugin-drizzle/package.json)