### PR TITLE
fix(drizzle): treat undefined query properties as absent

### DIFF
--- a/.changeset/calm-trees-filter.md
+++ b/.changeset/calm-trees-filter.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-drizzle': patch
+---
+
+Treat `undefined` query properties as absent when building Drizzle queries. Query callbacks that return a conditional filter (e.g. `where: cond ? filter : undefined`) previously produced a selection that compared as incompatible with an equivalent selection that omitted the key, causing the field's selection to be dropped. `where`, `orderBy`, `limit`, and `offset` are now normalized before selections are stored, compared, or passed to Drizzle.

--- a/packages/plugin-drizzle/src/connection-helpers.ts
+++ b/packages/plugin-drizzle/src/connection-helpers.ts
@@ -16,7 +16,12 @@ import {
 } from './utils/cursors.js';
 import { queryFromInfo } from './utils/map-query.js';
 import { getRefFromModel } from './utils/refs.js';
-import { createState, mergeSelection, selectionToQuery } from './utils/selections.js';
+import {
+  createState,
+  mergeSelection,
+  omitUndefinedKeys,
+  selectionToQuery,
+} from './utils/selections.js';
 
 export function drizzleConnectionHelpers<
   Types extends SchemaTypes,
@@ -181,10 +186,10 @@ export function drizzleConnectionHelpers<
     const baseQuery = typeof query === 'function' ? query(args, ctx) : (query ?? {});
     const queryResult = selectionToQuery(config, selectState);
 
-    return {
+    return omitUndefinedKeys({
       ...baseQuery,
       ...queryResult,
-    } as unknown as Omit<Selection, 'orderBy'> & {
+    }) as unknown as Omit<Selection, 'orderBy'> & {
       orderBy: {
         [K in TableConfig['table']['_'] extends { columns: infer Columns }
           ? keyof Columns

--- a/packages/plugin-drizzle/src/drizzle-field-builder.ts
+++ b/packages/plugin-drizzle/src/drizzle-field-builder.ts
@@ -56,7 +56,7 @@ import {
   wrapConnectionResult,
 } from './utils/cursors.js';
 import { getRefFromModel } from './utils/refs.js';
-import type { SelectionMap } from './utils/selections.js';
+import { omitUndefinedKeys, type SelectionMap } from './utils/selections.js';
 
 // Workaround for FieldKind not being extended on Builder classes
 const RootBuilder: {
@@ -526,7 +526,7 @@ export class DrizzleObjectFieldBuilder<
       const relQuery = {
         columns: {},
         with: {
-          [name]: {
+          [name]: omitUndefinedKeys({
             ...nestedQuery(query),
             ...((typeof query === 'function'
               ? (query as (args: {}, context: {}, pathInfo: PathInfo) => {})(
@@ -535,7 +535,7 @@ export class DrizzleObjectFieldBuilder<
                   pathInfo,
                 )
               : query) as {}),
-          },
+          }),
         },
       };
 

--- a/packages/plugin-drizzle/src/utils/cursors.ts
+++ b/packages/plugin-drizzle/src/utils/cursors.ts
@@ -17,7 +17,7 @@ import type { GraphQLResolveInfo } from 'graphql';
 import type { ConnectionOrderBy, QueryForDrizzleConnection } from '../types.js';
 import type { PothosDrizzleSchemaConfig } from './config.js';
 import { queryFromInfo } from './map-query.js';
-import type { SelectionMap } from './selections.js';
+import { omitUndefinedKeys, type SelectionMap } from './selections.js';
 
 const DEFAULT_MAX_SIZE = 100;
 const DEFAULT_SIZE = 20;
@@ -446,13 +446,13 @@ export function drizzleCursorConnectionQuery({
     whereClauses.push(parts.length > 1 ? { OR: parts } : parts[0]);
   }
 
-  return {
+  return omitUndefinedKeys({
     cursorColumns: parsedOrderBy.columns,
     columns,
     orderBy: parsedOrderBy.orderBy,
     limit,
     where: whereClauses.length > 1 ? { AND: whereClauses } : whereClauses[0],
-  };
+  });
 }
 
 export function wrapConnectionResult<T extends {}>(
@@ -540,7 +540,7 @@ export async function resolveDrizzleCursorConnection<T extends {}>(
     query = queryFromInfo({
       context: options.ctx,
       info,
-      select: {
+      select: omitUndefinedKeys({
         ...connectionQuery,
         columns: {
           ...q.columns,
@@ -552,7 +552,7 @@ export async function resolveDrizzleCursorConnection<T extends {}>(
                 AND: [q.where, connectionQuery.where],
               }
             : q.where || connectionQuery.where,
-      } as never,
+      }) as never,
       paths: [['nodes'], ['edges', 'node']],
       typeName,
       config,

--- a/packages/plugin-drizzle/src/utils/selections.ts
+++ b/packages/plugin-drizzle/src/utils/selections.ts
@@ -19,6 +19,13 @@ export interface SelectionState {
 
 export type SelectionMap = DBQueryConfig<'one'>;
 
+export function omitUndefinedKeys<T extends object>(query: T): T {
+  const entries = Object.entries(query);
+  const defined = entries.filter(([, value]) => value !== undefined);
+
+  return defined.length === entries.length ? query : (Object.fromEntries(defined) as T);
+}
+
 export function selectionCompatible(
   state: SelectionState,
   selectionMap: SelectionMap | boolean,
@@ -53,7 +60,7 @@ export function selectionCompatible(
     return false;
   }
 
-  return ignoreQuery || deepEqual(state.query, query);
+  return ignoreQuery || deepEqual(state.query, omitUndefinedKeys(query));
 }
 
 export function stateCompatible(
@@ -134,8 +141,9 @@ export function mergeSelection(
     }
   }
 
-  if (Object.keys(query).length > 0) {
-    state.query = query;
+  const normalizedQuery = omitUndefinedKeys(query);
+  if (Object.keys(normalizedQuery).length > 0) {
+    state.query = normalizedQuery;
   }
 
   if (extras) {
@@ -178,7 +186,7 @@ export function selectionToQuery(
   state: SelectionState,
 ): SelectionMap {
   const query: SelectionMap & { extras: Record<string, unknown> } = {
-    ...state.query,
+    ...omitUndefinedKeys(state.query),
     columns: undefined,
     with: {},
     extras: {},

--- a/packages/plugin-drizzle/tests/connection-helpers.test.ts
+++ b/packages/plugin-drizzle/tests/connection-helpers.test.ts
@@ -1,15 +1,18 @@
 import { execute } from '@pothos/test-utils';
 import { gql } from 'graphql-tag';
+import { vi } from 'vitest';
 import { createContext } from './example/context';
-import { clearDrizzleLogs, drizzleLogs } from './example/db';
+import { clearDrizzleLogs, db, drizzleLogs } from './example/db';
 import { schema } from './example/schema';
 
 describe('connection helpers', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     clearDrizzleLogs();
   });
   it('basic indirect connection', async () => {
     const context = await createContext({ userId: '1' });
+    const findFirst = vi.spyOn(db.query.users, 'findFirst');
     clearDrizzleLogs();
     const result = await execute({
       schema,
@@ -37,6 +40,8 @@ describe('connection helpers', () => {
       contextValue: context,
     });
 
+    expect(findFirst).toHaveBeenCalledTimes(1);
+    expect(findFirst.mock.calls[0][0]?.with?.userRoles).not.toHaveProperty('where');
     expect(drizzleLogs).toMatchInlineSnapshot(`
       [
         "Query: select "d0"."id" as "id", coalesce((select json_group_array(json_object('userId', "userId", 'roleId', "roleId", 'role', jsonb("role"))) as "r" from (select "d1"."user_id" as "userId", "d1"."role_id" as "roleId", (select jsonb_object('id', "id", 'name', "name") as "r" from (select "d2"."id" as "id", "d2"."name" as "name" from "roles" as "d2" where "d1"."role_id" = "d2"."id" limit ?) as "t") as "role" from "user_roles" as "d1" where "d0"."id" = "d1"."user_id" order by "d1"."role_id" asc limit ?) as "t"), jsonb_array()) as "userRoles" from "users" as "d0" where "d0"."id" = ? limit ? -- params: [1, 21, 1, 1]",

--- a/packages/plugin-drizzle/tests/drizzle-connections.test.ts
+++ b/packages/plugin-drizzle/tests/drizzle-connections.test.ts
@@ -1,11 +1,13 @@
 import { execute } from '@pothos/test-utils';
 import { gql } from 'graphql-tag';
+import { vi } from 'vitest';
 import { createContext } from './example/context';
-import { clearDrizzleLogs, drizzleLogs } from './example/db';
+import { clearDrizzleLogs, db, drizzleLogs } from './example/db';
 import { schema } from './example/schema';
 
 describe('drizzle connections', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     clearDrizzleLogs();
   });
   it('first', async () => {
@@ -874,6 +876,7 @@ describe('drizzle connections', () => {
 
   it('default orderBy', async () => {
     const context = await createContext({ userId: '1' });
+    const findMany = vi.spyOn(db.query.users, 'findMany');
     clearDrizzleLogs();
     const result = await execute({
       schema,
@@ -891,6 +894,9 @@ describe('drizzle connections', () => {
         `,
       contextValue: context,
     });
+
+    expect(findMany).toHaveBeenCalledTimes(1);
+    expect(findMany.mock.calls[0][0]).not.toHaveProperty('where');
 
     expect(drizzleLogs).toMatchInlineSnapshot(`
       [

--- a/packages/plugin-drizzle/tests/drizzle-field.test.ts
+++ b/packages/plugin-drizzle/tests/drizzle-field.test.ts
@@ -1,13 +1,36 @@
 import { execute } from '@pothos/test-utils';
 import { gql } from 'graphql-tag';
+import { vi } from 'vitest';
 import { createContext } from './example/context';
-import { clearDrizzleLogs, drizzleLogs } from './example/db';
+import { clearDrizzleLogs, db, drizzleLogs } from './example/db';
 import { schema } from './example/schema';
 
 describe('drizzle fields', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     clearDrizzleLogs();
   });
+
+  it('omits an undefined filter from a root query', async () => {
+    const context = await createContext({ userId: '1' });
+    const findMany = vi.spyOn(db.query.users, 'findMany');
+    const result = await execute({
+      schema,
+      document: gql`
+        {
+          users {
+            id
+          }
+        }
+      `,
+      contextValue: context,
+    });
+
+    expect(findMany).toHaveBeenCalledTimes(1);
+    expect(findMany.mock.calls[0][0]).not.toHaveProperty('where');
+    expect(result.errors).toBeUndefined();
+  });
+
   it('simple query using with, columns, extras on type', async () => {
     const context = await createContext({ userId: '1' });
     clearDrizzleLogs();

--- a/packages/plugin-drizzle/tests/example/schema/query.ts
+++ b/packages/plugin-drizzle/tests/example/schema/query.ts
@@ -36,7 +36,7 @@ builder.queryType({
     users: t.drizzleField({
       type: ['users'],
       resolve: (query) => {
-        return db.query.users.findMany(query());
+        return db.query.users.findMany(query({ where: undefined }));
       },
     }),
     usersConnection: t.drizzleConnection({

--- a/packages/plugin-drizzle/tests/example/schema/user.ts
+++ b/packages/plugin-drizzle/tests/example/schema/user.ts
@@ -38,6 +38,7 @@ const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
   }),
   query: (args: { invert?: boolean | null }) => ({
     orderBy: args.invert ? { roleId: 'desc' } : { roleId: 'asc' },
+    where: undefined,
   }),
   select: (nestedSelection) => ({
     with: {
@@ -268,6 +269,7 @@ export const User = builder.drizzleNode('users', {
         return {
           limit: args.testLimit ?? 5,
           orderBy: { updatedAt: 'desc' },
+          where: undefined,
         };
       },
     }),

--- a/packages/plugin-drizzle/tests/query-path.test.ts
+++ b/packages/plugin-drizzle/tests/query-path.test.ts
@@ -1,16 +1,19 @@
 import { execute } from '@pothos/test-utils';
 import { gql } from 'graphql-tag';
+import { vi } from 'vitest';
 import { createContext } from './example/context';
-import { clearDrizzleLogs } from './example/db';
+import { clearDrizzleLogs, db } from './example/db';
 import { schema } from './example/schema';
 
 describe('query path tracking', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     clearDrizzleLogs();
   });
 
   it('captures pathInfo in t.relation() query callback', async () => {
     const context = await createContext({ userId: '1' });
+    const findFirst = vi.spyOn(db.query.users, 'findFirst');
 
     // First query to trigger the relation with query callback
     const result = await execute({
@@ -38,6 +41,8 @@ describe('query path tracking', () => {
       contextValue: context,
     });
 
+    expect(findFirst).toHaveBeenCalledTimes(1);
+    expect(findFirst.mock.calls[0][0]?.with?.posts).not.toHaveProperty('where');
     expect(result.errors).toBeUndefined();
 
     const data = result.data as {

--- a/packages/plugin-drizzle/tests/related-connection.test.ts
+++ b/packages/plugin-drizzle/tests/related-connection.test.ts
@@ -1,11 +1,13 @@
 import { execute } from '@pothos/test-utils';
 import { gql } from 'graphql-tag';
+import { vi } from 'vitest';
 import { createContext } from './example/context';
-import { clearDrizzleLogs, drizzleLogs } from './example/db';
+import { clearDrizzleLogs, db, drizzleLogs } from './example/db';
 import { schema } from './example/schema';
 
 describe('related connections', () => {
   afterEach(() => {
+    vi.restoreAllMocks();
     clearDrizzleLogs();
   });
   it('first', async () => {
@@ -1089,6 +1091,7 @@ describe('related connections', () => {
 
   it('custom totalCount field', async () => {
     const context = await createContext({ userId: '1' });
+    const findFirst = vi.spyOn(db.query.users, 'findFirst');
     clearDrizzleLogs();
     const result = await execute({
       schema,
@@ -1109,6 +1112,9 @@ describe('related connections', () => {
         `,
       contextValue: context,
     });
+
+    expect(findFirst).toHaveBeenCalledTimes(1);
+    expect(findFirst.mock.calls[0][0]?.with?.comments).not.toHaveProperty('where');
 
     expect(drizzleLogs).toMatchInlineSnapshot(`
       [

--- a/packages/plugin-drizzle/tests/selections.test.ts
+++ b/packages/plugin-drizzle/tests/selections.test.ts
@@ -1,6 +1,13 @@
 import type { TableRelationalConfig } from 'drizzle-orm';
 import type { PothosDrizzleSchemaConfig } from '../src/utils/config';
-import { createState, mergeSelection, selectionToQuery } from '../src/utils/selections';
+import {
+  createState,
+  mergeSelection,
+  omitUndefinedKeys,
+  selectionCompatible,
+  selectionToQuery,
+  stateCompatible,
+} from '../src/utils/selections';
 
 const fakeTable = { name: 'users' } as unknown as TableRelationalConfig;
 const fakeConfig = {
@@ -11,6 +18,47 @@ const fakeConfig = {
 } as unknown as PothosDrizzleSchemaConfig;
 
 describe('selections', () => {
+  it('omits undefined properties without mutating the source query', () => {
+    const query = { where: undefined, orderBy: undefined, limit: 1 };
+
+    const normalized = omitUndefinedKeys(query);
+
+    expect(normalized).toEqual({ limit: 1 });
+    expect(normalized).not.toBe(query);
+    expect(query).toHaveProperty('where');
+    expect(query).toHaveProperty('orderBy');
+  });
+
+  it('preserves queries that have no undefined properties', () => {
+    const query = { where: { id: 1 }, limit: 1 };
+
+    expect(omitUndefinedKeys(query)).toBe(query);
+  });
+
+  it.each([
+    'where',
+    'orderBy',
+    'limit',
+    'offset',
+  ])('omits an undefined %s from merged selections', (key) => {
+    const state = createState(fakeTable, true);
+
+    mergeSelection(fakeConfig, state, { [key]: undefined });
+
+    expect(selectionToQuery(fakeConfig, state)).not.toHaveProperty(key);
+  });
+
+  it('treats an undefined property as equivalent to an absent one when merging', () => {
+    const withUndefined = createState(fakeTable, true);
+    mergeSelection(fakeConfig, withUndefined, { orderBy: undefined, where: undefined });
+
+    const withoutKeys = createState(fakeTable, true);
+    mergeSelection(fakeConfig, withoutKeys, {});
+
+    expect(selectionCompatible(withUndefined, {})).toBe(true);
+    expect(stateCompatible(withUndefined, withoutKeys)).toBe(true);
+  });
+
   it('ignores columns set to false instead of adding them to the selection', () => {
     const state = createState(fakeTable, true);
 


### PR DESCRIPTION
## Problem

A Drizzle query callback that returns a conditional filter silently breaks field selection:

```ts
t.relation('posts', {
  query: (args) => ({ where: args.filter ? buildFilter(args.filter) : undefined }),
})
```

The root cause is not Drizzle — Drizzle truthy-checks `where` at runtime (`sqlite-core/dialect.js:495`) and types it as `where?: ... | undefined`. The break is on the Pothos side: `deepEqual` (`src/utils/deep-equal.ts:37`) compares key *counts*, so `{ where: undefined }` does not match an equivalent selection that omits the key. `selectionCompatible` then rejects the nested relation and the field's selection is dropped.

## Fix

Normalize query objects by removing undefined-valued properties before they are stored on selection state, compared, or passed to Drizzle (`omitUndefinedKeys` in `src/utils/selections.ts`), applied in `mergeSelection`, `selectionCompatible`, `selectionToQuery`, `connection-helpers`, `drizzle-field-builder`, and `cursors`.

The helper is key-agnostic rather than `where`-specific by design. The failing mechanism is the key-count comparison, not anything about `where`, so `orderBy`, `limit`, and `offset` are reachable through the identical path — verified against a `where`-only version of this fix:

```
✗ orderBy: undefined leaks into selectionToQuery output
✗ orderBy: undefined → selectionCompatible(state, {}) === false
✗ limit:   undefined → selectionCompatible(state, {}) === false
```

`columns` / `with` / `extras` are destructured out before the rest-spread, so they are unaffected.

## Tests

98 tests pass, typecheck clean. Every new assertion is a genuine regression test — reverting only `src/` fails 8 integration assertions across 5 files plus 7 unit assertions in `selections.test.ts`. Coverage spans the merge level (`it.each` over `where`/`orderBy`/`limit`/`offset`), the compatibility level (`selectionCompatible` / `stateCompatible`), and end-to-end via `vi.spyOn` on `db.query.*` asserting the property never reaches Drizzle. All existing inline SQL snapshots are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
