### PR TITLE
chore: export connection utilities + types

### DIFF
--- a/.changeset/tricky-oranges-help.md
+++ b/.changeset/tricky-oranges-help.md
@@ -2,4 +2,4 @@
 "@pothos/plugin-relay": patch
 ---
 
-Export parseCurserArgs function + NodeType
+Export parseCurserConnectionArgs function

--- a/.changeset/tricky-oranges-help.md
+++ b/.changeset/tricky-oranges-help.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-relay": patch
+---
+
+Export parseCurserArgs function + NodeType

--- a/packages/plugin-relay/package.json
+++ b/packages/plugin-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pothos/plugin-relay",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "A Pothos plugin for adding relay style connections, nodes, and cursor based pagination to your GraphQL schema",
   "main": "./lib/index.js",
   "types": "./dts/index.d.ts",

--- a/packages/plugin-relay/package.json
+++ b/packages/plugin-relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pothos/plugin-relay",
-  "version": "4.2.1",
+  "version": "4.2.0",
   "description": "A Pothos plugin for adding relay style connections, nodes, and cursor based pagination to your GraphQL schema",
   "main": "./lib/index.js",
   "types": "./dts/index.d.ts",

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -202,7 +202,7 @@ export function resolveArrayConnection<T>(
   };
 }
 
-export function parseCursorCurserArgs(options: ResolveOffsetConnectionOptions) {
+export function parseCursorConnectionArgs(options: ResolveOffsetConnectionOptions) {
   const { before, after, first, last } = options.args;
 
   const defaultSize = options.defaultSize ?? DEFAULT_SIZE;

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -202,7 +202,7 @@ export function resolveArrayConnection<T>(
   };
 }
 
-export function parseCurserArgs(options: ResolveOffsetConnectionOptions) {
+export function parseCursorCurserArgs(options: ResolveOffsetConnectionOptions) {
   const { before, after, first, last } = options.args;
 
   const defaultSize = options.defaultSize ?? DEFAULT_SIZE;
@@ -231,7 +231,7 @@ export function parseCurserArgs(options: ResolveOffsetConnectionOptions) {
 }
 
 // biome-ignore lint/suspicious/noRedeclare: <explanation>
-export type NodeType<T> = T extends (infer N)[] | Promise<(infer N)[] | null> | null ? N : never;
+type NodeType<T> = T extends (infer N)[] | Promise<(infer N)[] | null> | null ? N : never;
 
 export async function resolveCursorConnection<
   U extends Promise<readonly unknown[] | null> | readonly unknown[] | null,
@@ -242,7 +242,7 @@ export async function resolveCursorConnection<
   RemoveMaybePromiseProps<ConnectionShape<SchemaTypes, NodeType<U>, false, false, false>>
 > {
   const { before, after, limit, inverted, expectedSize, hasPreviousPage, hasNextPage } =
-    parseCurserArgs(options);
+    parseCursorCurserArgs(options);
 
   const nodes = (await resolve({ before, after, limit, inverted })) as NodeType<U>[] | null;
 

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -202,7 +202,7 @@ export function resolveArrayConnection<T>(
   };
 }
 
-function parseCurserArgs(options: ResolveOffsetConnectionOptions) {
+export function parseCurserArgs(options: ResolveOffsetConnectionOptions) {
   const { before, after, first, last } = options.args;
 
   const defaultSize = options.defaultSize ?? DEFAULT_SIZE;
@@ -231,7 +231,7 @@ function parseCurserArgs(options: ResolveOffsetConnectionOptions) {
 }
 
 // biome-ignore lint/suspicious/noRedeclare: <explanation>
-type NodeType<T> = T extends (infer N)[] | Promise<(infer N)[] | null> | null ? N : never;
+export type NodeType<T> = T extends (infer N)[] | Promise<(infer N)[] | null> | null ? N : never;
 
 export async function resolveCursorConnection<
   U extends Promise<readonly unknown[] | null> | readonly unknown[] | null,

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -242,7 +242,7 @@ export async function resolveCursorConnection<
   RemoveMaybePromiseProps<ConnectionShape<SchemaTypes, NodeType<U>, false, false, false>>
 > {
   const { before, after, limit, inverted, expectedSize, hasPreviousPage, hasNextPage } =
-    parseCursorCurserArgs(options);
+    parseCursorConnectionArgs(options);
 
   const nodes = (await resolve({ before, after, limit, inverted })) as NodeType<U>[] | null;
 


### PR DESCRIPTION
This will be extremely helpful as I am writing relay connections for one of my projects and want to reuse this method to calculate relay cursor arguments from default connection args.

