### PR TITLE
Allow entry connections with drizzleConnectionHelper

### DIFF
--- a/.changeset/beige-socks-fetch.md
+++ b/.changeset/beige-socks-fetch.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-drizzle": minor
+---
+
+Allow implementing entry connections with drizzleConnectionHelper

--- a/packages/plugin-drizzle/src/connection-helpers.ts
+++ b/packages/plugin-drizzle/src/connection-helpers.ts
@@ -6,6 +6,7 @@ import type {
   RelationsFilter,
   TableRelationalConfig,
 } from 'drizzle-orm';
+import type { GraphQLResolveInfo } from 'graphql';
 import type { DrizzleRef } from './interface-ref';
 import type { QueryForDrizzleConnection } from './types';
 import { getSchemaConfig } from './utils/config';
@@ -14,6 +15,7 @@ import {
   getCursorFormatter,
   wrapConnectionResult,
 } from './utils/cursors';
+import { queryFromInfo } from './utils/map-query';
 import { getRefFromModel } from './utils/refs';
 import { createState, mergeSelection, selectionToQuery } from './utils/selections';
 
@@ -142,11 +144,24 @@ export function drizzleConnectionHelpers<
     };
   };
 
+  type NestedSelection = <T extends true | {}>(selection?: T, path?: string[]) => T;
+
   function getQuery(
     args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
     ctx: Types['Context'],
-    nestedSelection: <T extends true | {}>(selection?: T, path?: string[]) => T,
+    nestedSelectionOrInfo: NestedSelection | GraphQLResolveInfo,
   ) {
+    const nestedSelection: NestedSelection =
+      typeof nestedSelectionOrInfo === 'function'
+        ? nestedSelectionOrInfo
+        : (select, path) =>
+            queryFromInfo({
+              info: nestedSelectionOrInfo,
+              context: ctx,
+              config,
+              select,
+              path,
+            });
     const nestedSelect: Record<string, unknown> | true = select
       ? select((sel) => nestedSelection(sel, ['edges', 'node']), args, ctx)
       : nestedSelection(true, ['edges', 'node']);

--- a/packages/plugin-drizzle/src/connection-helpers.ts
+++ b/packages/plugin-drizzle/src/connection-helpers.ts
@@ -1,5 +1,11 @@
 import type { InputFieldMap, InputShapeFromFields, SchemaTypes } from '@pothos/core';
-import type { BuildQueryResult, DBQueryConfig, Table, TableRelationalConfig } from 'drizzle-orm';
+import type {
+  BuildQueryResult,
+  DBQueryConfig,
+  ExtractTablesWithRelations,
+  RelationsFilter,
+  TableRelationalConfig,
+} from 'drizzle-orm';
 import type { DrizzleRef } from './interface-ref';
 import type { QueryForDrizzleConnection } from './types';
 import { getSchemaConfig } from './utils/config';
@@ -167,6 +173,7 @@ export function drizzleConnectionHelpers<
       orderBy: {
         [K in keyof Table['columns']]?: 'asc' | 'desc' | undefined;
       };
+      where: RelationsFilter<Table, ExtractTablesWithRelations<Types['DrizzleRelations']>>;
     };
   }
 

--- a/packages/plugin-drizzle/tests/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-drizzle/tests/__snapshots__/index.test.ts.snap
@@ -121,6 +121,7 @@ type Query {
   postWithErrors(id: ID!): QueryPostWithErrorsResult
   posts(after: String, before: String, category: String, first: Int, invert: Boolean, last: Int, sortByCategory: Boolean): QueryPostsConnection
   user(id: ID!): User
+  userRolesConnection(after: String, before: String, first: Int, last: Int, userId: Int!): QueryUserRolesConnection
   userWithInput(input: QueryUserWithInputInput!): User
   users: [User!]
   usersConnection(after: String, before: String, first: Int, last: Int): QueryUsersConnection
@@ -140,6 +141,16 @@ type QueryPostsConnection {
 type QueryPostsConnectionEdge {
   cursor: String!
   node: Post
+}
+
+type QueryUserRolesConnection {
+  edges: [QueryUserRolesConnectionEdge]
+  pageInfo: PageInfo!
+}
+
+type QueryUserRolesConnectionEdge {
+  cursor: String!
+  node: Role
 }
 
 input QueryUserWithInputInput {

--- a/packages/plugin-drizzle/tests/connection-helpers.test.ts
+++ b/packages/plugin-drizzle/tests/connection-helpers.test.ts
@@ -421,4 +421,76 @@ describe('connection helpers', () => {
       }
     `);
   });
+
+  it('entry connection', async () => {
+    const context = await createContext({ userId: '1' });
+    clearDrizzleLogs();
+    const result = await execute({
+      schema,
+      document: gql`
+              query {
+                  userRolesConnection(userId: 1) {
+                      pageInfo {
+                          startCursor
+                          endCursor
+                          hasPreviousPage
+                          hasNextPage
+                      }
+                      edges {
+                          cursor
+                          node {
+                              id
+                              name
+                          }
+                      }
+                  }
+              }
+          `,
+      contextValue: context,
+    });
+
+    expect(drizzleLogs).toMatchInlineSnapshot(`
+      [
+        "Query: select "d0"."role_id" as "roleId", "d0"."user_id" as "userId", (select json_object('id', "id", 'name', "name") as "r" from (select "d1"."id" as "id", "d1"."name" as "name" from "roles" as "d1" where "d0"."role_id" = "d1"."id" limit ?) as "t") as "role" from "user_roles" as "d0" where "d0"."user_id" = ? order by "d0"."role_id" asc limit ? -- params: [1, 1, 21]",
+      ]
+    `);
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "userRolesConnection": {
+            "edges": [
+              {
+                "cursor": "REM6Tjox",
+                "node": {
+                  "id": "1",
+                  "name": "admin",
+                },
+              },
+              {
+                "cursor": "REM6Tjoy",
+                "node": {
+                  "id": "2",
+                  "name": "author",
+                },
+              },
+              {
+                "cursor": "REM6Tjoz",
+                "node": {
+                  "id": "3",
+                  "name": "user",
+                },
+              },
+            ],
+            "pageInfo": {
+              "endCursor": "REM6Tjoz",
+              "hasNextPage": false,
+              "hasPreviousPage": false,
+              "startCursor": "REM6Tjox",
+            },
+          },
+        },
+      }
+    `);
+  });
 });

--- a/packages/plugin-drizzle/tests/example/schema.graphql
+++ b/packages/plugin-drizzle/tests/example/schema.graphql
@@ -81,6 +81,7 @@ type Query {
   postWithErrors(id: ID!): QueryPostWithErrorsResult
   posts(after: String, before: String, category: String, first: Int, invert: Boolean, last: Int, sortByCategory: Boolean): QueryPostsConnection
   user(id: ID!): User
+  userRolesConnection(after: String, before: String, first: Int, last: Int, userId: Int!): QueryUserRolesConnection
   userWithInput(input: QueryUserWithInputInput!): User
   users: [User!]
   usersConnection(after: String, before: String, first: Int, last: Int): QueryUsersConnection
@@ -100,6 +101,16 @@ type QueryPostsConnection {
 type QueryPostsConnectionEdge {
   cursor: String!
   node: Post
+}
+
+type QueryUserRolesConnection {
+  edges: [QueryUserRolesConnectionEdge]
+  pageInfo: PageInfo!
+}
+
+type QueryUserRolesConnectionEdge {
+  cursor: String!
+  node: Role
 }
 
 input QueryUserWithInputInput {


### PR DESCRIPTION
This PR enables using `drizzleConnectionHelper` to create advanced Drizzle connections outside Drizzle objects.