### PR TITLE
Export Object ref type in drizzle plugin

### DIFF
--- a/.changeset/strong-doors-swim.md
+++ b/.changeset/strong-doors-swim.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-drizzle": minor
+---
+
+Export Object ref type in drizzle plugin

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -634,3 +634,5 @@ export interface DrizzleGraphQLInputExtensions {
   tableConfig: TableRelationalConfig;
   inputType: 'insert' | 'filters' | 'orderBy' | 'update';
 }
+
+export { DrizzleObjectRef } from "./object-ref";

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -635,4 +635,4 @@ export interface DrizzleGraphQLInputExtensions {
   inputType: 'insert' | 'filters' | 'orderBy' | 'update';
 }
 
-export { DrizzleObjectRef } from "./object-ref";
+export { DrizzleObjectRef } from './object-ref';


### PR DESCRIPTION
Addresses https://github.com/hayes/pothos/issues/1370 by exporting the type in the `types` module