### PR TITLE
fix(plugin-drizzle): restore query/relation type inference after beta changes

### DIFF
--- a/.changeset/drizzle-relation-type-fix.md
+++ b/.changeset/drizzle-relation-type-fix.md
@@ -1,0 +1,9 @@
+---
+"@pothos/plugin-drizzle": patch
+---
+
+Fix broken types in `query` argument of `drizzleField`, `drizzleConnection`,
+`t.relation`, and related connections after the drizzle-orm 1.0.0-beta.10
+update. The plugin was still referring to the removed `$relationBrand` and
+`targetTable['_']['name']` properties on `Relation`, which caused the query
+filter/option types to collapse to `any`.

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -392,7 +392,7 @@ export type RelatedFieldOptions<
 > & {
   description?: string | false;
   // biome-ignore lint/suspicious/noExplicitAny: this is fine
-  type?: DrizzleRef<any, Table['relations'][Field]['targetTable']['_']['name']>;
+  type?: DrizzleRef<any, Table['relations'][Field]['targetTableName']>;
   query?: QueryForField<Types, Args, Table['relations'][Field]>;
 };
 
@@ -446,7 +446,7 @@ export type VariantFieldOptions<
 };
 
 export type RefForRelation<Types extends SchemaTypes, Rel extends Relation> = Rel extends {
-  $relationBrand: 'One';
+  relationType: 'one';
 }
   ? ObjectRef<Types, TypesForRelation<Types, Rel>>
   : [ObjectRef<Types, TypesForRelation<Types, Rel>>];
@@ -465,7 +465,7 @@ export type RelatedCountOptions<
 
 export type TypesForRelation<Types extends SchemaTypes, Rel extends Relation> = BuildQueryResult<
   Types['DrizzleRelations'],
-  Types['DrizzleRelations'][Rel['targetTable']['_']['name']],
+  Types['DrizzleRelations'][Rel['targetTableName']],
   true
 >;
 
@@ -475,13 +475,13 @@ export type QueryForField<
   Rel extends Relation,
 > = (
   Rel extends {
-    $relationBrand: 'One';
+    relationType: 'one';
   }
     ? Omit<
         DBQueryConfig<
           'one',
           Types['DrizzleRelations'],
-          Types['DrizzleRelations'][Rel['targetTable']['_']['name']]
+          Types['DrizzleRelations'][Rel['targetTableName']]
         >,
         'columns' | 'extra' | 'with'
       >
@@ -489,7 +489,7 @@ export type QueryForField<
         DBQueryConfig<
           'many',
           Types['DrizzleRelations'],
-          Types['DrizzleRelations'][Rel['targetTable']['_']['name']]
+          Types['DrizzleRelations'][Rel['targetTableName']]
         >,
         'columns' | 'extra' | 'with'
       >
@@ -626,7 +626,7 @@ export type RelatedConnectionOptions<
   Args extends InputFieldMap,
   Type = unknown,
   NodeTable extends
-    TableRelationalConfig = Types['DrizzleRelations'][Table['relations'][Field]['targetTable']['_']['name']],
+    TableRelationalConfig = Types['DrizzleRelations'][Table['relations'][Field]['targetTableName']],
 > = Omit<
   PothosSchemaTypes.ObjectFieldOptions<
     Types,
@@ -669,7 +669,7 @@ export type RelatedConnectionOptions<
         >;
         query?: QueryForRelatedConnection<Types, NodeTable, ConnectionArgs>;
         // biome-ignore lint/suspicious/noExplicitAny: this is fine
-        type?: Type & DrizzleRef<any, Table['relations'][Field]['targetTable']['_']['name']>;
+        type?: Type & DrizzleRef<any, Table['relations'][Field]['targetTableName']>;
 
         defaultSize?: number | ((args: ConnectionArgs, ctx: Types['Context']) => number);
         maxSize?: number | ((args: ConnectionArgs, ctx: Types['Context']) => number);

--- a/packages/plugin-drizzle/tests/example/schema/user.ts
+++ b/packages/plugin-drizzle/tests/example/schema/user.ts
@@ -152,7 +152,7 @@ export const Viewer = builder.drizzleInterface('users', {
     drafts: t.relation('posts', {
       query: {
         where: {
-          published: false,
+          published: 0,
         },
         orderBy: {
           updatedAt: 'desc',


### PR DESCRIPTION
fixes #1615 