### PR TITLE
chore(plugin-prisma): accept generator-helper 8.x and document Prisma 8

### DIFF
--- a/.changeset/prisma-8-compat.md
+++ b/.changeset/prisma-8-compat.md
@@ -1,0 +1,8 @@
+---
+"@pothos/plugin-prisma": patch
+"@pothos/plugin-prisma-utils": patch
+---
+
+Accept `@prisma/generator-helper` 8.x alongside 7.x, and document how Prisma 8 relates to this plugin.
+
+Prisma 8 (`prisma@latest`) is Prisma Next, a contract-first rewrite with its own client and no `schema.prisma` generators or `@prisma/client`, so it is not something this plugin can target. Prisma ORM 7 continues to be maintained on Prisma's `v7` branch, and the plugin is verified against that branch's current builds; the dependency range is widened so a future 8.x release of the classic generator packages does not install a second copy of `@prisma/generator-helper`.

--- a/packages/plugin-prisma-utils/package.json
+++ b/packages/plugin-prisma-utils/package.json
@@ -47,7 +47,7 @@
     "seed": "tsx prisma/seed.ts"
   },
   "dependencies": {
-    "@prisma/generator-helper": "^7.7.0"
+    "@prisma/generator-helper": "^7.7.0 || ^8.0.0"
   },
   "peerDependencies": {
     "@pothos/core": "*",

--- a/packages/plugin-prisma/README.md
+++ b/packages/plugin-prisma/README.md
@@ -144,6 +144,19 @@ so we need a separate to handle the second `posts` relation.
 yarn add @pothos/plugin-prisma
 ```
 
+### Prisma versions
+
+This plugin is built on Prisma ORM's `@prisma/client` and its `prisma generate` generator API. It
+works with Prisma ORM 7 (and earlier versions), which Prisma continues to maintain on the
+[`v7` branch](https://github.com/prisma/prisma/tree/v7).
+
+Prisma 8 (`prisma@latest`, currently a release candidate) is
+[Prisma Next](https://github.com/prisma/prisma), a from-scratch rewrite with a different client and
+no `schema.prisma` generators or `@prisma/client`. It is a different ORM rather than an upgrade, and
+this plugin does not target it. If you use this plugin, keep `prisma` and `@prisma/client` on `^7`,
+or install the [`@prisma/prisma7`](https://www.npmjs.com/package/@prisma/prisma7) CLI wrapper if
+you need Prisma 8 alongside a Prisma ORM 7 project.
+
 ## Setup
 
 This plugin requires a little more setup than other plugins because it integrates with the prisma to

--- a/packages/plugin-prisma/package.json
+++ b/packages/plugin-prisma/package.json
@@ -64,7 +64,7 @@
     "provenance": true
   },
   "dependencies": {
-    "@prisma/generator-helper": "^7.7.0"
+    "@prisma/generator-helper": "^7.7.0 || ^8.0.0"
   },
   "prisma": {
     "seed": "node prisma/seed.mjs"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -845,7 +845,7 @@ importers:
   packages/plugin-prisma:
     dependencies:
       '@prisma/generator-helper':
-        specifier: ^7.7.0
+        specifier: ^7.7.0 || ^8.0.0
         version: 7.7.0
       graphql:
         specifier: ^17.0.1
@@ -894,7 +894,7 @@ importers:
   packages/plugin-prisma-utils:
     dependencies:
       '@prisma/generator-helper':
-        specifier: ^7.7.0
+        specifier: ^7.7.0 || ^8.0.0
         version: 7.7.0
       graphql:
         specifier: ^17.0.1

--- a/website/content/docs/plugins/prisma/setup.mdx
+++ b/website/content/docs/plugins/prisma/setup.mdx
@@ -3,9 +3,25 @@ title: Setup
 description: Setting up the Prisma plugin
 ---
 
+import { Callout } from 'fumadocs-ui/components/callout';
+
 ```package-install
 npm install --save @pothos/plugin-prisma
 ```
+
+<Callout type="info" title="Prisma versions">
+  This plugin is built on Prisma ORM's `@prisma/client` and its `prisma generate` generator API. It
+  works with Prisma ORM 7 (and earlier versions), which Prisma continues to maintain on the
+  [`v7` branch](https://github.com/prisma/prisma/tree/v7).
+
+  Prisma 8 (`prisma@latest`, currently a release candidate) is
+  [Prisma Next](https://github.com/prisma/prisma), a from-scratch rewrite with a different client
+  and no `schema.prisma` generators or `@prisma/client`. It is a different ORM rather than an
+  upgrade, and this plugin does not target it. If you use this plugin, keep `prisma` and
+  `@prisma/client` on `^7`, or install the
+  [`@prisma/prisma7`](https://www.npmjs.com/package/@prisma/prisma7) CLI wrapper if you need Prisma
+  8 alongside a Prisma ORM 7 project.
+</Callout>
 
 ## Setup
 


### PR DESCRIPTION
## Summary

Investigated what "Prisma 8 support" means for the Prisma plugins. Short version: Prisma 8 is not a version bump the plugin can follow, and nothing in the plugin needs to change to keep working with the ORM it targets.

- **Prisma 8 (`prisma@latest`, currently `8.0.0-rc.10`) is [Prisma Next](https://github.com/prisma/prisma)** — a from-scratch, contract-first rewrite with its own `db.orm.<Model>` client. It has no `schema.prisma` generators, no DMMF, and no `@prisma/client`; the unified `prisma@8` CLI has no `generate` command at all (`CLI.UNKNOWN_COMMAND`). There is nothing for `prisma-pothos-types` to plug into.
- **Prisma ORM 7 (`@prisma/client`, generators) continues on the [`v7` branch](https://github.com/prisma/prisma/tree/v7)**, published under the `prev` dist-tag, with a new `@prisma/prisma7` CLI wrapper and `prisma7.config.ts` for running side by side with Prisma 8.
- I ran the whole Prisma-dependent surface of this repo (`plugin-prisma`, `plugin-prisma-utils`, `plugin-scope-auth`, `plugin-with-input`) against the `v7` branch's current dev builds (`8.1.0-dev.1` of `prisma`, `@prisma/client`, `@prisma/generator-helper`, adapters, runtime-utils): generate, typecheck, and tests all pass with no code changes.

## Changes

- Widen `@prisma/generator-helper` to `^7.7.0 || ^8.0.0` in `plugin-prisma` and `plugin-prisma-utils`. The `v7` branch is already publishing `8.x` dev builds of the classic generator packages; without this, an 8.x classic release would install a second copy of `generator-helper` next to the user's.
- Add a "Prisma versions" note to the plugin README and the website setup page explaining the above and pointing users to `^7` / `@prisma/prisma7`.
- Changeset (patch for both packages).

Dev dependencies are left on stable `^7.7.0`; the `8.1.0-dev.1` verification was local only.

## Test plan

- [x] `plugin-prisma`: generate, `tsc`, 89/89 tests — against both `7.7.0` and `8.1.0-dev.1`
- [x] `plugin-scope-auth` (108/108) and `plugin-with-input` (3/3) — against `8.1.0-dev.1`
- [x] `plugin-prisma-utils`: generate + `tsc` against both; DB tests need Postgres, so relying on CI
- [x] `biome check` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbY4nojGaaVYDzhr21QfFw
