### PR TITLE
fix(add-graphql): pass through isOneOf setting from input objects

### DIFF
--- a/.changeset/selfish-ladybugs-study.md
+++ b/.changeset/selfish-ladybugs-study.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-add-graphql": patch
+---
+
+correctly pass through isOneOf setting from native GraphQL input objects

--- a/packages/plugin-add-graphql/src/schema-builder.ts
+++ b/packages/plugin-add-graphql/src/schema-builder.ts
@@ -301,6 +301,7 @@ proto.addGraphQLInput = function addGraphQLInput<Shape extends {}>(
     ...options,
     description: type.description ?? undefined,
     extensions: { ...type.extensions, ...extensions },
+    isOneOf: type.isOneOf,
     fields: (t) => {
       const existingFields = type.getFields();
       const newFields: Record<string, InputFieldRef<SchemaTypes, unknown> | null> =


### PR DESCRIPTION
this ensures native GraphQLInputObjectTypes with isOneOf enabled are correctly added to the pothos schema