### PR TITLE
Bind auth scope loaders to scopes object

### DIFF
--- a/.changeset/nervous-shoes-grin.md
+++ b/.changeset/nervous-shoes-grin.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-scope-auth": patch
+---
+
+Bind `authScopes` loaders to returned provider

--- a/packages/plugin-scope-auth/src/request-cache.ts
+++ b/packages/plugin-scope-auth/src/request-cache.ts
@@ -159,7 +159,7 @@ export default class RequestCache<Types extends SchemaTypes> {
     const key = this.cacheKey ? this.cacheKey(arg) : arg;
 
     if (!cache.has(key)) {
-      const loader = scopes[name];
+      let loader = scopes[name];
 
       if (typeof loader !== 'function') {
         throw new PothosValidationError(
@@ -167,6 +167,7 @@ export default class RequestCache<Types extends SchemaTypes> {
         );
       }
 
+      loader = loader.bind(scopes);
       let result: MaybePromise<boolean>;
 
       if (this.treatErrorsAsUnauthorized) {

--- a/packages/plugin-scope-auth/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-scope-auth/tests/__snapshots__/index.test.ts.snap
@@ -169,6 +169,7 @@ type Query {
   forAsyncPermission: String
   forAsyncPermissionFn(permission: String): String
   forBooleanFn(result: Boolean!): String
+  forBoundPermission: String
   forSyncPermission: String
   forSyncPermissionFn(permission: String): String
   grantedFromRoot: String

--- a/packages/plugin-scope-auth/tests/example/builder.ts
+++ b/packages/plugin-scope-auth/tests/example/builder.ts
@@ -64,7 +64,7 @@ const builder = new SchemaBuilder<{
         },
         boundPermission(this: AuthScopes) {
           return this.admin;
-        }
+        },
       };
     },
   },

--- a/packages/plugin-scope-auth/tests/example/builder.ts
+++ b/packages/plugin-scope-auth/tests/example/builder.ts
@@ -11,17 +11,20 @@ interface Context {
   count?: (name: string) => void;
 }
 
+interface AuthScopes {
+  loggedIn: boolean;
+  admin: boolean;
+  syncPermission: string;
+  asyncPermission: string;
+  boundPermission: boolean;
+}
+
 const builder = new SchemaBuilder<{
   Context: Context;
   Interfaces: {
     StringInterface: {};
   };
-  AuthScopes: {
-    loggedIn: boolean;
-    admin: boolean;
-    syncPermission: string;
-    asyncPermission: string;
-  };
+  AuthScopes: AuthScopes;
   AuthContexts: {
     loggedIn: Context & { user: User; isLoggedIn: true };
     admin: Context & { user: User; isAdmin: true };
@@ -59,6 +62,9 @@ const builder = new SchemaBuilder<{
 
           return await !!context.user?.permissions.includes(perm);
         },
+        boundPermission(this: AuthScopes) {
+          return this.admin;
+        }
       };
     },
   },

--- a/packages/plugin-scope-auth/tests/example/schema/index.ts
+++ b/packages/plugin-scope-auth/tests/example/schema/index.ts
@@ -441,6 +441,12 @@ builder.queryType({
       },
       resolve: () => 'ok',
     }),
+    forBoundPermission: t.string({
+      authScopes: {
+        boundPermission: true,
+      },
+      resolve: () => 'ok',
+    }),
     forAll: t.string({
       authScopes: {
         $all: {

--- a/packages/plugin-scope-auth/tests/field-auth-scopes.test.ts
+++ b/packages/plugin-scope-auth/tests/field-auth-scopes.test.ts
@@ -198,6 +198,62 @@ describe('queries for field authScopes with', () => {
     `);
   });
 
+  it('field scope with bound loader', async () => {
+    const query = gql`
+      query {
+        forBoundPermission
+      }
+    `;
+
+    const result = await execute({
+      schema: exampleSchema,
+      document: query,
+      contextValue: {
+        user: new User({
+          'x-user-id': '1',
+          'x-roles': 'admin',
+        }),
+      },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "forBoundPermission": "ok",
+        },
+      }
+    `);
+  });
+
+  it('field scope with bound loader (unauthorized)', async () => {
+    const query = gql`
+      query {
+        forBoundPermission
+      }
+    `;
+
+    const result = await execute({
+      schema: exampleSchema,
+      document: query,
+      contextValue: {
+        user: new User({
+          'x-user-id': '1',
+        }),
+      },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "forBoundPermission": null,
+        },
+        "errors": [
+          [GraphQLError: Not authorized to resolve Query.forBoundPermission],
+        ],
+      }
+    `);
+  });
+
   it('field with $any (sync)', async () => {
     const query = gql`
       query {


### PR DESCRIPTION
This PR binds scope loaders to the `scopes` object itself before execution. The motivation here is to allow passing in external classes that run authorization checks, such as the following pattern we tried when configuring `@pothos/plugin-scope-auth`:

```tsx
export const builder = new SchemaBuilder<{
  Context: ResolverContext;
  AuthScopes: {
    canEditObject: string;
  };
}>({
  plugins: [ScopeAuthPlugin],
  scopeAuth: { authScopes: (ctx) => ctx.auth },
});
```

where `ctx.auth` is an instance of a class that performs authorization checks e.g: 

```tsx
class AuthorizationChecker {
  private readonly user: User;
  canEditObject(objectUuid: string): Promise<boolean> {
    // Performs some checks based on objectUuid and this.user.
  }
}
```

Although this only saves us a few lines of code, it prevents issues where the return type of `authScopes` matches what the typechecker expects, but fails at runtime due to binding issues.