### PR TITLE
fix(plugin-drizzle): plan fragments on implemented interfaces, export DrizzleRef types

### DIFF
--- a/.changeset/drizzle-interface-fragment-select.md
+++ b/.changeset/drizzle-interface-fragment-select.md
@@ -1,0 +1,5 @@
+---
+'@pothos/plugin-drizzle': patch
+---
+
+Plan fragments on interfaces implemented by a Drizzle object against the object, so `select` declared on the interface's fields is merged into the query instead of being skipped and loaded separately. Export the `DrizzleInterfaceRef` and `DrizzleRef` types from the package index.

--- a/.changeset/drizzle-interface-fragment-select.md
+++ b/.changeset/drizzle-interface-fragment-select.md
@@ -2,4 +2,4 @@
 '@pothos/plugin-drizzle': patch
 ---
 
-Plan fragments on interfaces implemented by a Drizzle object against the object, so `select` declared on the interface's fields is merged into the query instead of being skipped and loaded separately. Export the `DrizzleInterfaceRef` and `DrizzleRef` types from the package index.
+Plan fragments on interfaces implemented by a Drizzle object against the object, so `select` declared on the interface's fields is merged into the query instead of being skipped and loaded separately. Export `DrizzleInterfaceRef` and the `DrizzleRef` type from the package index.

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -740,5 +740,5 @@ export interface DrizzleGraphQLInputExtensions {
   inputType: 'insert' | 'filters' | 'orderBy' | 'update';
 }
 
-export type { DrizzleInterfaceRef, DrizzleRef } from './interface-ref.js';
+export { DrizzleInterfaceRef, type DrizzleRef } from './interface-ref.js';
 export { DrizzleObjectRef } from './object-ref.js';

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -740,4 +740,5 @@ export interface DrizzleGraphQLInputExtensions {
   inputType: 'insert' | 'filters' | 'orderBy' | 'update';
 }
 
+export type { DrizzleInterfaceRef, DrizzleRef } from './interface-ref.js';
 export { DrizzleObjectRef } from './object-ref.js';

--- a/packages/plugin-drizzle/src/utils/map-query.ts
+++ b/packages/plugin-drizzle/src/utils/map-query.ts
@@ -230,6 +230,39 @@ function resolveIndirectInclude(
   }
 }
 
+// The type to plan a fragment's selections against, or null when the fragment
+// cannot apply to `type`. A fragment on an interface the object implements is
+// planned against the object, whose field map already carries the interface
+// fields and their `select` extensions.
+function typeForFragment(
+  type: GraphQLInterfaceType | GraphQLObjectType,
+  condition: GraphQLNamedType,
+): GraphQLInterfaceType | GraphQLObjectType | null {
+  if (isObjectType(type)) {
+    if (condition.name === type.name) {
+      return type;
+    }
+
+    if (
+      isInterfaceType(condition) &&
+      type.getInterfaces().some((iface) => iface.name === condition.name)
+    ) {
+      return type;
+    }
+
+    return null;
+  }
+
+  if (
+    (isObjectType(condition) || isInterfaceType(condition)) &&
+    condition.extensions?.pothosDrizzleModel === type.extensions.pothosDrizzleModel
+  ) {
+    return condition;
+  }
+
+  return null;
+}
+
 function addNestedSelections(
   config: PothosDrizzleSchemaConfig,
   type: GraphQLInterfaceType | GraphQLObjectType,
@@ -240,7 +273,7 @@ function addNestedSelections(
   indirectPath: string[],
   segments: FieldPathInfo[] = [],
 ) {
-  let parentType = type;
+  let parentType: GraphQLInterfaceType | GraphQLObjectType | null = type;
   for (const selection of selections.selections) {
     switch (selection.kind) {
       case Kind.FIELD:
@@ -252,14 +285,11 @@ function addNestedSelections(
           continue;
         }
 
-        parentType = info.schema.getType(
-          info.fragments[selection.name.value].typeCondition.name.value,
-        )! as GraphQLObjectType;
-        if (
-          isObjectType(type)
-            ? parentType.name !== type.name
-            : parentType.extensions?.pothosDrizzleModel !== type.extensions.pothosDrizzleModel
-        ) {
+        parentType = typeForFragment(
+          type,
+          info.schema.getType(info.fragments[selection.name.value].typeCondition.name.value)!,
+        );
+        if (!parentType) {
           continue;
         }
 
@@ -282,13 +312,9 @@ function addNestedSelections(
         }
 
         parentType = selection.typeCondition
-          ? (info.schema.getType(selection.typeCondition.name.value) as GraphQLObjectType)
+          ? typeForFragment(type, info.schema.getType(selection.typeCondition.name.value)!)
           : type;
-        if (
-          isObjectType(type)
-            ? parentType.name !== type.name
-            : parentType.extensions?.pothosDrizzleModel !== type.extensions.pothosDrizzleModel
-        ) {
+        if (!parentType) {
           continue;
         }
 

--- a/packages/plugin-drizzle/tests/interface-fragments.test.ts
+++ b/packages/plugin-drizzle/tests/interface-fragments.test.ts
@@ -1,0 +1,114 @@
+import { execute } from '@pothos/test-utils';
+import type { DocumentNode } from 'graphql';
+import { gql } from 'graphql-tag';
+import { createContext } from './example/context';
+import { clearDrizzleLogs, drizzleLogs } from './example/db';
+import { schema } from './example/schema';
+
+async function planFor(query: DocumentNode) {
+  const context = await createContext({ userId: '1' });
+  clearDrizzleLogs();
+
+  const result = await execute({
+    schema,
+    document: query,
+    contextValue: context,
+  });
+
+  return { result, logs: [...drizzleLogs] };
+}
+
+describe('fragments on interfaces implemented by drizzle objects', () => {
+  afterEach(() => {
+    clearDrizzleLogs();
+  });
+
+  it('plans a fragment spread on the interface like a fragment on the object', async () => {
+    const onObject = await planFor(gql`
+      query {
+        me {
+          ... on NormalViewer {
+            ...ViewerRoles
+          }
+        }
+      }
+
+      fragment ViewerRoles on NormalViewer {
+        id
+        roles
+      }
+    `);
+
+    const onInterface = await planFor(gql`
+      query {
+        me {
+          ... on NormalViewer {
+            ...ViewerRoles
+          }
+        }
+      }
+
+      fragment ViewerRoles on Viewer {
+        id
+        roles
+      }
+    `);
+
+    expect(onObject.result).toMatchInlineSnapshot(`
+      {
+        "data": {
+          "me": {
+            "id": "1",
+            "roles": [
+              "admin",
+              "author",
+              "user",
+            ],
+          },
+        },
+      }
+    `);
+    expect(onObject.logs).toMatchInlineSnapshot(`
+      [
+        "Query: select "d0"."id" as "id", coalesce((select json_group_array(json_object('id', "id", 'name', "name")) as "r" from (select "d1"."id" as "id", "d1"."name" as "name" from "roles" as "d1" inner join "user_roles" as "tr0" on "tr0"."role_id" = "d1"."id" where "d0"."id" = "tr0"."user_id") as "t"), jsonb_array()) as "roles" from "users" as "d0" where "d0"."id" = ? limit ? -- params: [1, 1]",
+      ]
+    `);
+
+    expect(onInterface.result).toEqual(onObject.result);
+    expect(onInterface.logs).toEqual(onObject.logs);
+  });
+
+  it('plans an inline fragment on the interface like a fragment on the object', async () => {
+    const onObject = await planFor(gql`
+      query {
+        me {
+          ... on NormalViewer {
+            ... on NormalViewer {
+              id
+              roles
+            }
+          }
+        }
+      }
+    `);
+
+    const onInterface = await planFor(gql`
+      query {
+        me {
+          ... on NormalViewer {
+            ... on Viewer {
+              id
+              roles
+            }
+          }
+        }
+      }
+    `);
+
+    expect(onObject.logs).toHaveLength(1);
+    expect(onObject.logs[0]).toContain('from "roles"');
+
+    expect(onInterface.result).toEqual(onObject.result);
+    expect(onInterface.logs).toEqual(onObject.logs);
+  });
+});


### PR DESCRIPTION
## Summary

- `addNestedSelections` skipped a fragment (spread or inline) whose type condition is an interface the Drizzle object implements, because it compared the fragment's type name with the object's name. Any `select` declared on the interface's fields never reached the planned query, and the field then resolved against a row missing the relation, falling back to a separate load. The fragment is now planned against the object, whose field map already carries the interface fields and their `pothosDrizzleSelect` extensions. Fragments on other objects, and the existing interface / `pothosDrizzleModel` branch, are unchanged; the two duplicated conditions collapse into one `typeForFragment` helper.
- Export `DrizzleInterfaceRef` (as a value, like `DrizzleObjectRef` and Prisma's `PrismaInterfaceRef`, so `instanceof` works for consumers) and the `DrizzleRef` union type from the package index, so a plugin wrapping `drizzleField` can name any Drizzle ref without reaching into `interface-ref.js`.
- Changeset for a patch release of `@pothos/plugin-drizzle`.

Found while running `@pothos/plugin-drizzle` in an app where interface fields carry `select` and clients query them through `... on IWalletAddress { ... }` fragments; the same skip applies to `drizzleInterface` fields, which is what the test exercises.

## Test plan

- [x] New `tests/interface-fragments.test.ts`: `me { ... on NormalViewer { ...ViewerRoles } }` with `fragment ViewerRoles on Viewer { id roles }` (and the inline-fragment form) plans the same single query, including the `roles` relation from the interface field's `select`, as the same fragment on `NormalViewer`. Before the fix the interface form issued a bare `select id` followed by a second loader query.
- [x] `pnpm vitest --run` in `packages/plugin-drizzle`: 20 files, 120 tests pass, vitest typecheck clean
- [x] `pnpm type` in `packages/plugin-drizzle`
- [x] `pnpm build` in `packages/plugin-drizzle`; `esm/types.js` and `lib/types.js` export `DrizzleInterfaceRef`, `dts/types.d.ts` re-exports both
- [x] `biome check` on the changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
