### PR TITLE
[wip] fix undefined filters in Drizzle connections

### DIFF
--- a/.changeset/quiet-ravens-filter.md
+++ b/.changeset/quiet-ravens-filter.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-drizzle': patch
+---
+
+Omit undefined `where` properties from generated connection queries for compatibility with strict Drizzle relational filters.

--- a/packages/plugin-drizzle/src/utils/cursors.ts
+++ b/packages/plugin-drizzle/src/utils/cursors.ts
@@ -446,12 +446,14 @@ export function drizzleCursorConnectionQuery({
     whereClauses.push(parts.length > 1 ? { OR: parts } : parts[0]);
   }
 
+  const connectionWhere = whereClauses.length > 1 ? { AND: whereClauses } : whereClauses[0];
+
   return {
     cursorColumns: parsedOrderBy.columns,
     columns,
     orderBy: parsedOrderBy.orderBy,
     limit,
-    where: whereClauses.length > 1 ? { AND: whereClauses } : whereClauses[0],
+    ...(connectionWhere === undefined ? {} : { where: connectionWhere }),
   };
 }
 
@@ -536,6 +538,12 @@ export async function resolveDrizzleCursorConnection<T extends {}>(
       table,
     });
     formatter = getCursorFormatter(cursorColumns, config);
+    const connectionWhere =
+      connectionQuery.where && q.where
+        ? {
+            AND: [q.where, connectionQuery.where],
+          }
+        : q.where || connectionQuery.where;
 
     query = queryFromInfo({
       context: options.ctx,
@@ -546,12 +554,7 @@ export async function resolveDrizzleCursorConnection<T extends {}>(
           ...q.columns,
           ...connectionQuery.columns,
         },
-        where:
-          connectionQuery.where && q.where
-            ? {
-                AND: [q.where, connectionQuery.where],
-              }
-            : q.where || connectionQuery.where,
+        ...(connectionWhere === undefined ? {} : { where: connectionWhere }),
       } as never,
       paths: [['nodes'], ['edges', 'node']],
       typeName,

--- a/packages/plugin-drizzle/tests/drizzle-connections.test.ts
+++ b/packages/plugin-drizzle/tests/drizzle-connections.test.ts
@@ -1,11 +1,13 @@
 import { execute } from '@pothos/test-utils';
 import { gql } from 'graphql-tag';
+import { vi } from 'vitest';
 import { createContext } from './example/context';
-import { clearDrizzleLogs, drizzleLogs } from './example/db';
+import { clearDrizzleLogs, db, drizzleLogs } from './example/db';
 import { schema } from './example/schema';
 
 describe('drizzle connections', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     clearDrizzleLogs();
   });
   it('first', async () => {
@@ -874,6 +876,7 @@ describe('drizzle connections', () => {
 
   it('default orderBy', async () => {
     const context = await createContext({ userId: '1' });
+    const findMany = vi.spyOn(db.query.users, 'findMany');
     clearDrizzleLogs();
     const result = await execute({
       schema,
@@ -891,6 +894,8 @@ describe('drizzle connections', () => {
         `,
       contextValue: context,
     });
+
+    expect(findMany.mock.calls[0][0]).not.toHaveProperty('where');
 
     expect(drizzleLogs).toMatchInlineSnapshot(`
       [

--- a/packages/plugin-drizzle/tests/related-connection.test.ts
+++ b/packages/plugin-drizzle/tests/related-connection.test.ts
@@ -1113,6 +1113,7 @@ describe('related connections', () => {
       contextValue: context,
     });
 
+    expect(findFirst).toHaveBeenCalled();
     expect(findFirst.mock.calls[0][0]?.with?.comments).not.toHaveProperty('where');
 
     expect(drizzleLogs).toMatchInlineSnapshot(`

--- a/packages/plugin-drizzle/tests/related-connection.test.ts
+++ b/packages/plugin-drizzle/tests/related-connection.test.ts
@@ -1,11 +1,13 @@
 import { execute } from '@pothos/test-utils';
 import { gql } from 'graphql-tag';
+import { vi } from 'vitest';
 import { createContext } from './example/context';
-import { clearDrizzleLogs, drizzleLogs } from './example/db';
+import { clearDrizzleLogs, db, drizzleLogs } from './example/db';
 import { schema } from './example/schema';
 
 describe('related connections', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     clearDrizzleLogs();
   });
   it('first', async () => {
@@ -1089,6 +1091,7 @@ describe('related connections', () => {
 
   it('custom totalCount field', async () => {
     const context = await createContext({ userId: '1' });
+    const findFirst = vi.spyOn(db.query.users, 'findFirst');
     clearDrizzleLogs();
     const result = await execute({
       schema,
@@ -1109,6 +1112,8 @@ describe('related connections', () => {
         `,
       contextValue: context,
     });
+
+    expect(findFirst.mock.calls[0][0]?.with?.comments).not.toHaveProperty('where');
 
     expect(drizzleLogs).toMatchInlineSnapshot(`
       [


### PR DESCRIPTION
## Summary

- omit `where` from generated Drizzle connection queries when there is no filter
- cover both root `drizzleConnection` and nested `relatedConnection` query shapes
- add a patch changeset for `@pothos/plugin-drizzle`

## Why

Drizzle `1.0.0-rc.5-169397b` rejects an explicitly undefined relational filter with:

> Unexpected 'undefined' in filter value. Use 'EmptyFilter' if you want the filter field to be skipped.

Connection queries without a user filter or cursor currently include `where: undefined`. Omitting the optional property preserves existing behavior on earlier Drizzle versions and satisfies the stricter rc.5 contract.

## Validation

- regression assertions fail on both affected query paths before the fix
- `drizzle-orm@1.0.0-rc.2`: 90/90 plugin tests pass
- `drizzle-orm@1.0.0-rc.4`: 90/90 plugin tests pass
- `drizzle-orm@1.0.0-rc.5-169397b`: 90/90 plugin tests pass
- `pnpm --filter @pothos/plugin-drizzle type`
- `pnpm --filter @pothos/plugin-drizzle build`
