### PR TITLE
fix(plugin-federation): add .js extension to the @apollo/subgraph subpath import

### DIFF
--- a/.changeset/federation-esm-subpath-extension.md
+++ b/.changeset/federation-esm-subpath-extension.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-federation': patch
+---
+
+Add the `.js` extension to the `@apollo/subgraph/dist/types` import so the published ESM build loads on Node. `@apollo/subgraph` ships no `exports` map and Node's ESM resolver does not guess extensions, so importing `@pothos/plugin-federation` from an ESM package failed with `ERR_MODULE_NOT_FOUND` on 4.4.3 through 4.5.0. CJS was unaffected.

--- a/packages/plugin-federation/src/schema-builder.ts
+++ b/packages/plugin-federation/src/schema-builder.ts
@@ -1,5 +1,5 @@
 import { printSubgraphSchema } from '@apollo/subgraph';
-import { EntityType, entitiesField, serviceField } from '@apollo/subgraph/dist/types';
+import { EntityType, entitiesField, serviceField } from '@apollo/subgraph/dist/types.js';
 import SchemaBuilder, { type MaybePromise, type SchemaTypes } from '@pothos/core';
 import {
   GraphQLList,

--- a/packages/plugin-federation/tests/esm-imports.test.ts
+++ b/packages/plugin-federation/tests/esm-imports.test.ts
@@ -1,0 +1,63 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+
+const require = createRequire(import.meta.url);
+const srcDir = join(import.meta.dirname, '../src');
+
+function sourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) =>
+    entry.isDirectory() ? sourceFiles(join(dir, entry.name)) : [join(dir, entry.name)],
+  );
+}
+
+function packageSubpathImports(file: string) {
+  const specifiers = [...readFileSync(file, 'utf8').matchAll(/(?:from|import\()\s*'([^']+)'/g)].map(
+    ([, specifier]) => specifier,
+  );
+
+  return specifiers.filter((specifier) => {
+    if (specifier.startsWith('.') || specifier.startsWith('node:')) {
+      return false;
+    }
+
+    const segments = specifier.split('/');
+
+    return specifier.startsWith('@') ? segments.length > 2 : segments.length > 1;
+  });
+}
+
+describe('esm imports', () => {
+  // Node's ESM resolver never appends extensions to package subpaths, so a subpath that isn't
+  // remapped by the target package's `exports` map has to name a file that exists. Biome's
+  // useImportExtensions rule only covers relative imports, so nothing else catches this.
+  it('uses subpaths that resolve without extension guessing', () => {
+    for (const file of sourceFiles(srcDir)) {
+      for (const specifier of packageSubpathImports(file)) {
+        const segments = specifier.split('/');
+        const name = specifier.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0];
+        const subpath = specifier.slice(name.length + 1);
+
+        let manifestPath: string;
+
+        try {
+          manifestPath = require.resolve(`${name}/package.json`);
+        } catch {
+          // package.json isn't reachable, which means an `exports` map governs the subpath
+          continue;
+        }
+
+        const manifest = JSON.parse(readFileSync(manifestPath, 'utf8')) as { exports?: unknown };
+
+        if (manifest.exports) {
+          continue;
+        }
+
+        expect(
+          existsSync(join(dirname(manifestPath), subpath)) ? null : specifier,
+          `${specifier} in ${file} does not resolve to a file`,
+        ).toBeNull();
+      }
+    }
+  });
+});


### PR DESCRIPTION
Fixes #1661.

## The bug

`packages/plugin-federation/src/schema-builder.ts` imports `@apollo/subgraph/dist/types` with no file extension. Node's ESM resolver does not guess extensions for package subpaths, and `@apollo/subgraph` publishes no `exports` map that would remap it, so importing `@pothos/plugin-federation` from an ESM package throws at startup on 4.4.3 through 4.5.0:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../@apollo/subgraph/dist/types'
imported from .../@pothos/plugin-federation/esm/schema-builder.js
Did you mean to import "@apollo/subgraph/dist/types.js"?
```

CJS is unaffected — `require()` still resolves extensions, so `lib/` works on both versions.

## Why it regressed

Up to 4.4.2 the ESM build appended extensions via `scripts/esm-transformer.ts`, which resolved bare subpaths through `require.resolve` and rewrote them. The TypeScript 7 migration (a32b270) replaced that step with extensions written in source and enforced by biome's `useImportExtensions`. That rule only covers relative imports, so the relative specifiers in this file were updated and the bare subpath on line 2 was left as it was.

## The fix

One character of behavior: `@apollo/subgraph/dist/types` → `@apollo/subgraph/dist/types.js`. `dist/types.js` and its sibling `dist/types.d.ts` both exist in the published package, so CJS, ESM, and type resolution all keep working.

## Other occurrences

I swept every `packages/*/src` tree for non-relative subpath specifiers. `@apollo/subgraph/dist/types` was the only one. The other subpath imports in the repo are all in `examples/` and `website/` (`next/*`, `drizzle-orm/*`, `@apollo/server/*`, `fumadocs-*`), which are not published and whose targets all ship `exports` maps.

## Regression guard

Added `packages/plugin-federation/tests/esm-imports.test.ts`. For each package subpath imported from `src`, it reads the target package's manifest: if there is no `exports` map to remap the subpath, the specifier has to name a file that exists. This is the check biome's rule does not do.

## Verification

- The reproduction from the issue fails on the pre-fix build with the exact error above, and loads cleanly after: `node --input-type=module -e "await import('./esm/index.js')"` → OK; `node -e "require('./lib/index.js')"` → OK.
- The new test fails when the extension is removed and passes with it.
- `pnpm turbo run build --filter='@pothos/plugin-federation...'` succeeds; the built `esm/` and `lib/` output both carry `dist/types.js`.
- `pnpm vitest --run` in `packages/plugin-federation`: 3 files, 9 tests passed, no type errors.
- `pnpm biome check` clean.

One note on running the suite locally: the `superGraph` test in `tests/index.test.ts` starts local HTTP servers and fails with a `405 Method Not Allowed` if an HTTP proxy is set in the environment. Unsetting the proxy variables makes it pass. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1YyNQHKx3pmp3zS9f9CMw

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1YyNQHKx3pmp3zS9f9CMw)_