### PR TITLE
fix(tracing-opentelemetry): ignoreError no longer inverted

### DIFF
--- a/.changeset/every-radios-type.md
+++ b/.changeset/every-radios-type.md
@@ -1,0 +1,5 @@
+---
+"@pothos/tracing-opentelemetry": minor
+---
+
+ignoreErrors no longer inverted (`false` previously didn't record exceptions)

--- a/packages/tracing-opentelemetry/src/index.ts
+++ b/packages/tracing-opentelemetry/src/index.ts
@@ -60,7 +60,7 @@ export function createOpenTelemetryWrapper<T = unknown>(
       tracingOptions?.onSpan?.(span, fieldOptions, parent, args, context, info);
       options?.onSpan?.(span, fieldOptions, parent, args, context, info);
 
-      return runWithSpan(span, !!(tracingOptions?.ignoreError ?? options?.ignoreError), () =>
+      return runWithSpan(span, !(tracingOptions?.ignoreError ?? options?.ignoreError), () =>
         resolver(parent, args, context, info),
       );
     };


### PR DESCRIPTION
The boolean value of `ignoreError` was passed directly as the argument `recordException`. If we are ignoring errors, we should NOT be recording and vice-versa. One single NOT, so one single `!`

This does change the default behavior when unset, but now follows the documented default behavior