### PR TITLE
[prisma, drizzle] skip selections on `@defer`

### DIFF
--- a/packages/plugin-drizzle/src/field-builder.ts
+++ b/packages/plugin-drizzle/src/field-builder.ts
@@ -36,6 +36,7 @@ fieldBuilderProto.drizzleField = function drizzleField({ type, resolve, ...optio
             context,
             select,
             info,
+            skipDeferredFragments: this.builder.options.drizzle.skipDeferredFragments,
             // withUsageCheck: !!this.builder.options.drizzle?.onUnusedQuery,
           }),
         parent,
@@ -77,6 +78,7 @@ fieldBuilderProto.drizzleFieldWithInput = function drizzleFieldWithInput(
             context,
             select,
             info,
+            skipDeferredFragments: this.builder.options.drizzle.skipDeferredFragments,
             // withUsageCheck: !!this.builder.options.drizzle?.onUnusedQuery,
           }),
         parent,
@@ -147,7 +149,7 @@ fieldBuilderProto.drizzleConnection = function drizzleConnection<
             defaultSize,
             args,
           },
-
+          this.builder.options.drizzle.skipDeferredFragments,
           (q) => {
             // return checkIfQueryIsUsed(
             //   this.builder,

--- a/packages/plugin-drizzle/src/model-loader.ts
+++ b/packages/plugin-drizzle/src/model-loader.ts
@@ -81,7 +81,12 @@ export class ModelLoader {
   getSelection(info: GraphQLResolveInfo) {
     const key = cacheKey(info.parentType.name, info.path);
     if (!this.queryCache.has(key)) {
-      const selection = selectionStateFromInfo(this.config, this.context, info);
+      const selection = selectionStateFromInfo(
+        this.config,
+        this.context,
+        info,
+        this.builder.options.drizzle.skipDeferredFragments,
+      );
       this.queryCache.set(key, {
         selection,
         query: selectionToQuery(selection),
@@ -99,6 +104,7 @@ export class ModelLoader {
         context: this.context,
         info,
         typeName,
+        skipDeferredFragments: this.builder.options.drizzle.skipDeferredFragments,
       });
 
       this.queryCache.set(key, {

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -49,6 +49,7 @@ export type DrizzleClient = {
 export type DrizzlePluginOptions<Types extends SchemaTypes> = {
   maxConnectionSize?: number;
   defaultConnectionSize?: number;
+  skipDeferredFragments?: boolean;
 } & (
   | {
       client: DrizzleClient;

--- a/packages/plugin-drizzle/src/utils/cursors.ts
+++ b/packages/plugin-drizzle/src/utils/cursors.ts
@@ -481,6 +481,7 @@ export async function resolveDrizzleCursorConnection<T extends {}>(
   typeName: string,
   config: PothosDrizzleSchemaConfig,
   options: Omit<DrizzleCursorConnectionQueryOptions, 'orderBy'>,
+  skipDeferredFragments: boolean | undefined,
   resolve: (
     queryFn: (query: QueryForDrizzleConnection<SchemaTypes, TableRelationalConfig>) => SelectionMap,
   ) => MaybePromise<readonly T[]>,
@@ -514,6 +515,7 @@ export async function resolveDrizzleCursorConnection<T extends {}>(
       paths: [['nodes'], ['edges', 'node']],
       typeName,
       config,
+      skipDeferredFragments,
       // withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
     });
 

--- a/packages/plugin-prisma/src/field-builder.ts
+++ b/packages/plugin-prisma/src/field-builder.ts
@@ -46,6 +46,7 @@ fieldBuilderProto.prismaField = function prismaField({ type, resolve, ...options
         context,
         info,
         withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
+        skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
       });
 
       return checkIfQueryIsUsed(
@@ -84,6 +85,7 @@ fieldBuilderProto.prismaFieldWithInput = function prismaFieldWithInput(
         context,
         info,
         withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
+        skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
       });
 
       return checkIfQueryIsUsed(
@@ -153,6 +155,7 @@ fieldBuilderProto.prismaConnection = function prismaConnection<
           paths: [['nodes'], ['edges', 'node']],
           typeName,
           withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
+          skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
         });
 
         const returnType = getNamedType(info.returnType);

--- a/packages/plugin-prisma/src/global-types.ts
+++ b/packages/plugin-prisma/src/global-types.ts
@@ -56,6 +56,7 @@ declare global {
             onUnusedQuery?: 'error' | 'warn' | ((info: GraphQLResolveInfo) => void) | null;
             maxConnectionSize?: number;
             defaultConnectionSize?: number;
+            skipDeferredFragments?: boolean;
           }
         | {
             filterConnectionTotalCount?: boolean;
@@ -69,6 +70,7 @@ declare global {
             onUnusedQuery?: 'error' | 'warn' | ((info: GraphQLResolveInfo) => void) | null;
             maxConnectionSize?: number;
             defaultConnectionSize?: number;
+            skipDeferredFragments?: boolean;
           };
     }
 

--- a/packages/plugin-prisma/src/index.ts
+++ b/packages/plugin-prisma/src/index.ts
@@ -162,7 +162,17 @@ export class PothosPrismaPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
       }
 
       if (fallback) {
-        return fallback(queryFromInfo({ context, info }), parent, args, context, info);
+        return fallback(
+          queryFromInfo({
+            context,
+            info,
+            skipDeferredFragments: this.builder.options.prisma.skipDeferredFragments,
+          }),
+          parent,
+          args,
+          context,
+          info,
+        );
       }
 
       return loaderCache(context)

--- a/packages/plugin-prisma/src/model-loader.ts
+++ b/packages/plugin-prisma/src/model-loader.ts
@@ -236,7 +236,11 @@ export class ModelLoader {
   getSelection(info: GraphQLResolveInfo) {
     const key = cacheKey(info.parentType.name, info.path);
     if (!this.queryCache.has(key)) {
-      const selection = selectionStateFromInfo(this.context, info);
+      const selection = selectionStateFromInfo(
+        this.context,
+        info,
+        this.builder.options.prisma.skipDeferredFragments,
+      );
       this.queryCache.set(key, {
         selection,
         query: selectionToQuery(selection),

--- a/packages/plugin-prisma/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-prisma/tests/__snapshots__/index.test.ts.snap
@@ -1,7 +1,18 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`prisma > generates schema 1`] = `
-"type BaseError implements Error {
+""""
+Directs the executor to defer this fragment when the \`if\` argument is true or undefined.
+"""
+directive @defer(
+  """Deferred when true or undefined."""
+  if: Boolean! = true
+
+  """Unique name"""
+  label: String
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+type BaseError implements Error {
   message: String
 }
 

--- a/packages/plugin-prisma/tests/example/schema/index.ts
+++ b/packages/plugin-prisma/tests/example/schema/index.ts
@@ -7,6 +7,13 @@ import { prismaConnectionHelpers } from '../../../src';
 import { queryFromInfo } from '../../../src/util/map-query';
 import type { Post } from '../../client';
 import builder, { prisma } from '../builder';
+import {
+  DirectiveLocation,
+  GraphQLBoolean,
+  GraphQLDirective,
+  GraphQLNonNull,
+  GraphQLString,
+} from 'graphql';
 
 const ErrorInterface = builder.interfaceRef<Error>('Error').implement({
   fields: (t) => ({
@@ -1322,4 +1329,24 @@ builder.queryField('namedConnection', (t) =>
   }),
 );
 
-export default builder.toSchema();
+export default builder.toSchema({
+  directives: [
+    new GraphQLDirective({
+      name: 'defer',
+      description:
+        'Directs the executor to defer this fragment when the `if` argument is true or undefined.',
+      locations: [DirectiveLocation.FRAGMENT_SPREAD, DirectiveLocation.INLINE_FRAGMENT],
+      args: {
+        if: {
+          type: new GraphQLNonNull(GraphQLBoolean),
+          description: 'Deferred when true or undefined.',
+          defaultValue: true,
+        },
+        label: {
+          type: GraphQLString,
+          description: 'Unique name',
+        },
+      },
+    }),
+  ],
+});

--- a/packages/plugin-prisma/tests/index.test.ts
+++ b/packages/plugin-prisma/tests/index.test.ts
@@ -65,7 +65,7 @@ describe('prisma', () => {
     `);
   });
 
-  it('skips fields based on @skip and @include directives', async () => {
+  it('skips fields based on @skip, @include, and @defer directives', async () => {
     const query = gql`
       query {
         me {
@@ -75,6 +75,12 @@ describe('prisma', () => {
           }
           posts(limit: 1) @include(if: false) {
             id
+          }
+          ...@defer {
+            postCount
+          }
+          ...@defer(if: true) {
+          	publishedCount
           }
         }
       }
@@ -91,6 +97,8 @@ describe('prisma', () => {
         "data": {
           "me": {
             "id": "VXNlcjox",
+            "postCount": 250,
+            "publishedCount": 149,
           },
         },
       }
@@ -109,11 +117,51 @@ describe('prisma', () => {
           "model": "User",
           "runInTransaction": false,
         },
+        {
+          "action": "findUniqueOrThrow",
+          "args": {
+            "include": {
+              "_count": {
+                "select": {
+                  "posts": true,
+                },
+              },
+            },
+            "where": {
+              "id": 1,
+            },
+          },
+          "dataPath": [],
+          "model": "User",
+          "runInTransaction": false,
+        },
+        {
+          "action": "findUniqueOrThrow",
+          "args": {
+            "include": {
+              "_count": {
+                "select": {
+                  "posts": {
+                    "where": {
+                      "published": true,
+                    },
+                  },
+                },
+              },
+            },
+            "where": {
+              "id": 1,
+            },
+          },
+          "dataPath": [],
+          "model": "User",
+          "runInTransaction": false,
+        },
       ]
     `);
   });
 
-  it('includes fields based on @skip and @include directives', async () => {
+  it('includes fields based on @skip, @include, and @defer directives', async () => {
     const query = gql`
       query {
         me {
@@ -123,6 +171,9 @@ describe('prisma', () => {
           }
           posts(limit: 1) @include(if: true) {
             id
+          }
+          ...@defer(if: false) {
+          	postCount
           }
         }
       }
@@ -139,6 +190,7 @@ describe('prisma', () => {
         "data": {
           "me": {
             "id": "VXNlcjox",
+            "postCount": 250,
             "posts": [
               {
                 "id": "250",
@@ -158,6 +210,11 @@ describe('prisma', () => {
           "action": "findUnique",
           "args": {
             "include": {
+              "_count": {
+                "select": {
+                  "posts": true,
+                },
+              },
               "posts": {
                 "include": {
                   "comments": {


### PR DESCRIPTION
This PR makes the Prisma and Drizzle plugins skip fetching ahead if `@defer`red fragment is found, which matches the expected behavior of `@defer`.
It's also configurable with the `skipDeferredFragments` option of each plugin.