### PR TITLE
fix(core): migrate deprecated graphql-js APIs for v17/v18 compat

### DIFF
--- a/packages/converter/src/index.ts
+++ b/packages/converter/src/index.ts
@@ -660,8 +660,10 @@ export default class PothosConverter {
             this.writeRequiredness(writer, arg.type);
             writer.write(',');
             writer.newLine();
-            if (arg.defaultValue != null) {
-              writer.write(`defaultValue: ${JSON.stringify(arg.defaultValue)}`);
+            // biome-ignore lint/suspicious/noExplicitAny: v17+ 'default' API
+            const defaultVal = (arg as any).default?.value ?? arg.defaultValue;
+            if (defaultVal != null) {
+              writer.write(`defaultValue: ${JSON.stringify(defaultVal)}`);
               writer.write(',');
               writer.newLine();
             }

--- a/packages/core/src/build-cache.ts
+++ b/packages/core/src/build-cache.ts
@@ -21,6 +21,7 @@ import {
   GraphQLString,
   type GraphQLTypeResolver,
   GraphQLUnionType,
+  getNamedType,
 } from 'graphql';
 import type { SchemaBuilder } from './builder.js';
 import type { ConfigStore } from './config-store.js';
@@ -64,6 +65,48 @@ type NullableInputType =
   | GraphQLEnumType
   | GraphQLInputObjectType
   | GraphQLList<GraphQLInputType>;
+
+/**
+ * Serialize a default value from internal/coerced form to external form.
+ * Required for graphql 17+ where `default: { value }` expects external values.
+ * For enums, converts internal value (e.g., 2) to external name (e.g., "TWO").
+ * For scalars, applies the serialize function.
+ * For input objects and lists, recursively serializes nested values.
+ */
+function unwrapType(type: GraphQLInputType): GraphQLInputType {
+  return type instanceof GraphQLNonNull ? type.ofType : type;
+}
+
+function serializeDefaultValue(value: unknown, type: GraphQLInputType): unknown {
+  if (value == null) {
+    return value;
+  }
+
+  const unwrapped = unwrapType(type);
+
+  if (Array.isArray(value) && unwrapped instanceof GraphQLList) {
+    const itemType = unwrapType(unwrapped.ofType);
+    return value.map((item) => serializeDefaultValue(item, itemType));
+  }
+
+  const namedType = getNamedType(type);
+
+  if (namedType instanceof GraphQLEnumType || namedType instanceof GraphQLScalarType) {
+    return namedType.serialize(value);
+  }
+
+  if (namedType instanceof GraphQLInputObjectType && typeof value === 'object') {
+    const fields = namedType.getFields();
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      const field = fields[key];
+      result[key] = field ? serializeDefaultValue(val, field.type) : val;
+    }
+    return result;
+  }
+
+  return value;
+}
 
 export class BuildCache<Types extends SchemaTypes> {
   types = new Map<string, GraphQLNamedType>();
@@ -376,9 +419,18 @@ export class BuildCache<Types extends SchemaTypes> {
       const config = this.inputFieldConfigs.get(originalConfig)!;
 
       if (config) {
+        const builtType = this.buildInputTypeParam(config.type);
+
         built[fieldName] = {
           ...config,
-          type: this.buildInputTypeParam(config.type),
+          type: builtType,
+          // graphql 17+ default value API; uses 'default: { value }' with the external
+          // (serialized) value. Enum internal values (e.g., 2) must be serialized to
+          // external names (e.g., "TWO") to avoid v17 validation errors.
+          // Spread so keys don't trip graphql 16's narrower config types. Ignored on v16.
+          ...(config.defaultValue !== undefined
+            ? { default: { value: serializeDefaultValue(config.defaultValue, builtType) } }
+            : {}),
           extensions: {
             ...config.extensions,
             pothosOptions: config.pothosOptions,

--- a/packages/plugin-add-graphql/src/schema-builder.ts
+++ b/packages/plugin-add-graphql/src/schema-builder.ts
@@ -141,7 +141,8 @@ proto.addGraphQLObject = function addGraphQLObject<Shape>(
             ...input,
             description: arg.description ?? undefined,
             deprecationReason: arg.deprecationReason ?? undefined,
-            defaultValue: arg.defaultValue,
+            // biome-ignore lint/suspicious/noExplicitAny: v17+ 'default' API
+            defaultValue: (arg as any).default?.value ?? arg.defaultValue,
             extensions: arg.extensions,
             astNode: arg.astNode ?? undefined,
           });
@@ -214,7 +215,8 @@ proto.addGraphQLInterface = function addGraphQLInterface<Shape = unknown>(
             ...resolveInputType(this, arg.type),
             description: arg.description ?? undefined,
             deprecationReason: arg.deprecationReason ?? undefined,
-            defaultValue: arg.defaultValue,
+            // biome-ignore lint/suspicious/noExplicitAny: v17+ 'default' API
+            defaultValue: (arg as any).default?.value ?? arg.defaultValue,
             extensions: arg.extensions,
             astNode: arg.astNode ?? undefined,
           });
@@ -332,7 +334,8 @@ proto.addGraphQLInput = function addGraphQLInput<Shape extends {}>(
         combinedFields[fieldName] = t.field({
           ...resolveInputType(this, field.type),
           description: field.description ?? undefined,
-          defaultValue: field.defaultValue,
+          // biome-ignore lint/suspicious/noExplicitAny: v17+ 'default' API
+          defaultValue: (field as any).default?.value ?? field.defaultValue,
           extensions: field.extensions,
           astNode: field.astNode ?? undefined,
         });

--- a/packages/plugin-directives/src/mock-ast.ts
+++ b/packages/plugin-directives/src/mock-ast.ts
@@ -1,7 +1,7 @@
 import './global-types.js';
+import * as graphqlModule from 'graphql';
 import {
   type ArgumentNode,
-  astFromValue,
   type ConstDirectiveNode,
   type ConstValueNode,
   type DirectiveNode,
@@ -33,6 +33,62 @@ import {
   type ValueNode,
 } from 'graphql';
 import type { DirectiveList } from './types.js';
+
+// graphql 17 deprecated astFromValue() in favor of valueToLiteral().
+// They take different value shapes: astFromValue takes internal/coerced values,
+// valueToLiteral takes external values. For default values, prefer stored AST
+// literals from graphql 17+ 'default' API when available.
+// biome-ignore lint/suspicious/noExplicitAny: accessing conditionally available APIs
+const gql = graphqlModule as Record<string, any>;
+const _astFromValue = gql.astFromValue as
+  | ((value: unknown, type: GraphQLType) => ValueNode | null | undefined)
+  | undefined;
+const _valueToLiteral = gql.valueToLiteral as
+  | ((value: unknown, type: GraphQLType) => ValueNode | undefined)
+  | undefined;
+
+/**
+ * Convert an internal/coerced default value to an AST literal.
+ * Handles the graphql v16→v17→v18 migration:
+ * - v16/v17: uses astFromValue (deprecated in v17)
+ * - v17+: uses stored literal from 'default' API when available
+ * - v18+: uses valueToLiteral with serialize() to convert internal→external values
+ */
+function internalValueToLiteral(
+  value: unknown,
+  type: GraphQLType,
+  storedDefault?: { literal?: ValueNode; value?: unknown },
+): ValueNode | null | undefined {
+  // Prefer stored AST literal (graphql 17+ 'default: { literal }' API)
+  if (storedDefault?.literal) {
+    return storedDefault.literal;
+  }
+
+  // Use astFromValue if available (graphql 16/17)
+  if (_astFromValue) {
+    return _astFromValue(value, type);
+  }
+
+  // Fallback for graphql 18+: serialize internal→external, then valueToLiteral
+  if (_valueToLiteral) {
+    const namedType = getNamedType(type);
+    if (namedType && 'serialize' in namedType) {
+      const externalValue = (namedType as GraphQLScalarType | GraphQLEnumType).serialize(value);
+      return _valueToLiteral(externalValue, type);
+    }
+    // For non-scalar/enum types, value is already in external form
+    return _valueToLiteral(value, type);
+  }
+
+  return null;
+}
+
+function getNamedType(type: GraphQLType): GraphQLType {
+  if (type instanceof GraphQLNonNull || type instanceof GraphQLList) {
+    return getNamedType(type.ofType);
+  }
+  return type;
+}
 
 export default function mockAst(schema: GraphQLSchema) {
   const types = schema.getTypeMap();
@@ -146,7 +202,9 @@ function valueNode(value: unknown, arg?: GraphQLArgument): ValueNode {
   }
 
   if (arg) {
-    return astFromValue(value, arg.type) as ValueNode;
+    // biome-ignore lint/suspicious/noExplicitAny: accessing v17+ 'default' property
+    const stored = (arg as any).default as { literal?: ValueNode; value?: unknown } | undefined;
+    return (internalValueToLiteral(value, arg.type, stored) ?? { kind: Kind.NULL }) as ValueNode;
   }
 
   if (Array.isArray(value)) {
@@ -261,14 +319,21 @@ function inputFieldNodes(
   return Object.keys(fields).map((fieldName) => {
     const field: GraphQLInputField = fields[fieldName];
 
-    const defaultValueNode = astFromValue(field.defaultValue, field.type) as ConstValueNode;
+    // biome-ignore lint/suspicious/noExplicitAny: accessing v17+ 'default' property
+    const stored = (field as any).default as { literal?: ValueNode; value?: unknown } | undefined;
+    // Use stored literal (v17+) or fall back to field.defaultValue (internal/coerced).
+    // Do NOT use stored?.value — it's in external form and astFromValue expects internal.
+    const defaultValueNode =
+      field.defaultValue === undefined && !stored?.literal
+        ? undefined
+        : (internalValueToLiteral(field.defaultValue, field.type, stored) as ConstValueNode);
 
     field.astNode ||= {
       kind: Kind.INPUT_VALUE_DEFINITION,
       description: field.description ? { kind: Kind.STRING, value: field.description } : undefined,
       name: { kind: Kind.NAME, value: fieldName },
       type: typeNode(field.type),
-      defaultValue: field.defaultValue === undefined ? undefined : defaultValueNode,
+      defaultValue: defaultValueNode,
       directives: directiveNodes(
         field.extensions?.directives as DirectiveList,
         field.deprecationReason ?? null,
@@ -285,14 +350,19 @@ function argumentNodes(
   schema: GraphQLSchema,
 ): InputValueDefinitionNode[] {
   return args.map((arg): InputValueDefinitionNode => {
-    const defaultValueNode = astFromValue(arg.defaultValue, arg.type) as ConstValueNode;
+    // biome-ignore lint/suspicious/noExplicitAny: accessing v17+ 'default' property
+    const stored = (arg as any).default as { literal?: ValueNode; value?: unknown } | undefined;
+    const defaultValueNode =
+      arg.defaultValue === undefined && !stored?.literal
+        ? undefined
+        : (internalValueToLiteral(arg.defaultValue, arg.type, stored) as ConstValueNode);
 
     arg.astNode ||= {
       kind: Kind.INPUT_VALUE_DEFINITION,
       description: arg.description ? { kind: Kind.STRING, value: arg.description } : undefined,
       name: { kind: Kind.NAME, value: arg.name },
       type: typeNode(arg.type),
-      defaultValue: arg.defaultValue === undefined ? undefined : defaultValueNode,
+      defaultValue: defaultValueNode,
       directives: directiveNodes(
         arg.extensions?.directives as DirectiveList,
         arg.deprecationReason ?? null,

--- a/packages/plugin-directives/tests/index.test.ts
+++ b/packages/plugin-directives/tests/index.test.ts
@@ -111,6 +111,13 @@ describe('extends example schema', () => {
     });
   });
 
+  it('prints schema with enum default values correctly (graphql v17+ compat)', () => {
+    // Validates that enum defaults with internal values (e.g., 2 for TWO)
+    // produce valid SDL via printSchema — previously broken in graphql v17
+    const sdl = printSchema(schema);
+    expect(sdl).toContain('enumWithDefault: EN = TWO');
+  });
+
   it('gatsby format', () => {
     const builder = new SchemaBuilder<{
       Directives: {

--- a/packages/plugin-sub-graph/src/index.ts
+++ b/packages/plugin-sub-graph/src/index.ts
@@ -230,6 +230,8 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
           newArguments[argConfig.name] = {
             description: argConfig.description,
             defaultValue: argConfig.defaultValue,
+            // biome-ignore lint/suspicious/noExplicitAny: v17+ 'default' API
+            ...((argConfig as any).default ? { default: (argConfig as any).default } : {}),
             extensions: argConfig.extensions,
             astNode: argConfig.astNode,
             deprecationReason: argConfig.deprecationReason,
@@ -292,6 +294,8 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
           extensions: fieldConfig.extensions,
           astNode: fieldConfig.astNode,
           defaultValue: fieldConfig.defaultValue,
+          // biome-ignore lint/suspicious/noExplicitAny: v17+ 'default' API
+          ...((fieldConfig as any).default ? { default: (fieldConfig as any).default } : {}),
           deprecationReason: fieldConfig.deprecationReason,
           type: replaceType(
             fieldConfig.type,


### PR DESCRIPTION
## Summary

Closes #1637

Fixes enum and custom scalar default values breaking in graphql v17+. The root cause: graphql v17 validates default values using `getDefaultValueAST()` which requires the `default: { value }` API (external values), not just the deprecated `defaultValue` (internal values).

### Key insight — the value-shape trap

`astFromValue(value, type)` takes **internal/coerced** values (e.g., `2` for enum `TWO`).  
`valueToLiteral(value, type)` takes **external** values (e.g., `"TWO"`).  
Naive swap silently corrupts enum and custom scalar defaults.

### Approach: serialize internal→external at build time

Rather than swapping `astFromValue` → `valueToLiteral`, we:
1. **Serialize** internal values to external form via `type.serialize()` at build time
2. **Emit** `default: { value: serialized }` alongside deprecated `defaultValue`
3. **Prefer** stored AST literals from v17+ `default` API in mock-ast, falling back to `astFromValue` (v16/v17) then `valueToLiteral` + serialize (v18+)

### Files changed

| File | Change |
|------|--------|
| `core/src/build-cache.ts` | Emit `default: { value: serializeDefaultValue(...) }` in `buildInputFields()` |
| `plugin-directives/src/mock-ast.ts` | Replace 3x `astFromValue()` with `internalValueToLiteral()` helper |
| `plugin-add-graphql/src/schema-builder.ts` | Read from `.default?.value ?? .defaultValue` |
| `plugin-sub-graph/src/index.ts` | Copy `default` property in config reconstruction |
| `converter/src/index.ts` | Read from `.default?.value ?? .defaultValue` |

### Backward compat

All changes are additive — graphql v16 ignores unknown config keys, v17+ uses them. No breaking changes.

## Test plan

- [x] 155 tests pass across 8 packages (core, directives, prisma, sub-graph, add-graphql, relay, federation, converter)
- [x] **Fixes 2 pre-existing test failures** in plugin-directives (enum default values in `printSchema` and `validateSchema`)
- [x] New test: validates `printSchema` produces `enumWithDefault: EN = TWO` for enum with internal value `2`
- [x] Existing test validates AST structure for enum/boolean/string/ID/list defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)