### PR TITLE
fix(plugin-validation): report issues from every sibling input field

### DIFF
--- a/.changeset/validation-sibling-issues.md
+++ b/.changeset/validation-sibling-issues.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-validation': patch
+---
+
+Report validation issues from every field of an input object instead of stopping after the first field that fails

--- a/.changeset/validation-sibling-issues.md
+++ b/.changeset/validation-sibling-issues.md
@@ -2,4 +2,4 @@
 '@pothos/plugin-validation': patch
 ---
 
-Report validation issues from every field of an input object instead of stopping after the first field that fails
+Report validation issues from every field of an input object instead of stopping after the first field that fails. When the type-level schemas for a field fail, the field-level schemas for that field are no longer run against the failed result, and list-level schemas now wait for async type-level schemas of list items to complete.

--- a/.changeset/validation-sibling-issues.md
+++ b/.changeset/validation-sibling-issues.md
@@ -2,4 +2,4 @@
 '@pothos/plugin-validation': patch
 ---
 
-Report validation issues from every field of an input object instead of stopping after the first field that fails. When the type-level schemas for a field fail, the field-level schemas for that field are no longer run against the failed result, and list-level schemas now wait for async type-level schemas of list items to complete.
+Report validation issues from every field of an input object instead of stopping after the first field that fails. When the type-level schemas for a field fail, the field-level schemas for that field are no longer run against the failed result, list-level schemas now wait for async type-level schemas of list items to complete, type-level schemas still run for list items whose nested fields passed when a sibling item failed, and async nested field failures inside list items no longer reject with a promise chaining error.

--- a/packages/plugin-validation/src/utils.ts
+++ b/packages/plugin-validation/src/utils.ts
@@ -170,6 +170,9 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
       // un-transformed) data. This flag is scoped to the current field so that
       // sibling fields are still validated and their issues are reported together.
       let hasIssues = false;
+      // For list fields, nested failures are tracked per item so that the type schemas
+      // still run for the items that passed nested validation.
+      const failedItems = new Set<string>();
 
       function addFieldIssues(indices: number[] = []) {
         const add = addIssues([...fieldPath, ...indices]);
@@ -200,6 +203,7 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
               const promise = completeValue(result, (newVal) => {
                 if (newVal.issues) {
                   hasIssues = true;
+                  failedItems.add(indices.join('.'));
                   issues.push(...newVal.issues);
                 } else {
                   newList[i] = newVal.value;
@@ -237,7 +241,7 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
       const promise = completeValue(
         fieldPromises.length ? Promise.all(fieldPromises) : null,
         () => {
-          if (field.value === null || hasIssues) {
+          if (field.value === null) {
             return;
           }
 
@@ -247,7 +251,7 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
               mapped[fieldName],
               field.listDepth,
               (val, i, arr, indices) => {
-                if (val == null) {
+                if (val == null || failedItems.has(indices.join('.'))) {
                   return val;
                 }
 
@@ -274,6 +278,10 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
                 mapped[fieldName] = finalVal;
               });
             });
+          }
+
+          if (hasIssues) {
+            return;
           }
 
           return completeValue(

--- a/packages/plugin-validation/src/utils.ts
+++ b/packages/plugin-validation/src/utils.ts
@@ -162,10 +162,23 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
 
     map.forEach((field, fieldName) => {
       const fieldVal = (obj as Record<string, unknown>)[fieldName];
+      const fieldPath = [...path, fieldName];
       const fieldPromises: PromiseLike<unknown>[] = [];
-      // Tracks whether a nested input object for this field failed validation, so
-      // that the field's own schemas are skipped without affecting sibling fields.
-      let nestedIssues = false;
+      // Validation for a field runs as a chain: nested input objects, then the schemas
+      // of the field's type, then the field's own schemas. Once any stage reports an
+      // issue, later stages are skipped because they would run against invalid (or
+      // un-transformed) data. This flag is scoped to the current field so that
+      // sibling fields are still validated and their issues are reported together.
+      let hasIssues = false;
+
+      function addFieldIssues(indices: number[] = []) {
+        const add = addIssues([...fieldPath, ...indices]);
+
+        return (newIssues: readonly StandardSchemaV1.Issue[]) => {
+          hasIssues = true;
+          add(newIssues);
+        };
+      }
 
       if (fieldVal === null || fieldVal === undefined) {
         mapped[fieldName] = fieldVal;
@@ -182,16 +195,11 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
                 return val;
               }
 
-              const result = mapObject(
-                val,
-                field.fields.map!,
-                [...path, fieldName, ...indices],
-                ...args,
-              );
+              const result = mapObject(val, field.fields.map!, [...fieldPath, ...indices], ...args);
 
               const promise = completeValue(result, (newVal) => {
                 if (newVal.issues) {
-                  nestedIssues = true;
+                  hasIssues = true;
                   issues.push(...newVal.issues);
                 } else {
                   newList[i] = newVal.value;
@@ -209,15 +217,10 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
           );
         } else {
           const promise = completeValue(
-            mapObject(
-              fieldVal as Record<string, unknown>,
-              field.fields.map,
-              [...path, fieldName],
-              ...args,
-            ),
+            mapObject(fieldVal as Record<string, unknown>, field.fields.map, fieldPath, ...args),
             (newVal) => {
               if (newVal.issues) {
-                nestedIssues = true;
+                hasIssues = true;
                 issues.push(...newVal.issues);
               } else {
                 mapped[fieldName] = newVal.value;
@@ -234,54 +237,60 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
       const promise = completeValue(
         fieldPromises.length ? Promise.all(fieldPromises) : null,
         () => {
-          if (field.value !== null && !nestedIssues) {
-            if (field.isList) {
-              const list = mapListValue(
-                mapped[fieldName],
-                field.listDepth,
-                (val, i, arr, indices) => {
-                  if (val != null) {
-                    const result = mapType(
-                      val,
-                      field,
-                      addIssues([...path, fieldName, ...indices]),
-                      ...args,
-                    );
+          if (field.value === null || hasIssues) {
+            return;
+          }
 
-                    if (isThenable(result)) {
-                      promises.push(
-                        completeValue(result, (newVal) => {
-                          arr[i] = newVal;
-                        }) as Promise<unknown>,
-                      );
-                    }
-
-                    return result;
-                  }
-
+          if (field.isList) {
+            const itemPromises: PromiseLike<unknown>[] = [];
+            const list = mapListValue(
+              mapped[fieldName],
+              field.listDepth,
+              (val, i, arr, indices) => {
+                if (val == null) {
                   return val;
-                },
-              );
+                }
+
+                const result = mapType(val, field, addFieldIssues(indices), ...args);
+
+                if (isThenable(result)) {
+                  itemPromises.push(
+                    completeValue(result, (newVal) => {
+                      arr[i] = newVal;
+                    }) as Promise<unknown>,
+                  );
+                }
+
+                return result;
+              },
+            );
+
+            return completeValue(itemPromises.length ? Promise.all(itemPromises) : null, () => {
+              if (hasIssues) {
+                return;
+              }
+
+              return completeValue(mapField(list, field, addFieldIssues(), ...args), (finalVal) => {
+                mapped[fieldName] = finalVal;
+              });
+            });
+          }
+
+          return completeValue(
+            mapType(mapped[fieldName], field, addFieldIssues(), ...args),
+            (newVal) => {
+              if (hasIssues) {
+                return;
+              }
 
               return completeValue(
-                mapField(list, field, addIssues([...path, fieldName]), ...args),
+                mapField(newVal, field, addFieldIssues(), ...args),
                 (finalVal) => {
                   mapped[fieldName] = finalVal;
                 },
               );
-            }
-
-            return completeValue(
-              mapType(mapped[fieldName], field, addIssues([...path, fieldName]), ...args),
-              (newVal) =>
-                completeValue(
-                  mapField(newVal, field, addIssues([...path, fieldName]), ...args),
-                  (newVal) => {
-                    mapped[fieldName] = newVal;
-                  },
-                ),
-            );
-          }
+            },
+          );
         },
       );
 

--- a/packages/plugin-validation/src/utils.ts
+++ b/packages/plugin-validation/src/utils.ts
@@ -164,14 +164,8 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
       const fieldVal = (obj as Record<string, unknown>)[fieldName];
       const fieldPath = [...path, fieldName];
       const fieldPromises: PromiseLike<unknown>[] = [];
-      // Validation for a field runs as a chain: nested input objects, then the schemas
-      // of the field's type, then the field's own schemas. Once any stage reports an
-      // issue, later stages are skipped because they would run against invalid (or
-      // un-transformed) data. This flag is scoped to the current field so that
-      // sibling fields are still validated and their issues are reported together.
+      // per-field, so a failure only skips the remaining schemas for this field
       let hasIssues = false;
-      // For list fields, nested failures are tracked per item so that the type schemas
-      // still run for the items that passed nested validation.
       const failedItems = new Set<string>();
 
       function addFieldIssues(indices: number[] = []) {

--- a/packages/plugin-validation/src/utils.ts
+++ b/packages/plugin-validation/src/utils.ts
@@ -199,11 +199,13 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
                   hasIssues = true;
                   failedItems.add(indices.join('.'));
                   issues.push(...newVal.issues);
-                } else {
-                  newList[i] = newVal.value;
+
+                  return val;
                 }
 
-                return newList[i];
+                newList[i] = newVal.value;
+
+                return newVal.value;
               });
 
               if (isThenable(promise)) {

--- a/packages/plugin-validation/src/utils.ts
+++ b/packages/plugin-validation/src/utils.ts
@@ -163,6 +163,9 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
     map.forEach((field, fieldName) => {
       const fieldVal = (obj as Record<string, unknown>)[fieldName];
       const fieldPromises: PromiseLike<unknown>[] = [];
+      // Tracks whether a nested input object for this field failed validation, so
+      // that the field's own schemas are skipped without affecting sibling fields.
+      let nestedIssues = false;
 
       if (fieldVal === null || fieldVal === undefined) {
         mapped[fieldName] = fieldVal;
@@ -188,6 +191,7 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
 
               const promise = completeValue(result, (newVal) => {
                 if (newVal.issues) {
+                  nestedIssues = true;
                   issues.push(...newVal.issues);
                 } else {
                   newList[i] = newVal.value;
@@ -213,6 +217,7 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
             ),
             (newVal) => {
               if (newVal.issues) {
+                nestedIssues = true;
                 issues.push(...newVal.issues);
               } else {
                 mapped[fieldName] = newVal.value;
@@ -229,7 +234,7 @@ export function createInputValueMapper<Types extends SchemaTypes, T, Args extend
       const promise = completeValue(
         fieldPromises.length ? Promise.all(fieldPromises) : null,
         () => {
-          if (field.value !== null && !issues.length) {
+          if (field.value !== null && !nestedIssues) {
             if (field.isList) {
               const list = mapListValue(
                 mapped[fieldName],

--- a/packages/plugin-validation/tests/advanced-validation.test.ts
+++ b/packages/plugin-validation/tests/advanced-validation.test.ts
@@ -930,7 +930,7 @@ describe('Advanced Validation', () => {
       expect(result.errors?.map((e) => e.toJSON())).toMatchInlineSnapshot(`
         [
           {
-            "message": "Validation error: enum1: Invalid input, recursive.float: Invalid input, contactInfo.aliases.0: Aliases should be capitalized, contactInfo.name: Name should be capitalized",
+            "message": "Validation error: enum1: Invalid input, recursive.float: Invalid input, odd: number must be odd, contactInfo.aliases.0: Aliases should be capitalized, contactInfo.email: no example.com email addresses, contactInfo.name: Name should be capitalized",
             "path": [
               "exampleField",
             ],

--- a/packages/plugin-validation/tests/error-handling.test.ts
+++ b/packages/plugin-validation/tests/error-handling.test.ts
@@ -282,7 +282,74 @@ describe('Error Handling', () => {
       expect(result.errors?.map((e) => e.toJSON())).toMatchInlineSnapshot(`
         [
           {
-            "message": "Multiple validation errors: user.name: Too small: expected string to have >=5 characters",
+            "message": "Multiple validation errors: user.name: Too small: expected string to have >=5 characters; user.email: Invalid email address",
+            "path": [
+              "testField",
+            ],
+          },
+        ]
+      `);
+    });
+
+    it('reports issues from every sibling field of an input object', async () => {
+      const builder = new SchemaBuilder<{}>({
+        plugins: ['validation'],
+      });
+
+      const ExampleInput = builder.inputType('ExampleInput', {
+        fields: (t) => ({
+          fieldA: t.string({ validate: zod.z.string().max(5) }),
+          fieldB: t.string({ validate: zod.z.string().max(5) }),
+          nested: t.field({
+            type: builder.inputType('NestedInput', {
+              fields: (t) => ({
+                fieldC: t.string({ validate: zod.z.string().max(5) }),
+              }),
+            }),
+          }),
+          fieldD: t.string({ validate: zod.z.string().max(5) }),
+        }),
+      });
+
+      builder.queryType({
+        fields: (t) => ({
+          testField: t.boolean({
+            args: {
+              input: t.arg({ type: ExampleInput, required: true }),
+              other: t.arg.string({ validate: zod.z.string().max(5) }),
+            },
+            resolve: () => true,
+          }),
+        }),
+      });
+
+      const schema = builder.toSchema();
+
+      const query = gql`
+        query {
+          testField(
+            input: {
+              fieldA: "toolong"
+              fieldB: "alsotoolong"
+              nested: { fieldC: "toolong" }
+              fieldD: "toolong"
+            }
+            other: "toolong"
+          )
+        }
+      `;
+
+      const result = await execute({
+        schema,
+        document: query,
+        contextValue: {},
+      });
+
+      expect(result.data?.testField).toBeNull();
+      expect(result.errors?.map((e) => e.toJSON())).toMatchInlineSnapshot(`
+        [
+          {
+            "message": "Validation error: input.fieldA: Too big: expected string to have <=5 characters, input.fieldB: Too big: expected string to have <=5 characters, input.nested.fieldC: Too big: expected string to have <=5 characters, input.fieldD: Too big: expected string to have <=5 characters, other: Too big: expected string to have <=5 characters",
             "path": [
               "testField",
             ],
@@ -449,7 +516,7 @@ describe('Error Handling', () => {
       expect(result.errors?.map((e) => e.toJSON())).toMatchInlineSnapshot(`
         [
           {
-            "message": "Input validation failed: Too small: expected string to have >=2 characters",
+            "message": "Input validation failed: Too small: expected string to have >=2 characters, Too small: expected number to be >=18",
             "path": [
               "testField",
             ],

--- a/packages/plugin-validation/tests/error-handling.test.ts
+++ b/packages/plugin-validation/tests/error-handling.test.ts
@@ -382,6 +382,16 @@ describe('Error Handling', () => {
         validate: zod.z.object({ name: zod.z.string().max(3) }),
       });
 
+      const Entry = builder.inputType('Entry', {
+        fields: (t) => ({
+          name: t.string({ validate: zod.z.string().max(3) }),
+          tag: t.string(),
+        }),
+        validate: zod.z
+          .object({ name: zod.z.string(), tag: zod.z.string() })
+          .refine((v) => v.tag !== 'bad', 'bad tag'),
+      });
+
       const AsyncItem = builder.inputType('AsyncItem', {
         fields: (t) => ({
           name: t.string(),
@@ -408,6 +418,16 @@ describe('Error Handling', () => {
             args: {
               items: t.arg({
                 type: [Item],
+                required: true,
+                validate: zod.z.array(zod.z.object({ name: zod.z.string() })).max(5),
+              }),
+            },
+            resolve: () => true,
+          }),
+          entries: t.boolean({
+            args: {
+              entries: t.arg({
+                type: [Entry],
                 required: true,
                 validate: zod.z.array(zod.z.object({ name: zod.z.string() })).max(5),
               }),
@@ -472,6 +492,30 @@ describe('Error Handling', () => {
             "message": "Validation error: items.1.name: Too big: expected string to have <=3 characters",
             "path": [
               "items",
+            ],
+          },
+        ]
+      `);
+    });
+
+    it('runs type schemas for list items whose nested fields passed', async () => {
+      const result = await execute({
+        schema: createSchema(),
+        document: gql`
+          query {
+            entries(entries: [{ name: "toolong", tag: "ok" }, { name: "ok", tag: "bad" }])
+          }
+        `,
+        contextValue: {},
+      });
+
+      expect(result.data?.entries).toBeNull();
+      expect(result.errors?.map((e) => e.toJSON())).toMatchInlineSnapshot(`
+        [
+          {
+            "message": "Validation error: entries.0.name: Too big: expected string to have <=3 characters, entries.1: bad tag",
+            "path": [
+              "entries",
             ],
           },
         ]

--- a/packages/plugin-validation/tests/error-handling.test.ts
+++ b/packages/plugin-validation/tests/error-handling.test.ts
@@ -392,6 +392,14 @@ describe('Error Handling', () => {
           .refine((v) => v.tag !== 'bad', 'bad tag'),
       });
 
+      const AsyncEntry = builder.inputType('AsyncEntry', {
+        fields: (t) => ({
+          name: t.string({
+            validate: zod.z.string().refine(async (v) => v !== 'bad', 'bad name'),
+          }),
+        }),
+      });
+
       const AsyncItem = builder.inputType('AsyncItem', {
         fields: (t) => ({
           name: t.string(),
@@ -431,6 +439,12 @@ describe('Error Handling', () => {
                 required: true,
                 validate: zod.z.array(zod.z.object({ name: zod.z.string() })).max(5),
               }),
+            },
+            resolve: () => true,
+          }),
+          asyncEntries: t.boolean({
+            args: {
+              entries: t.arg({ type: [AsyncEntry], required: true }),
             },
             resolve: () => true,
           }),
@@ -516,6 +530,30 @@ describe('Error Handling', () => {
             "message": "Validation error: entries.0.name: Too big: expected string to have <=3 characters, entries.1: bad tag",
             "path": [
               "entries",
+            ],
+          },
+        ]
+      `);
+    });
+
+    it('reports async nested field failures inside list items', async () => {
+      const result = await execute({
+        schema: createSchema(),
+        document: gql`
+          query {
+            asyncEntries(entries: [{ name: "ok" }, { name: "bad" }])
+          }
+        `,
+        contextValue: {},
+      });
+
+      expect(result.data?.asyncEntries).toBeNull();
+      expect(result.errors?.map((e) => e.toJSON())).toMatchInlineSnapshot(`
+        [
+          {
+            "message": "Validation error: entries.1.name: bad name",
+            "path": [
+              "asyncEntries",
             ],
           },
         ]

--- a/packages/plugin-validation/tests/error-handling.test.ts
+++ b/packages/plugin-validation/tests/error-handling.test.ts
@@ -359,6 +359,165 @@ describe('Error Handling', () => {
     });
   });
 
+  describe('validation chain per field', () => {
+    function createSchema() {
+      const builder = new SchemaBuilder<{}>({
+        plugins: ['validation'],
+      });
+
+      const Pair = builder.inputType('Pair', {
+        fields: (t) => ({
+          a: t.string(),
+          b: t.string(),
+        }),
+        validate: zod.z
+          .object({ a: zod.z.string(), b: zod.z.string() })
+          .refine((v) => v.a === v.b, 'a must equal b'),
+      });
+
+      const Item = builder.inputType('Item', {
+        fields: (t) => ({
+          name: t.string(),
+        }),
+        validate: zod.z.object({ name: zod.z.string().max(3) }),
+      });
+
+      const AsyncItem = builder.inputType('AsyncItem', {
+        fields: (t) => ({
+          name: t.string(),
+        }),
+        validate: zod.z
+          .object({ name: zod.z.string() })
+          .refine(async (v) => v.name !== 'bad', 'bad item'),
+      });
+
+      builder.queryType({
+        fields: (t) => ({
+          pair: t.boolean({
+            args: {
+              pair: t.arg({
+                type: Pair,
+                required: true,
+                validate: zod.z.object({ a: zod.z.string().max(1) }),
+              }),
+              other: t.arg.string({ validate: zod.z.string().max(1) }),
+            },
+            resolve: () => true,
+          }),
+          items: t.boolean({
+            args: {
+              items: t.arg({
+                type: [Item],
+                required: true,
+                validate: zod.z.array(zod.z.object({ name: zod.z.string() })).max(5),
+              }),
+            },
+            resolve: () => true,
+          }),
+          asyncItems: t.boolean({
+            args: {
+              items: t.arg({
+                type: [AsyncItem],
+                required: true,
+                validate: zod.z.array(zod.z.object({ name: zod.z.string() })).max(5),
+              }),
+            },
+            resolve: () => true,
+          }),
+        }),
+      });
+
+      return builder.toSchema();
+    }
+
+    it('skips field schemas when the type schemas for the same field fail', async () => {
+      const result = await execute({
+        schema: createSchema(),
+        document: gql`
+          query {
+            pair(pair: { a: "xx", b: "yy" }, other: "zz")
+          }
+        `,
+        contextValue: {},
+      });
+
+      expect(result.data?.pair).toBeNull();
+      expect(result.errors?.map((e) => e.toJSON())).toMatchInlineSnapshot(`
+        [
+          {
+            "message": "Validation error: pair: a must equal b, other: Too big: expected string to have <=1 characters",
+            "path": [
+              "pair",
+            ],
+          },
+        ]
+      `);
+    });
+
+    it('skips list field schemas when the type schemas for a list item fail', async () => {
+      const result = await execute({
+        schema: createSchema(),
+        document: gql`
+          query {
+            items(items: [{ name: "ok" }, { name: "toolong" }])
+          }
+        `,
+        contextValue: {},
+      });
+
+      expect(result.data?.items).toBeNull();
+      expect(result.errors?.map((e) => e.toJSON())).toMatchInlineSnapshot(`
+        [
+          {
+            "message": "Validation error: items.1.name: Too big: expected string to have <=3 characters",
+            "path": [
+              "items",
+            ],
+          },
+        ]
+      `);
+    });
+
+    it('waits for async type schemas of list items before running list field schemas', async () => {
+      const schema = createSchema();
+
+      const valid = await execute({
+        schema,
+        document: gql`
+          query {
+            asyncItems(items: [{ name: "ok" }, { name: "fine" }])
+          }
+        `,
+        contextValue: {},
+      });
+
+      expect(valid.errors).toBeUndefined();
+      expect(valid.data?.asyncItems).toBe(true);
+
+      const invalid = await execute({
+        schema,
+        document: gql`
+          query {
+            asyncItems(items: [{ name: "ok" }, { name: "bad" }])
+          }
+        `,
+        contextValue: {},
+      });
+
+      expect(invalid.data?.asyncItems).toBeNull();
+      expect(invalid.errors?.map((e) => e.toJSON())).toMatchInlineSnapshot(`
+        [
+          {
+            "message": "Validation error: items.1: bad item",
+            "path": [
+              "asyncItems",
+            ],
+          },
+        ]
+      `);
+    });
+  });
+
   describe('edge cases', () => {
     it('handles validationError handler that throws an error', async () => {
       const builder = new SchemaBuilder<{

--- a/packages/plugin-validation/tests/utils.test.ts
+++ b/packages/plugin-validation/tests/utils.test.ts
@@ -945,7 +945,7 @@ describe('createInputValueMapper', () => {
       });
     });
 
-    it('stops processing subsequent fields after first validation error', () => {
+    it('continues processing subsequent fields after a validation error', () => {
       const mapping = new Map<string, TestInputFieldMapping>([
         ['email', createScalarMapping('email')],
         ['age', createScalarMapping('positive')],
@@ -981,10 +981,13 @@ describe('createInputValueMapper', () => {
       const result = mapper({ email: 'invalid', age: -5 });
 
       expect(emailProcessed).toBe(true);
-      expect(ageProcessed).toBe(false);
+      expect(ageProcessed).toBe(true);
 
       expect(result).toEqual({
-        issues: [{ message: 'Invalid email format', path: ['email'] }],
+        issues: [
+          { message: 'Invalid email format', path: ['email'] },
+          { message: 'Must be positive', path: ['age'] },
+        ],
       });
     });
 


### PR DESCRIPTION
Fixes #1656

## Problem

When two sibling fields of an input object both fail their `validate` schemas, only the first field's issues are reported. The docs (`validation.mdx` "Validation execution order") promise the opposite: *"Validations for separate fields or arguments are executed in parallel, and their results are merged into a single set of issues."*

In `createInputValueMapper`, the guard `if (field.value !== null && !issues.length)` was intended to skip a field's own type/field schemas when that field's *nested* input object had already failed. But `issues` is the accumulator shared by every field of the object being mapped, so as soon as one field pushed an issue, every later sibling (including sibling top-level args) was skipped entirely. The guard has been there since the first WIP commit of the plugin; the unit test asserting it (`stops processing subsequent fields after first validation error`) was added later in the bulk "Add tests and docs" commit and captured the behaviour rather than a design decision.

## Fix

Each field's validation is a chain: nested input objects → the schemas of the field's type → the field's own schemas. A per-field `hasIssues` flag now gates each stage, so a failure stops the rest of *that field's* chain (later stages would otherwise run against invalid / un-transformed data) without affecting sibling fields. For list fields, nested failures are tracked per item, so an item that fails nested validation doesn't suppress the type-level schemas of the other items; only the list-level schemas are skipped.

This also fixes two pre-existing problems in the same chain that were previously masked by the short-circuit:

- When a field's type-level schemas failed, `mapField` still ran the field-level schemas against the `null` result, adding a spurious `Invalid input: expected object, received null` issue.
- For list fields, the list-level schemas ran before async type-level schemas for the items had resolved, so they validated an array of pending promises. An all-valid list with an async input-type `validate` plus an arg-level `validate` always failed with `expected string, received undefined`. Item schemas are now awaited before the list-level schemas run.
- When a list item's nested input object failed validation *asynchronously*, the completion callback returned the still-pending promise for that slot, so the promise self-resolved and rejected with `TypeError: Chaining cycle detected for promise` instead of the validation error.

## Tests

- Sibling fields, a nested input object, a trailing field, and a sibling arg all invalid → all five issues reported.
- Type-level failure on a field no longer produces the spurious null issue; the sibling arg is still reported.
- Sync and async type-level failures on list items; all-valid async list now passes.
- List where item 0 fails a nested field schema and item 1 fails its type-level schema → both reported.
- Async nested field failure inside a list item → reported as a validation error, not a TypeError.
- `utils.test.ts`: `stops processing subsequent fields after first validation error` rewritten to assert both fields are processed.
- Three existing inline snapshots that had been capturing truncated issue lists now include the full set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbY4nojGaaVYDzhr21QfFw
