### PR TITLE
add add-graphql option includeSchemaDirecties

### DIFF
--- a/packages/plugin-add-graphql/package.json
+++ b/packages/plugin-add-graphql/package.json
@@ -48,6 +48,9 @@
     "@pothos/core": "*",
     "graphql": "^16.10.0"
   },
+  "dependencies": {
+    "@graphql-tools/utils": "^10.11.0"
+  },
   "devDependencies": {
     "@pothos/core": "workspace:*",
     "@pothos/test-utils": "workspace:*",

--- a/packages/plugin-add-graphql/src/global-types.ts
+++ b/packages/plugin-add-graphql/src/global-types.ts
@@ -28,6 +28,7 @@ declare global {
       add?: {
         schema?: GraphQLSchema;
         types?: GraphQLNamedType[] | Record<string, GraphQLNamedType>;
+        includeSchemaDirectives?: boolean;
       };
     }
 

--- a/packages/plugin-add-graphql/src/index.ts
+++ b/packages/plugin-add-graphql/src/index.ts
@@ -1,5 +1,6 @@
 import './global-types';
 import './schema-builder';
+import { addTypes } from '@graphql-tools/utils';
 import SchemaBuilder, { BasePlugin, type SchemaTypes } from '@pothos/core';
 import { GraphQLSchema } from 'graphql';
 import { addTypeToSchema } from './utils';
@@ -23,6 +24,16 @@ export class PothosAddGraphQLPlugin<Types extends SchemaTypes> extends BasePlugi
     for (const type of allTypes) {
       addTypeToSchema(this.builder, type);
     }
+  }
+
+  override afterBuild(schema: GraphQLSchema): GraphQLSchema {
+    const { schema: addedSchema, includeSchemaDirectives = false } = this.builder.options.add ?? {};
+
+    if (includeSchemaDirectives && addedSchema) {
+      return addTypes(schema, [...addedSchema.getDirectives()]);
+    }
+
+    return schema;
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,7 +303,7 @@ importers:
         version: 5.17.1(graphql@16.12.0)
       next:
         specifier: 16.0.10
-        version: 16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -641,6 +641,9 @@ importers:
 
   packages/plugin-add-graphql:
     dependencies:
+      '@graphql-tools/utils':
+        specifier: ^10.11.0
+        version: 10.11.0(graphql@16.12.0)
       graphql:
         specifier: ^16.10.0
         version: 16.12.0
@@ -1388,7 +1391,7 @@ importers:
         version: 0.561.0(react@19.2.3)
       next:
         specifier: ^16.0.10
-        version: 16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -13162,7 +13165,7 @@ snapshots:
       '@graphql-tools/utils': 8.9.0(graphql@16.12.0)
       dataloader: 2.1.0
       graphql: 16.12.0
-      tslib: 2.4.1
+      tslib: 2.8.1
       value-or-promise: 1.0.11
 
   '@graphql-tools/batch-execute@9.0.19(graphql@16.12.0)':
@@ -13223,7 +13226,7 @@ snapshots:
     dependencies:
       graphql: 16.12.0
       lodash.sortby: 4.7.0
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@graphql-tools/executor-common@0.0.4(graphql@16.12.0)':
     dependencies:
@@ -13420,14 +13423,14 @@ snapshots:
   '@graphql-tools/optimize@2.0.0(graphql@16.12.0)':
     dependencies:
       graphql: 16.12.0
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@graphql-tools/relay-operation-optimizer@7.0.26(encoding@0.1.13)(graphql@16.12.0)':
     dependencies:
       '@ardatan/relay-compiler': 12.0.3(encoding@0.1.13)(graphql@16.12.0)
       '@graphql-tools/utils': 10.11.0(graphql@16.12.0)
       graphql: 16.12.0
-      tslib: 2.6.3
+      tslib: 2.8.1
     transitivePeerDependencies:
       - encoding
 
@@ -17171,7 +17174,7 @@ snapshots:
   camel-case@4.1.2:
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.2.0
+      tslib: 2.8.1
 
   caniuse-lite@1.0.30001759: {}
 
@@ -18624,7 +18627,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
       lucide-react: 0.561.0(react@19.2.3)
-      next: 16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       zod: 4.1.13
@@ -18662,7 +18665,7 @@ snapshots:
       vfile: 6.0.3
       zod: 4.1.13
     optionalDependencies:
-      next: 16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       vite: 7.2.6(@types/node@25.0.1)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -18692,7 +18695,7 @@ snapshots:
       tailwind-merge: 3.4.0
     optionalDependencies:
       '@types/react': 19.2.7
-      next: 16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tailwindcss: 4.1.18
     transitivePeerDependencies:
       - '@mixedbread/sdk'
@@ -20798,7 +20801,7 @@ snapshots:
       - typescript
       - webpack
 
-  next@16.0.10(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       '@next/env': 16.0.10
       '@swc/helpers': 0.5.15
@@ -20806,7 +20809,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.0.10
       '@next/swc-darwin-x64': 16.0.10
@@ -21203,7 +21206,7 @@ snapshots:
   pascal-case@3.1.2:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.2.0
+      tslib: 2.8.1
 
   path-browserify@0.0.1: {}
 
@@ -22553,10 +22556,12 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.28.5
 
-  styled-jsx@5.1.6(react@19.2.3):
+  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
+    optionalDependencies:
+      '@babel/core': 7.28.5
 
   stylis-rule-sheet@0.0.10(stylis@3.5.4):
     dependencies:


### PR DESCRIPTION
While I'm doing incremental migration to Pothos using the add-graphql plugin,

```ts
import SchemaBuilder from '@pothos/core';
import AddGraphQLPlugin from '@pothos/plugin-add-graphql';

import { filterSchema } from '@graphql-tools/utils';
import { schema as orignalSchema } from '#schema.ts';

const remainingSchema = filterSchema(originalSchema, { ... });

const builder = new SchemaBuilder({
  plugins: [AddGraphQLPlugin],
  add: {
    schema: remainingSchema,
  },
});
```

I noticed that directives from `originalSchema` are omitted. Even with `printSchemaWithDirectives()` from `@graphql-tools/utils`, it doesn't generate directives in the SDL.

This was important to me because I needed to verify that the new schema provided the same functionality (including the printer) as the existing schema.

I made this patch to fix it, but I'm not sure it can be merged upstream.