### PR TITLE
fix(plugin-drizzle): keyset pagination drops the equality clause for Date columns

### DIFF
--- a/packages/plugin-drizzle/src/utils/cursors.ts
+++ b/packages/plugin-drizzle/src/utils/cursors.ts
@@ -499,15 +499,16 @@ function parseOrderBy(
 // doesn't cover are left out: it was issued for a shorter ordering, and its
 // prefix still describes a position.
 function compareTo(entry: OrderByEntry, operator: 'gt' | 'lt' | 'eq', value: unknown) {
-  // drizzle's shorthand equality takes `typeof null === 'object'` for a nested
-  // filter and throws, so a null has to be spelled out
   const isNullish = value === null || value === undefined;
 
   if (entry.column) {
-    if (operator === 'eq') {
-      return isNullish ? { [entry.key]: { isNull: true } } : { [entry.key]: value };
+    if (operator === 'eq' && isNullish) {
+      return { [entry.key]: { isNull: true } };
     }
 
+    // never the `{ column: value }` shorthand: drizzle reads any object value
+    // as a nested filter, so a null throws and a Date silently drops the
+    // comparison. Naming the operator works for every value a cursor can hold
     return { [entry.key]: { [operator]: value } };
   }
 

--- a/packages/plugin-drizzle/tests/cursor-values.test.ts
+++ b/packages/plugin-drizzle/tests/cursor-values.test.ts
@@ -169,3 +169,61 @@ describe('composite primary keys', () => {
     expect(query.orderBy).toEqual({ userId: 'asc', groupId: 'asc' });
   });
 });
+
+describe('keyset filters', () => {
+  async function whereSQLForCursor(cursorValues: { createdAt: Date | null; id: bigint }) {
+    const { defineRelations } = await import('drizzle-orm');
+    const { getTableConfig: getPgTableConfig } = await import('drizzle-orm/pg-core');
+    const { drizzle } = await import('drizzle-orm/postgres-js');
+    const { default: postgres } = await import('postgres');
+    const { default: SchemaBuilder } = await import('@pothos/core');
+    const { getSchemaConfig } = await import('../src/utils/config');
+    const { drizzleCursorConnectionQuery, getCursorFormatter } = await import(
+      '../src/utils/cursors'
+    );
+    const DrizzlePlugin = (await import('../src')).default;
+
+    const relations = defineRelations({ events }, () => ({}));
+    const builder = new SchemaBuilder<{ DrizzleRelations: typeof relations }>({
+      plugins: [DrizzlePlugin],
+      drizzle: { client: {} as never, getTableConfig: getPgTableConfig, relations },
+    } as never);
+
+    const schemaConfig = getSchemaConfig(builder as never);
+    const cursor = getCursorFormatter([events.createdAt, events.id], schemaConfig)(cursorValues);
+
+    const query = drizzleCursorConnectionQuery({
+      args: { first: 3, after: cursor },
+      ctx: {},
+      orderBy: { createdAt: 'desc', id: 'desc' },
+      config: schemaConfig,
+      table: schemaConfig.relations.events,
+    });
+
+    // the filter is only as good as the SQL drizzle builds from it, so compile it
+    const db = drizzle({
+      client: postgres('postgresql://pothos:pothos@localhost:5455/pothos'),
+      relations,
+    });
+
+    return db.query.events.findMany({ where: query.where as {} }).toSQL();
+  }
+
+  it('keeps the equality clause when the cursor value is a Date', async () => {
+    const createdAt = new Date('2026-08-20T12:00:00.086Z');
+    const { sql, params } = await whereSQLForCursor({ createdAt, id: BigInt(12) });
+
+    // drizzle reads a bare Date as a nested filter and drops the clause, which
+    // leaves `created_at < $1 or id < $2` -- a filter that walks rows it should
+    // not, and skips rows it should return
+    expect(sql).toMatch(/"created_at" < \$1.*"created_at" = \$2.*"id" < \$3/s);
+    // the timestamp codec renders the Date, and both copies have to survive it
+    expect(params).toEqual([createdAt.toISOString(), createdAt.toISOString(), BigInt(12)]);
+  });
+
+  it('keeps comparing against null cursor values with is null', async () => {
+    const { sql } = await whereSQLForCursor({ createdAt: null, id: BigInt(12) });
+
+    expect(sql).toMatch(/"created_at" is null.*"id" < \$/s);
+  });
+});


### PR DESCRIPTION
Follow up to #1651, reported from a run against Postgres 17.11.

## What breaks

Ordering a connection by a timestamp column returns the wrong rows. With 12 rows sharing a millisecond and `{ createdAt: 'desc', id: 'desc' }`, `first: 3` walks all 12 instead of 3.

The keyset filter should be:

```sql
created_at < $1 OR (created_at = $2 AND id < $3)
```

What actually reached Postgres:

```sql
created_at < $1 OR id < $2
```

Those are two unrelated conditions, not a keyset comparison. Rows outside the page come back, and a newer row with a smaller id is returned as though it were older.

## Cause

The equality half was written with drizzle's `{ column: value }` shorthand. `relationsFieldFilterToSQL` treats any object value as a nested filter rather than a comparison:

```js
if (typeof filter !== "object" || is(filter, Placeholder)) return eq(column, filter);
const entries = Object.entries(filter);
if (!entries.length) return void 0;
```

`Object.entries(new Date())` is `[]`, so the clause returns `undefined` and disappears. No error. `null` hit the same branch and threw, which is why it was already special cased; `Date` fails silently instead.

This only became reachable when compound cursors started carrying tagged values. Before that, JSON serialization handed the filter a date *string*, and a string is not an object, so drizzle built the comparison correctly by accident. Single column orderings never emit an equality clause, and expression orderings build their SQL through `RAW`, so neither path was affected.

## Fix

Name the operator instead of relying on the shorthand:

```diff
-if (operator === 'eq') {
-  return isNullish ? { [entry.key]: { isNull: true } } : { [entry.key]: value };
+if (operator === 'eq' && isNullish) {
+  return { [entry.key]: { isNull: true } };
 }
 return { [entry.key]: { [operator]: value } };
```

The shorthand is gone entirely rather than special cased for `Date`, so bytea, array, and json columns cannot reach it either. Arrays would have crashed on `operators['0']` rather than compiling away.

## Tests

Two tests in `cursor-values.test.ts` build a filter through `drizzleCursorConnectionQuery` and compile it with `.toSQL()`. Asserting the shape of the filter object would have passed on the broken code, since the object looked right and drizzle discarded it. Verified red before the fix:

```
- expected: /"created_at" < \$1.*"created_at" = \$2.*"id" < \$3/
- actual:   where (("d0"."created_at" < $1) or ("d0"."id" < $2))
```

The 16 unrelated test file failures in the drizzle suite are pre existing, from `@pothos/plugin-errors` resolving against an unbuilt workspace. Same count before and after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHUkipCNUgbk6gsm38dkAb