### PR TITLE
Enable aggregate functions in Drizzle

### DIFF
--- a/packages/plugin-drizzle/src/utils/selections.ts
+++ b/packages/plugin-drizzle/src/utils/selections.ts
@@ -15,6 +15,7 @@ export interface SelectionState {
   parent?: SelectionState;
   depth: number;
   skipDeferredFragments: boolean;
+  aggregation?: boolean;
 }
 
 export type SelectionMap = DBQueryConfig<'one'>;
@@ -188,9 +189,11 @@ export function selectionToQuery(
       query.columns![key] = true;
     }
 
-    for (const column of config.getPrimaryKey(state.table.name)) {
-      const tsName = config.columnToTsName(column);
-      query.columns![tsName] = true;
+    if (!state.aggregation) {
+      for (const column of config.getPrimaryKey(state.table.name)) {
+        const tsName = config.columnToTsName(column);
+        query.columns![tsName] = true;
+      }
     }
   }
 


### PR DESCRIPTION
pothosDrizzleSelect allows empty columns and enables the use of aggregate functions such as count.

https://github.com/node-libraries/pothos-drizzle-generator/blob/test/src/pothos-drizzle-generator-plugin/PothosDrizzleGeneratorPlugin.ts#L273

```ts
          const relayCount = Object.entries(relations).map(
            ([relayName, relay]) => {
              const inputWhere = this.getInputWhere(relay.targetTableName);
              return [
                `${relayName}Count`,
                t.field({
                  type: "Int",
                  nullable: false,
                  args: {
                    offset: t.arg({ type: "Int" }),
                    limit: t.arg({ type: "Int" }),
                    where: t.arg({ type: inputWhere }),
                  },
                  extensions: {
                    pothosDrizzleSelect: (args: any) => ({
                      with: {
                        [relayName]: {
                          aggregation: true, // Specifying Aggregation Functions
                          columns: {}, //Clear the field
                          extras: {
                            _count: () => sql`count(*)`,
                          },
                          ...args,
                        },
                      },
                    }),
                  },
                  resolve: (parent: any) => {
                    const target = parent[relayName];
                    return Array.isArray(target)
                      ? target[0]["_count"]
                      : target["_count"];
                  },
                }),
              ];
            }
          );
```