### PR TITLE
Add Claude Code slash commands for plugin development

### DIFF
--- a/.claude/commands/add-field-method.md
+++ b/.claude/commands/add-field-method.md
@@ -1,0 +1,106 @@
+---
+argument-hint: [method-name] [description]
+description: Add a new field builder method to RootFieldBuilder
+---
+
+Add a new field builder method called `$1` to the RootFieldBuilder.
+
+**Purpose:** $ARGUMENTS (starting from $2)
+
+This will allow users to call `t.$1()` when defining fields on Query, Mutation, Subscription, Object, and Interface types.
+
+## Implementation Steps
+
+I'll implement this by:
+
+1. **Analyzing the requirements**
+   - Understand what the method should do based on the description
+   - Determine which implementation pattern to use
+   - Identify what options the method needs
+
+2. **Adding the method signature to `global-types.ts`**
+   - Extend the `RootFieldBuilder` interface in the `PothosSchemaTypes` namespace
+   - Define the method with proper generic types
+   - Include all necessary options based on the functionality
+
+3. **Creating the options type in `types.ts`**
+   - Define an options interface that extends `FieldOptionsFromKind`
+   - Add any custom options your method needs
+
+4. **Implementing the method in `field-builder.ts`**
+   - Get the prototype: `RootFieldBuilder.prototype as PothosSchemaTypes.RootFieldBuilder<SchemaTypes, unknown, FieldKind>`
+   - Implement the method function (NOT arrow function)
+   - Typically calls `this.field()` with modified options or custom resolver
+
+5. **Importing the implementation**
+   - Add `import './field-builder';` to `index.ts` if not already present
+
+## Implementation Patterns
+
+**Pattern 1: Simple Wrapper** (like `fieldWithInput`)
+- Used when: Modifying field options or creating related types
+- Calls `this.field()` with modified options
+- May use `fieldRef.onFirstUse()` to create types dynamically
+
+**Pattern 2: Custom Resolver** (like `globalID`, `node`, `loadable`)
+- Used when: Transforming resolve behavior or return values
+- Wraps or replaces the resolve function
+- Handles async operations, data loading, or transformations
+
+**Pattern 3: Dynamic Type Creation** (like `connection`)
+- Used when: Creating complex types based on field configuration
+- Creates type refs and implements them on first use
+- Uses `fieldRef.onFirstUse()` to access field config
+
+## Reference Examples
+
+- Simple wrapper: `/packages/plugin-with-input/src/schema-builder.ts` - `fieldWithInput`
+- Custom resolver: `/packages/plugin-relay/src/field-builder.ts` - `globalID`, `node`
+- Advanced dataloading: `/packages/plugin-dataloader/src/field-builder.ts` - `loadable`, `loadableList`
+- Dynamic types: `/packages/plugin-relay/src/field-builder.ts` - `connection`
+
+## Key Implementation Details
+
+1. **Type signature structure:**
+```typescript
+export interface RootFieldBuilder<
+  Types extends SchemaTypes,
+  ParentShape,
+  Kind extends FieldKind = FieldKind,
+> {
+  $1: <
+    Args extends InputFieldMap,
+    Type extends TypeParam<Types>,
+    Nullable extends FieldNullability<Type> = Types['DefaultFieldNullability'],
+    ResolveShape,
+    ResolveReturnShape,
+  >(
+    options: ${1}Options<...>,
+  ) => FieldRef<Types, ShapeFromTypeParam<Types, Type, Nullable>, Kind>;
+}
+```
+
+2. **Implementation structure:**
+```typescript
+import { RootFieldBuilder, type FieldKind, type SchemaTypes } from '@pothos/core';
+
+const fieldBuilderProto = RootFieldBuilder.prototype as PothosSchemaTypes.RootFieldBuilder<
+  SchemaTypes,
+  unknown,
+  FieldKind
+>;
+
+fieldBuilderProto.$1 = function $1({ /* destructure options */, ...options }) {
+  // Implementation based on the pattern
+  return this.field({
+    ...options,
+    // modifications
+  } as never);
+};
+```
+
+3. **Don't use arrow functions** - use `function` keyword so `this` binds correctly
+4. **Use `as never`** when calling `this.field()` (only when absalutely necissary) to satisfy complex generic constraints
+5. **Import all needed types** from `@pothos/core`
+
+Now I'll analyze the requirements and implement the `$1` method accordingly.

--- a/.claude/commands/create-test.md
+++ b/.claude/commands/create-test.md
@@ -1,0 +1,81 @@
+---
+argument-hint: [test-name] [description]
+description: Create a new test file with comprehensive test cases
+---
+
+Create a new test file called `$1.test.ts` in the appropriate test directory.
+
+**Test Purpose:** $ARGUMENTS (starting from $2)
+
+## Test File Structure
+
+I'll create a test file following the Pothos testing patterns with emphasis on inline snapshot testing:
+
+1. **Import the schema and test utilities**
+   - Import or create the schema to test
+   - Import `graphql` for executing queries
+   - Import `expect` from vitest
+
+2. **Organize tests with describe blocks**
+   - Group related tests together
+   - Use descriptive test names that explain what is being tested
+
+3. **Use inline snapshot testing as primary assertion**
+   - Use `toMatchInlineSnapshot()` instead of `toMatchSnapshot()`
+   - Inline snapshots keep test data in the test file itself
+   - Snapshot the full result EARLY (right after execution)
+   - This makes test failures easy to understand by showing the complete response
+   - Snapshots include all data, so additional assertions are usually unnecessary
+   - Only add specific assertions for critical runtime validation not visible in snapshots
+
+4. **Write comprehensive test cases**
+   - Test success cases
+   - Test error cases
+   - Test edge cases
+   - Test all union type members
+
+## Test Pattern
+
+**Standard test structure:**
+```typescript
+import { execute, parse } from 'graphql';
+import { describe, expect, it } from 'vitest';
+import { builder } from './example/builder';
+import { createSchema } from './example/schema';
+
+const schema = createSchema(builder);
+
+describe('feature name', () => {
+  it('describes what is being tested', async () => {
+    const result = await execute({
+      schema,
+      document: parse(`
+        query TestQuery($arg: String!) {
+          field(arg: $arg) {
+            __typename
+            ... on SuccessType {
+              data
+            }
+            ... on ErrorType {
+              message
+            }
+          }
+        }
+      `),
+      variableValues: { arg: 'value' },
+    });
+
+    expect(result).toMatchInlineSnapshot();
+  });
+});
+```
+
+**Key principles:**
+- Use inline snapshots (not separate snapshot files)
+- Snapshot first (often the only assertion needed)
+- Include `__typename` in queries to verify union resolution
+- Use descriptive test names
+- Test each path through the resolver
+- Keep tests simple - snapshots show everything
+
+Now I'll create the test file with comprehensive inline snapshot-first test cases.


### PR DESCRIPTION
Add two helper commands for developing Pothos plugins:
- /add-field-method: Template for adding new field builder methods
- /create-test: Template for creating comprehensive test files

These commands provide structured guidance for common plugin development tasks.