### PR TITLE
fix(dataloader): exclude Error from inferred loadable Shape

### DIFF
--- a/.changeset/dataloader-shape-error-exclude.md
+++ b/.changeset/dataloader-shape-error-exclude.md
@@ -1,5 +1,5 @@
 ---
-'@pothos/plugin-dataloader': patch
+'@pothos/plugin-dataloader': minor
 ---
 
 Fix `loadableObject`, `loadableObjectRef`, `loadableInterfaceRef`, and `loadableNodeRef` to infer the object `Shape` with `Error` excluded from the `load` result union. Previously a `load` method resolving to `Shape | Error` caused dependent field and resolver types to incorrectly include `Error`.

--- a/.changeset/dataloader-shape-error-exclude.md
+++ b/.changeset/dataloader-shape-error-exclude.md
@@ -1,5 +1,5 @@
 ---
-'@pothos/plugin-dataloader': minor
+'@pothos/plugin-dataloader': patch
 ---
 
 Fix `loadableObject`, `loadableObjectRef`, `loadableInterfaceRef`, and `loadableNodeRef` to infer the object `Shape` with `Error` excluded from the `load` result union. Previously a `load` method resolving to `Shape | Error` caused dependent field and resolver types to incorrectly include `Error`.

--- a/.changeset/dataloader-shape-error-exclude.md
+++ b/.changeset/dataloader-shape-error-exclude.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-dataloader': patch
+---
+
+Fix `loadableObject`, `loadableObjectRef`, `loadableInterfaceRef`, and `loadableNodeRef` to infer the object `Shape` with `Error` excluded from the `load` result union. Previously a `load` method resolving to `Shape | Error` caused dependent field and resolver types to incorrectly include `Error`.

--- a/packages/plugin-dataloader/src/global-types.ts
+++ b/packages/plugin-dataloader/src/global-types.ts
@@ -83,36 +83,77 @@ declare global {
       ) => LoadableInterfaceRef<Types, Key | Shape, Shape, Key, CacheKey>;
 
       loadableObjectRef: <
-        LoadResult,
+        Shape,
         Key extends bigint | number | string,
         CacheKey = Key,
-        Shape = ShapeFromLoadResult<LoadResult>,
+        // `LoadResult` is inferred from `options.load` and is not intended to be
+        // passed explicitly. It defaults to `Shape | Error` so that explicit
+        // generics keep working exactly as before (`loadableObjectRef<User, string>`),
+        // while inference excludes `Error` from the resolved shape (#951).
+        LoadResult = Shape | Error,
       >(
         name: string,
-        options: DataLoaderOptions<Types, LoadResult, Key, CacheKey, Shape>,
-      ) => ImplementableLoadableObjectRef<Types, Key | Shape, Shape, Key, CacheKey>;
+        options: DataLoaderOptions<
+          Types,
+          LoadResult,
+          Key,
+          CacheKey,
+          ShapeFromLoadResult<LoadResult>
+        >,
+      ) => ImplementableLoadableObjectRef<
+        Types,
+        Key | ShapeFromLoadResult<LoadResult>,
+        ShapeFromLoadResult<LoadResult>,
+        Key,
+        CacheKey
+      >;
 
       loadableInterfaceRef: <
-        LoadResult,
+        Shape,
         Key extends bigint | number | string,
         CacheKey = Key,
-        Shape = ShapeFromLoadResult<LoadResult>,
+        LoadResult = Shape | Error,
       >(
         name: string,
-        options: DataLoaderOptions<Types, LoadResult, Key, CacheKey, Shape>,
-      ) => ImplementableLoadableInterfaceRef<Types, Key | Shape, Shape, Key, CacheKey>;
+        options: DataLoaderOptions<
+          Types,
+          LoadResult,
+          Key,
+          CacheKey,
+          ShapeFromLoadResult<LoadResult>
+        >,
+      ) => ImplementableLoadableInterfaceRef<
+        Types,
+        Key | ShapeFromLoadResult<LoadResult>,
+        ShapeFromLoadResult<LoadResult>,
+        Key,
+        CacheKey
+      >;
 
       loadableNodeRef: <
-        LoadResult,
+        Shape,
         IDShape extends bigint | number | string = string,
         Key extends bigint | number | string = IDShape,
         CacheKey = Key,
-        Shape = ShapeFromLoadResult<LoadResult>,
+        LoadResult = Shape | Error,
       >(
         name: string,
-        options: DataLoaderOptions<Types, LoadResult, Key, CacheKey, Shape> &
-          LoadableNodeId<Types, Shape, IDShape>,
-      ) => ImplementableLoadableNodeRef<Types, Key | Shape, Shape, IDShape, Key, CacheKey>;
+        options: DataLoaderOptions<
+          Types,
+          LoadResult,
+          Key,
+          CacheKey,
+          ShapeFromLoadResult<LoadResult>
+        > &
+          LoadableNodeId<Types, ShapeFromLoadResult<LoadResult>, IDShape>,
+      ) => ImplementableLoadableNodeRef<
+        Types,
+        Key | ShapeFromLoadResult<LoadResult>,
+        ShapeFromLoadResult<LoadResult>,
+        IDShape,
+        Key,
+        CacheKey
+      >;
 
       loadableUnion: <
         Key extends bigint | number | string,

--- a/packages/plugin-dataloader/src/global-types.ts
+++ b/packages/plugin-dataloader/src/global-types.ts
@@ -82,24 +82,35 @@ declare global {
         >,
       ) => LoadableInterfaceRef<Types, Key | Shape, Shape, Key, CacheKey>;
 
-      loadableObjectRef: <Shape, Key extends bigint | number | string, CacheKey = Key>(
+      loadableObjectRef: <
+        LoadResult,
+        Key extends bigint | number | string,
+        CacheKey = Key,
+        Shape = ShapeFromLoadResult<LoadResult>,
+      >(
         name: string,
-        options: DataLoaderOptions<Types, Shape | Error, Key, CacheKey, Shape>,
+        options: DataLoaderOptions<Types, LoadResult, Key, CacheKey, Shape>,
       ) => ImplementableLoadableObjectRef<Types, Key | Shape, Shape, Key, CacheKey>;
 
-      loadableInterfaceRef: <Shape, Key extends bigint | number | string, CacheKey = Key>(
+      loadableInterfaceRef: <
+        LoadResult,
+        Key extends bigint | number | string,
+        CacheKey = Key,
+        Shape = ShapeFromLoadResult<LoadResult>,
+      >(
         name: string,
-        options: DataLoaderOptions<Types, Shape | Error, Key, CacheKey, Shape>,
+        options: DataLoaderOptions<Types, LoadResult, Key, CacheKey, Shape>,
       ) => ImplementableLoadableInterfaceRef<Types, Key | Shape, Shape, Key, CacheKey>;
 
       loadableNodeRef: <
-        Shape,
+        LoadResult,
         IDShape extends bigint | number | string = string,
         Key extends bigint | number | string = IDShape,
         CacheKey = Key,
+        Shape = ShapeFromLoadResult<LoadResult>,
       >(
         name: string,
-        options: DataLoaderOptions<Types, Shape | Error, Key, CacheKey, Shape> &
+        options: DataLoaderOptions<Types, LoadResult, Key, CacheKey, Shape> &
           LoadableNodeId<Types, Shape, IDShape>,
       ) => ImplementableLoadableNodeRef<Types, Key | Shape, Shape, IDShape, Key, CacheKey>;
 

--- a/packages/plugin-dataloader/src/global-types.ts
+++ b/packages/plugin-dataloader/src/global-types.ts
@@ -83,77 +83,36 @@ declare global {
       ) => LoadableInterfaceRef<Types, Key | Shape, Shape, Key, CacheKey>;
 
       loadableObjectRef: <
-        Shape,
+        LoadResult,
         Key extends bigint | number | string,
         CacheKey = Key,
-        // `LoadResult` is inferred from `options.load` and is not intended to be
-        // passed explicitly. It defaults to `Shape | Error` so that explicit
-        // generics keep working exactly as before (`loadableObjectRef<User, string>`),
-        // while inference excludes `Error` from the resolved shape (#951).
-        LoadResult = Shape | Error,
+        Shape = ShapeFromLoadResult<LoadResult>,
       >(
         name: string,
-        options: DataLoaderOptions<
-          Types,
-          LoadResult,
-          Key,
-          CacheKey,
-          ShapeFromLoadResult<LoadResult>
-        >,
-      ) => ImplementableLoadableObjectRef<
-        Types,
-        Key | ShapeFromLoadResult<LoadResult>,
-        ShapeFromLoadResult<LoadResult>,
-        Key,
-        CacheKey
-      >;
+        options: DataLoaderOptions<Types, LoadResult | Error, Key, CacheKey, Shape>,
+      ) => ImplementableLoadableObjectRef<Types, Key | Shape, Shape, Key, CacheKey>;
 
       loadableInterfaceRef: <
-        Shape,
+        LoadResult,
         Key extends bigint | number | string,
         CacheKey = Key,
-        LoadResult = Shape | Error,
+        Shape = ShapeFromLoadResult<LoadResult>,
       >(
         name: string,
-        options: DataLoaderOptions<
-          Types,
-          LoadResult,
-          Key,
-          CacheKey,
-          ShapeFromLoadResult<LoadResult>
-        >,
-      ) => ImplementableLoadableInterfaceRef<
-        Types,
-        Key | ShapeFromLoadResult<LoadResult>,
-        ShapeFromLoadResult<LoadResult>,
-        Key,
-        CacheKey
-      >;
+        options: DataLoaderOptions<Types, LoadResult | Error, Key, CacheKey, Shape>,
+      ) => ImplementableLoadableInterfaceRef<Types, Key | Shape, Shape, Key, CacheKey>;
 
       loadableNodeRef: <
-        Shape,
+        LoadResult,
         IDShape extends bigint | number | string = string,
         Key extends bigint | number | string = IDShape,
         CacheKey = Key,
-        LoadResult = Shape | Error,
+        Shape = ShapeFromLoadResult<LoadResult>,
       >(
         name: string,
-        options: DataLoaderOptions<
-          Types,
-          LoadResult,
-          Key,
-          CacheKey,
-          ShapeFromLoadResult<LoadResult>
-        > &
-          LoadableNodeId<Types, ShapeFromLoadResult<LoadResult>, IDShape>,
-      ) => ImplementableLoadableNodeRef<
-        Types,
-        Key | ShapeFromLoadResult<LoadResult>,
-        ShapeFromLoadResult<LoadResult>,
-        IDShape,
-        Key,
-        CacheKey
-      >;
+        options: DataLoaderOptions<Types, LoadResult | Error, Key, CacheKey, Shape> &
+          LoadableNodeId<Types, Shape, IDShape>,
+      ) => ImplementableLoadableNodeRef<Types, Key | Shape, Shape, IDShape, Key, CacheKey>;
 
       loadableUnion: <
         Key extends bigint | number | string,

--- a/packages/plugin-dataloader/src/schema-builder.ts
+++ b/packages/plugin-dataloader/src/schema-builder.ts
@@ -23,15 +23,15 @@ import { dataloaderGetter } from './util';
 const schemaBuilderProto = SchemaBuilder.prototype as PothosSchemaTypes.SchemaBuilder<SchemaTypes>;
 
 schemaBuilderProto.loadableObjectRef = function loadableObjectRef(name, options) {
-  return new ImplementableLoadableObjectRef(this, name, options);
+  return new ImplementableLoadableObjectRef(this, name, options as never);
 };
 
 schemaBuilderProto.loadableInterfaceRef = function loadableInterfaceRef(name, options) {
-  return new ImplementableLoadableInterfaceRef(this, name, options);
+  return new ImplementableLoadableInterfaceRef(this, name, options as never);
 };
 
 schemaBuilderProto.loadableNodeRef = function loadableNodeRef(name, options) {
-  return new ImplementableLoadableNodeRef(this, name, options);
+  return new ImplementableLoadableNodeRef(this, name, options as never);
 };
 
 schemaBuilderProto.loadableObject = function loadableObject<

--- a/packages/plugin-dataloader/tests/dataloader.test-d.ts
+++ b/packages/plugin-dataloader/tests/dataloader.test-d.ts
@@ -56,3 +56,54 @@ describe('dataloader Shape inference (#951)', () => {
     });
   });
 });
+
+// The `builder.*Ref` methods are intended to keep working with explicit type
+// params. Passing `<Shape, Key>` (Shape first, Key second) must resolve
+// `Shape`/`Key` exactly as before the #951 fix, without requiring callers to
+// refactor explicit-generic call sites.
+describe('dataloader ref explicit generics (backwards compatibility)', () => {
+  it('loadableObjectRef<User, string> resolves Shape=User, Key=string', () => {
+    builder.loadableObjectRef<User, string>('ObjectRefExplicit', {
+      load: (keys) => {
+        expectTypeOf(keys).toEqualTypeOf<string[]>();
+        return Promise.resolve(keys.map((id) => ({ id: Number(id) })));
+      },
+      toKey: (value) => {
+        expectTypeOf(value).toEqualTypeOf<User>();
+        return String(value.id);
+      },
+    });
+  });
+
+  it('loadableInterfaceRef<User, string> resolves Shape=User, Key=string', () => {
+    builder.loadableInterfaceRef<User, string>('InterfaceRefExplicit', {
+      load: (keys) => {
+        expectTypeOf(keys).toEqualTypeOf<string[]>();
+        return Promise.resolve(keys.map((id) => ({ id: Number(id) })));
+      },
+      toKey: (value) => {
+        expectTypeOf(value).toEqualTypeOf<User>();
+        return String(value.id);
+      },
+    });
+  });
+
+  it('loadableNodeRef<User, string> resolves Shape=User, Key=string', () => {
+    builder.loadableNodeRef<User, string>('NodeRefExplicit', {
+      id: {
+        resolve: (value) => {
+          expectTypeOf(value).toEqualTypeOf<User>();
+          return value.id;
+        },
+      },
+      load: (keys) => {
+        expectTypeOf(keys).toEqualTypeOf<string[]>();
+        return Promise.resolve(keys.map((id) => ({ id: Number(id) })));
+      },
+      toKey: (value) => {
+        expectTypeOf(value).toEqualTypeOf<User>();
+        return String(value.id);
+      },
+    });
+  });
+});

--- a/packages/plugin-dataloader/tests/dataloader.test-d.ts
+++ b/packages/plugin-dataloader/tests/dataloader.test-d.ts
@@ -66,7 +66,9 @@ describe('dataloader ref explicit generics (backwards compatibility)', () => {
     builder.loadableObjectRef<User, string>('ObjectRefExplicit', {
       load: (keys) => {
         expectTypeOf(keys).toEqualTypeOf<string[]>();
-        return Promise.resolve(keys.map((id) => ({ id: Number(id) })));
+        return Promise.resolve(
+          keys.map((id) => (Number(id) > 0 ? { id: Number(id) } : new GraphQLError('bad'))),
+        );
       },
       toKey: (value) => {
         expectTypeOf(value).toEqualTypeOf<User>();
@@ -79,7 +81,9 @@ describe('dataloader ref explicit generics (backwards compatibility)', () => {
     builder.loadableInterfaceRef<User, string>('InterfaceRefExplicit', {
       load: (keys) => {
         expectTypeOf(keys).toEqualTypeOf<string[]>();
-        return Promise.resolve(keys.map((id) => ({ id: Number(id) })));
+        return Promise.resolve(
+          keys.map((id) => (Number(id) > 0 ? { id: Number(id) } : new GraphQLError('bad'))),
+        );
       },
       toKey: (value) => {
         expectTypeOf(value).toEqualTypeOf<User>();
@@ -98,7 +102,9 @@ describe('dataloader ref explicit generics (backwards compatibility)', () => {
       },
       load: (keys) => {
         expectTypeOf(keys).toEqualTypeOf<string[]>();
-        return Promise.resolve(keys.map((id) => ({ id: Number(id) })));
+        return Promise.resolve(
+          keys.map((id) => (Number(id) > 0 ? { id: Number(id) } : new GraphQLError('bad'))),
+        );
       },
       toKey: (value) => {
         expectTypeOf(value).toEqualTypeOf<User>();

--- a/packages/plugin-dataloader/tests/dataloader.test-d.ts
+++ b/packages/plugin-dataloader/tests/dataloader.test-d.ts
@@ -1,0 +1,58 @@
+import { GraphQLError } from 'graphql';
+import { describe, expectTypeOf, it } from 'vitest';
+import builder from './example/builder';
+
+interface User {
+  id: number;
+}
+
+// Regression tests for #951: when `load` resolves to `Shape | Error`, the object
+// `Shape` must be inferred with `Error` excluded from the union, so dependent
+// callbacks (`toKey`, `sort`, `cacheResolved`) receive the resolved `Shape` only.
+describe('dataloader Shape inference (#951)', () => {
+  it('loadableObject infers Shape with Error excluded', () => {
+    builder.loadableObject('ObjectShape951', {
+      load: async (ids: string[]) =>
+        ids.map((id) => (Number(id) > 0 ? { id: Number(id) } : new GraphQLError('bad'))),
+      fields: () => ({}),
+      toKey: (value) => {
+        expectTypeOf(value).toEqualTypeOf<User>();
+        return String(value.id);
+      },
+    });
+  });
+
+  it('loadableObjectRef infers Shape with Error excluded', () => {
+    builder.loadableObjectRef('ObjectRefShape951', {
+      load: async (ids: string[]) =>
+        ids.map((id) => (Number(id) > 0 ? { id: Number(id) } : new GraphQLError('bad'))),
+      toKey: (value) => {
+        expectTypeOf(value).toEqualTypeOf<User>();
+        return String(value.id);
+      },
+    });
+  });
+
+  it('loadableInterfaceRef infers Shape with Error excluded', () => {
+    builder.loadableInterfaceRef('InterfaceRefShape951', {
+      load: async (ids: string[]) =>
+        ids.map((id) => (Number(id) > 0 ? { id: Number(id) } : new GraphQLError('bad'))),
+      toKey: (value) => {
+        expectTypeOf(value).toEqualTypeOf<User>();
+        return String(value.id);
+      },
+    });
+  });
+
+  it('loadableNodeRef infers Shape with Error excluded', () => {
+    builder.loadableNodeRef('NodeRefShape951', {
+      id: { resolve: (value) => value.id },
+      load: async (ids: string[]) =>
+        ids.map((id) => (Number(id) > 0 ? { id: Number(id) } : new GraphQLError('bad'))),
+      toKey: (value) => {
+        expectTypeOf(value).toEqualTypeOf<User>();
+        return String(value.id);
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Problem
When a dataloader `load` method resolves to `Shape | Error` (returning errors per key), the loadable refs inferred the object `Shape` without excluding `Error` from the union, so dependent field and resolver types incorrectly included `Error`.

## Fix
`loadableObject`, `loadableObjectRef`, `loadableInterfaceRef`, and `loadableNodeRef` now derive `Shape` via `ShapeFromLoadResult<LoadResult>`, which strips `Error` from the load result. `Error` values are still accepted at runtime; only the inferred object type is corrected.

## Tests
Added `packages/plugin-dataloader/tests/dataloader.test-d.ts` asserting that a `load` resolving to `{ id } | GraphQLError` infers `Shape` as `User` (Error excluded) for all four loadable ref constructors. `pnpm run type` passes.

Closes #951