### PR TITLE
fix(plugin-validation): propagate prototype of issues for structured errors

### DIFF
--- a/.changeset/clean-trees-obey.md
+++ b/.changeset/clean-trees-obey.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-validation": minor
+---
+
+Propagate prototype of validation issues to preserve structured errors

--- a/packages/plugin-validation/src/utils.ts
+++ b/packages/plugin-validation/src/utils.ts
@@ -139,7 +139,13 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
     function addIssues(path: (string | number)[]) {
       return (newIssues: readonly StandardSchemaV1.Issue[]) => {
         issues.push(
-          ...newIssues.map((issue) => ({ ...issue, path: [...path, ...(issue.path ?? [])] })),
+          ...newIssues.map((issue) =>
+            Object.create(issue, {
+              path: { value: [...path, ...(issue.path ?? [])], enumerable: true, configurable: true },
+              // NOTE: We inherit any getters that might be associated with the "message" property
+              message: Object.getOwnPropertyDescriptor(issue, "message") ?? { value: issue.message, enumerable: true, configurable: true }
+            })
+          ),
         );
       };
     }


### PR DESCRIPTION
Fixes #1626

Validators like ArkType returns a `ArkError` class object as the `StandardSchemaV1.issue`. This allows downstream callbacks like `validationError` to get the class object and have access to it's fields and methods.

Based on the 3rd implementation as suggested [here](https://github.com/hayes/pothos/issues/1626#issuecomment-4452802395). Thank you, I didn't think of `Object.create` simply adding to the prototype chain.

I used `Object.getOwnPropertyDescriptior` to propagate any message getters so that the message can be lazily generated or modified before being generated in the case of `ArkError` from ArkType. If that is needlessly complicated/unnecessary, that part can easily be removed in favor of the value itself as originally suggested (I don't personally need it for my use-case right now, so I have no problem removing it). 