### PR TITLE
fix(prisma, drizzle): relation selection and loading bugs

### DIFF
--- a/.changeset/selection-mapper-bugs.md
+++ b/.changeset/selection-mapper-bugs.md
@@ -1,0 +1,20 @@
+---
+'@pothos/plugin-prisma': patch
+'@pothos/plugin-drizzle': patch
+---
+
+Fix several bugs in how relation selections are mapped and loaded.
+
+Prisma:
+
+- A relation `query` returning keys set to `undefined` (`{ where: cond ? filter : undefined }`) is now treated as compatible with a sibling selection of the same relation. Previously the sibling fell back to a separate query per row whenever the condition was false.
+- `onNull` now receives `args`, `context`, and `info`. Previously it was called with empty objects, so any callback reading them threw at runtime.
+
+Drizzle:
+
+- `totalCount` on `t.relatedConnection` now applies the `where` returned by the field's `query`, so it counts the same rows the connection paginates. Previously it reported the unfiltered count.
+- New builder option `drizzle.filterConnectionTotalCount` (default `true`). Set it to `false` to keep counting every related row regardless of the filter, matching the prisma plugin's option.
+- `t.relatedConnection` no longer accepts a `resolve` option. It was silently discarded, so the resolver never ran.
+- `drizzleConnectionHelpers(builder, table)` can now be called without the options argument. Previously it threw.
+- `t.relation`, `t.relatedCount`, and `t.relatedConnection` now load their data through the model loader when the parent row was returned by a resolver that fetched it itself, instead of returning `undefined` or an empty page.
+- `t.relatedField` (and so `t.relatedCount`) now forwards every field option and merges `extensions` instead of dropping them.

--- a/.changeset/selection-mapper-bugs.md
+++ b/.changeset/selection-mapper-bugs.md
@@ -9,6 +9,7 @@ Prisma:
 
 - A relation `query` returning keys set to `undefined` (`{ where: cond ? filter : undefined }`) is now treated as compatible with a sibling selection of the same relation. Previously the sibling fell back to a separate query per row whenever the condition was false.
 - `onNull` now receives `args`, `context`, and `info`. Previously it was called with empty objects, so any callback reading them threw at runtime.
+- When a relation field is loaded through the fallback query, every occurrence of the field under the same response key (for example the same relation selected again inside a fragment) is planned, not only the first.
 
 Drizzle:
 
@@ -18,3 +19,7 @@ Drizzle:
 - `drizzleConnectionHelpers(builder, table)` can now be called without the options argument. Previously it threw.
 - `t.relation`, `t.relatedCount`, and `t.relatedConnection` now load their data through the model loader when the parent row was returned by a resolver that fetched it itself, instead of returning `undefined` or an empty page.
 - `t.relatedField` (and so `t.relatedCount`) now forwards every field option and merges `extensions` instead of dropping them.
+- `t.relatedConnection` reads its selection at resolve time the same way the planner does (through fragments, `@skip`/`@include`, and a wrapping type). A count-only selection written through a fragment no longer crashes, and a parent row that carries the relation rows but not the count is reloaded instead of resolving `totalCount` as `undefined`.
+- `t.relation` evaluates a `query` callback once, with `pathInfo`. Previously it was called a second time without `pathInfo`.
+- Every occurrence of a field under the same response key is planned when it is loaded through the fallback, not only the first.
+- `pathInfo.segments[].isList` is `true` for non-null list fields (`[Post!]!`). Previously only nullable lists were reported as lists.

--- a/packages/plugin-drizzle/src/connection-helpers.ts
+++ b/packages/plugin-drizzle/src/connection-helpers.ts
@@ -79,7 +79,7 @@ export function drizzleConnectionHelpers<
       | number
       | ((args: PothosSchemaTypes.DefaultConnectionArguments, ctx: Types['Context']) => number);
     resolveNode?: (edge: EdgeShape) => NodeShape;
-  },
+  } = {},
 ) {
   const config = getSchemaConfig(builder);
   const tableName =

--- a/packages/plugin-drizzle/src/drizzle-field-builder.ts
+++ b/packages/plugin-drizzle/src/drizzle-field-builder.ts
@@ -25,9 +25,11 @@ import {
   eq,
   type InferSelectModel,
   Many,
+  relationsFilterToSQL,
   type SQL,
   type Table,
   type TableRelationalConfig,
+  type TablesRelationalConfig,
 } from 'drizzle-orm';
 import {
   type FieldNode,
@@ -67,6 +69,15 @@ const RootBuilder: {
     graphqlKind: PothosSchemaTypes.PothosKindToGraphQLType[FieldKind],
   ): PothosSchemaTypes.RootFieldBuilder<Types, Shape, Kind>;
 } = RootFieldBuilder as never;
+
+// drizzle-orm declares two parameters, but the implementation also takes the table's relations
+// and the full relational config, which lets a `where` filter on related tables.
+type RelationsFilterToSQL = (
+  table: Table,
+  filter: unknown,
+  tableRelations?: TableRelationalConfig['relations'],
+  tablesRelations?: TablesRelationalConfig,
+) => SQL | undefined;
 
 export class DrizzleObjectFieldBuilder<
   Types extends SchemaTypes,
@@ -212,34 +223,59 @@ export class DrizzleObjectFieldBuilder<
     const ref = options.type ?? getRefFromModel(relationField.targetTableName, this.builder);
     let typeName: string | undefined;
 
-    const buildCountFilter = (parentTable: TableConfig['table']): SQL => {
+    const filterTotalCount = this.builder.options.drizzle?.filterConnectionTotalCount !== false;
+
+    // The count for `totalCount` matches the connection's own filter: the relation columns plus
+    // the `where` from the field's `query`, so the count agrees with the rows being paginated.
+    const buildCountFilter = (parentTable: TableConfig['table'], where?: unknown): SQL => {
       const { sourceColumns, targetColumns } = relationField;
-      return and(
+      const relationFilter = and(
         ...sourceColumns.map((sourceCol: { name: string }, i: number) =>
           eq(targetColumns[i], parentTable[sourceCol.name as never]),
         ),
       )!;
+
+      if (!where || !filterTotalCount) {
+        return relationFilter;
+      }
+
+      return and(
+        relationFilter,
+        (relationsFilterToSQL as RelationsFilterToSQL)(
+          relatedTable.table as Table,
+          where,
+          relatedTable.relations,
+          schemaConfig.relations,
+        ),
+      )!;
     };
 
-    const getQuery = (
+    interface ConnectionFieldQuery {
+      limit?: number;
+      orderBy?: unknown;
+      where?: SQL;
+      columns?: Record<string, boolean>;
+      extras?: DrizzleCursorConnectionQueryOptions['extras'];
+    }
+
+    const resolveFieldQuery = (
       args: PothosSchemaTypes.DefaultConnectionArguments,
       ctx: {},
       pathInfo?: import('./types').PathInfo,
-    ) => {
-      const { limit, orderBy, where, ...fieldQuery } = ((typeof query === 'function'
+    ): ConnectionFieldQuery =>
+      ((typeof query === 'function'
         ? (query as (args: {}, ctx: {}, pathInfo?: import('./types').PathInfo) => {})(
             args,
             ctx,
             pathInfo,
           )
-        : query) ?? {}) as {
-        limit?: number;
-        orderBy?: unknown;
-        where?: SQL;
-        columns?: Record<string, boolean>;
-        extras?: DrizzleCursorConnectionQueryOptions['extras'];
-      };
+        : query) ?? {}) as ConnectionFieldQuery;
 
+    const getQuery = (
+      args: PothosSchemaTypes.DefaultConnectionArguments,
+      ctx: {},
+      { limit, orderBy, where, ...fieldQuery }: ConnectionFieldQuery,
+    ) => {
       const { cursorFields, columns, ...connectionQuery } = drizzleCursorConnectionQuery({
         ctx,
         maxSize,
@@ -282,11 +318,12 @@ export class DrizzleObjectFieldBuilder<
       const hasNodes = !!getSelection(['nodes']);
       const hasPageInfo = !!getSelection(['pageInfo']);
       const totalCountOnly = hasTotalCount && !hasEdges && !hasNodes && !hasPageInfo;
+      const fieldQuery = resolveFieldQuery(args, context, pathInfo);
       const countSelection = {
         [`_${name as string}_count`]: (parent: TableConfig['table']) =>
           getClient(this.builder, context).$count(
             relatedTable.table as Table,
-            buildCountFilter(parent),
+            buildCountFilter(parent, fieldQuery.where),
           ),
       };
 
@@ -298,7 +335,7 @@ export class DrizzleObjectFieldBuilder<
         };
       }
 
-      const nested = nestedQuery(getQuery(args, context, pathInfo).select, {
+      const nested = nestedQuery(getQuery(args, context, fieldQuery).select, {
         getType: () => typeName!,
         paths: [[{ name: 'nodes' }], [{ name: 'edges' }, { name: 'node' }]],
       }) as SelectionMap;
@@ -379,7 +416,11 @@ export class DrizzleObjectFieldBuilder<
             };
           }
 
-          const { select, cursorFields } = getQuery(args, context);
+          const { select, cursorFields } = getQuery(
+            args,
+            context,
+            resolveFieldQuery(args, context),
+          );
 
           return wrapConnectionResult(
             parentRecord[name] as readonly {}[],

--- a/packages/plugin-drizzle/src/drizzle-field-builder.ts
+++ b/packages/plugin-drizzle/src/drizzle-field-builder.ts
@@ -30,14 +30,7 @@ import {
   type TableRelationalConfig,
   type TablesRelationalConfig,
 } from 'drizzle-orm';
-import {
-  type FieldNode,
-  Kind as GraphQLKind,
-  type GraphQLResolveInfo,
-  getNamedType,
-  isInterfaceType,
-  isObjectType,
-} from 'graphql';
+import type { FieldNode, GraphQLResolveInfo } from 'graphql';
 import type { DrizzleRef } from './interface-ref.js';
 import type {
   DrizzleConnectionShape,
@@ -57,6 +50,7 @@ import {
   getCursorFormatter,
   wrapConnectionResult,
 } from './utils/cursors.js';
+import { selectsPath } from './utils/map-query.js';
 import { getRefFromModel } from './utils/refs.js';
 import { omitUndefinedKeys, type SelectionMap } from './utils/selections.js';
 
@@ -297,19 +291,16 @@ export class DrizzleObjectFieldBuilder<
 
     const countKey = `_${name as string}_count`;
 
-    const isTotalCountOnly = (info: GraphQLResolveInfo) => {
-      const returnType = getNamedType(info.returnType);
-      const fields =
-        isObjectType(returnType) || isInterfaceType(returnType) ? returnType.getFields() : {};
+    // What the document asks of this connection, read the way the planner reads it (through
+    // fragments, directives, and a wrapping type), so the resolve side agrees with the plan.
+    const connectionSelection = (info: GraphQLResolveInfo) => {
+      const hasTotalCount = !!totalCount && selectsPath(info, ['totalCount']);
+      const hasRows =
+        selectsPath(info, ['edges']) ||
+        selectsPath(info, ['nodes']) ||
+        selectsPath(info, ['pageInfo']);
 
-      return info.fieldNodes.every((selection) =>
-        selection.selectionSet?.selections.every(
-          (s) =>
-            s.kind === GraphQLKind.FIELD &&
-            (fields[s.name.value]?.extensions?.pothosDrizzleTotalCount ||
-              s.name.value === '__typename'),
-        ),
-      );
+      return { hasTotalCount, totalCountOnly: hasTotalCount && !hasRows };
     };
 
     const relationSelect = (
@@ -366,10 +357,14 @@ export class DrizzleObjectFieldBuilder<
         extensions: {
           ...extensions,
           pothosDrizzleSelect: relationSelect,
-          pothosDrizzleLoaded: (value: Record<string, unknown>, info: GraphQLResolveInfo) =>
-            totalCount && isTotalCountOnly(info)
-              ? value[countKey] !== undefined
-              : value[name as string] !== undefined,
+          pothosDrizzleLoaded: (value: Record<string, unknown>, info: GraphQLResolveInfo) => {
+            const { hasTotalCount, totalCountOnly } = connectionSelection(info);
+
+            return (
+              (!hasTotalCount || value[countKey] !== undefined) &&
+              (totalCountOnly || value[name as string] !== undefined)
+            );
+          },
         },
         description,
         type: ref,
@@ -385,7 +380,7 @@ export class DrizzleObjectFieldBuilder<
             : undefined;
 
           // Only totalCount was requested: the relation was never selected, so skip the cursors.
-          if (isTotalCountOnly(info)) {
+          if (connectionSelection(info).totalCountOnly) {
             return {
               parent,
               args,
@@ -551,23 +546,23 @@ export class DrizzleObjectFieldBuilder<
       _resolveSelection: unknown,
       pathInfo: PathInfo,
     ) => {
-      const relQuery = {
+      // Evaluate a `query` callback once, with `pathInfo`; it used to be called a second time
+      // (without `pathInfo`) when the nested selection was built.
+      const fieldQuery = (
+        typeof query === 'function'
+          ? (query as (args: {}, context: {}, pathInfo: PathInfo) => {})(args, context, pathInfo)
+          : query
+      ) as {};
+
+      return {
         columns: {},
         with: {
           [name]: omitUndefinedKeys({
-            ...nestedQuery(query),
-            ...((typeof query === 'function'
-              ? (query as (args: {}, context: {}, pathInfo: PathInfo) => {})(
-                  args,
-                  context,
-                  pathInfo,
-                )
-              : query) as {}),
+            ...nestedQuery(fieldQuery),
+            ...fieldQuery,
           }),
         },
       };
-
-      return relQuery;
     };
 
     return this.field({

--- a/packages/plugin-drizzle/src/drizzle-field-builder.ts
+++ b/packages/plugin-drizzle/src/drizzle-field-builder.ts
@@ -8,7 +8,6 @@ import {
   type InputShapeFromFields,
   type InterfaceParam,
   isThenable,
-  type MaybePromise,
   type NormalizeArgs,
   ObjectRef,
   type PluginName,
@@ -186,7 +185,6 @@ export class DrizzleObjectFieldBuilder<
       maxSize = this.builder.options.drizzle?.maxConnectionSize,
       defaultSize = this.builder.options.drizzle?.defaultConnectionSize,
       query,
-      resolve: _,
       extensions,
       description,
       totalCount,
@@ -199,13 +197,6 @@ export class DrizzleObjectFieldBuilder<
       description?: string;
       query?: ((args: {}, ctx: {}) => {}) | {};
       totalCount?: boolean;
-      resolve?: (
-        query: {},
-        parent: unknown,
-        args: {},
-        ctx: {},
-        info: {},
-      ) => MaybePromise<readonly {}[]>;
     } = {},
     connectionOptions = {},
     edgeOptions = {},
@@ -304,6 +295,23 @@ export class DrizzleObjectFieldBuilder<
       };
     };
 
+    const countKey = `_${name as string}_count`;
+
+    const isTotalCountOnly = (info: GraphQLResolveInfo) => {
+      const returnType = getNamedType(info.returnType);
+      const fields =
+        isObjectType(returnType) || isInterfaceType(returnType) ? returnType.getFields() : {};
+
+      return info.fieldNodes.every((selection) =>
+        selection.selectionSet?.selections.every(
+          (s) =>
+            s.kind === GraphQLKind.FIELD &&
+            (fields[s.name.value]?.extensions?.pothosDrizzleTotalCount ||
+              s.name.value === '__typename'),
+        ),
+      );
+    };
+
     const relationSelect = (
       args: object,
       context: object,
@@ -320,7 +328,7 @@ export class DrizzleObjectFieldBuilder<
       const totalCountOnly = hasTotalCount && !hasEdges && !hasNodes && !hasPageInfo;
       const fieldQuery = resolveFieldQuery(args, context, pathInfo);
       const countSelection = {
-        [`_${name as string}_count`]: (parent: TableConfig['table']) =>
+        [countKey]: (parent: TableConfig['table']) =>
           getClient(this.builder, context).$count(
             relatedTable.table as Table,
             buildCountFilter(parent, fieldQuery.where),
@@ -358,6 +366,10 @@ export class DrizzleObjectFieldBuilder<
         extensions: {
           ...extensions,
           pothosDrizzleSelect: relationSelect,
+          pothosDrizzleLoaded: (value: Record<string, unknown>, info: GraphQLResolveInfo) =>
+            totalCount && isTotalCountOnly(info)
+              ? value[countKey] !== undefined
+              : value[name as string] !== undefined,
         },
         description,
         type: ref,
@@ -367,41 +379,13 @@ export class DrizzleObjectFieldBuilder<
           context: {},
           info: GraphQLResolveInfo,
         ) => {
-          const countKey = `_${name as string}_count`;
           const parentRecord = parent as Record<string, unknown>;
           const countValue = totalCount
             ? (parentRecord[countKey] as number | undefined)
             : undefined;
 
-          if (!(name in parentRecord)) {
-            return {
-              parent,
-              args,
-              totalCount: countValue,
-              edges: [],
-              pageInfo: {
-                startCursor: null,
-                endCursor: null,
-                hasPreviousPage: false,
-                hasNextPage: false,
-              },
-            };
-          }
-
-          // Detect totalCountOnly to skip cursor computation when only totalCount is requested
-          const returnType = getNamedType(info.returnType);
-          const fields =
-            isObjectType(returnType) || isInterfaceType(returnType) ? returnType.getFields() : {};
-          const totalCountOnly = info.fieldNodes.every((selection) =>
-            selection.selectionSet?.selections.every(
-              (s) =>
-                s.kind === GraphQLKind.FIELD &&
-                (fields[s.name.value]?.extensions?.pothosDrizzleTotalCount ||
-                  s.name.value === '__typename'),
-            ),
-          );
-
-          if (totalCountOnly) {
+          // Only totalCount was requested: the relation was never selected, so skip the cursors.
+          if (isTotalCountOnly(info)) {
             return {
               parent,
               args,
@@ -592,6 +576,8 @@ export class DrizzleObjectFieldBuilder<
       extensions: {
         ...extensions,
         pothosDrizzleSelect: relationSelect as never,
+        pothosDrizzleLoaded: (value: Record<string, unknown>) =>
+          value[name as string] !== undefined,
       },
       resolve: (parent: Record<string, never>) => parent[name as string],
     } as never) as never;
@@ -626,6 +612,7 @@ export class DrizzleObjectFieldBuilder<
         ctx: Types['Context'],
         info: unknown,
       ) => ShapeFromTypeParam<Types, Type, Nullable>;
+      extensions?: Record<string, unknown>;
     },
   ): FieldRef<Types, ShapeFromTypeParam<Types, Type, Nullable>, 'DrizzleObject'> {
     const schemaConfig = getSchemaConfig(this.builder);
@@ -665,12 +652,12 @@ export class DrizzleObjectFieldBuilder<
       };
     };
 
+    const { select: _select, extensions, ...fieldOptions } = options;
+
     return this.field({
-      type: options.type,
-      nullable: options.nullable,
-      args: options.args,
-      description: options.description,
+      ...fieldOptions,
       extensions: {
+        ...extensions,
         pothosDrizzleSelect: relationSelect as never,
       },
       resolve: options.resolve as never,
@@ -695,6 +682,10 @@ export class DrizzleObjectFieldBuilder<
       ...options,
       type: 'Int' as never,
       nullable: false,
+      extensions: {
+        ...(options as { extensions?: Record<string, unknown> }).extensions,
+        pothosDrizzleLoaded: (value: Record<string, unknown>) => value[countKey] !== undefined,
+      },
       select: (
         buildFilter: (parent: TableConfig['table']) => SQL,
         args: object,

--- a/packages/plugin-drizzle/src/index.ts
+++ b/packages/plugin-drizzle/src/index.ts
@@ -8,7 +8,7 @@ import SchemaBuilder, {
   type PothosTypeConfig,
   type SchemaTypes,
 } from '@pothos/core';
-import type { GraphQLFieldResolver } from 'graphql';
+import type { GraphQLFieldResolver, GraphQLResolveInfo } from 'graphql';
 import type { ModelLoader } from './model-loader.js';
 import { getLoaderMapping, setLoaderMappings } from './utils/loader-map.js';
 
@@ -161,6 +161,12 @@ export class PothosDrizzlePlugin<Types extends SchemaTypes> extends BasePlugin<T
     }
 
     const parentConfig = this.buildCache.getTypeConfig(fieldConfig.parentType);
+    // A field can declare how to tell whether its data is already on the parent row. When the
+    // row was not loaded from the planned query (a resolver returned a row it fetched itself),
+    // the mapping alone is not proof, and the field falls back to the model loader.
+    const loadedCheck = fieldConfig.extensions?.pothosDrizzleLoaded as
+      | ((value: unknown, info: GraphQLResolveInfo) => boolean)
+      | undefined;
 
     const parentTypes = new Set([fieldConfig.parentType]);
 
@@ -193,7 +199,7 @@ export class PothosDrizzlePlugin<Types extends SchemaTypes> extends BasePlugin<T
         }
       }
 
-      if (mapping) {
+      if ((!loadedCheck || loadedCheck(parent, info)) && mapping) {
         setLoaderMappings(context, info, mapping);
 
         return resolver(parent, args, context, info);

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -85,6 +85,12 @@ type DrizzlePluginBaseOptions = {
   maxConnectionSize?: number;
   defaultConnectionSize?: number;
   skipDeferredFragments?: boolean;
+  /**
+   * When `true` (the default), the `totalCount` of a `relatedConnection` applies the `where`
+   * returned by the field's `query`, so it counts the same rows the connection paginates. Set to
+   * `false` to count every related row regardless of the filter.
+   */
+  filterConnectionTotalCount?: boolean;
 };
 
 export type DrizzlePluginOptions<Types extends SchemaTypes> = DrizzlePluginBaseOptions &

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -661,18 +661,6 @@ export type RelatedConnectionOptions<
   (InputShapeFromFields<Args> &
     PothosSchemaTypes.DefaultConnectionArguments extends infer ConnectionArgs
     ? {
-        resolve?: (
-          parent: Shape,
-          args: ConnectionArgs,
-          context: Types['Context'],
-          info: GraphQLResolveInfo,
-        ) => MaybePromise<
-          ShapeFromTypeParam<
-            Types,
-            [ObjectRef<Types, TypesForRelation<Types, Table['relations'][Field]>>],
-            Nullable
-          >
-        >;
         query?: QueryForRelatedConnection<Types, NodeTable, ConnectionArgs>;
         // biome-ignore lint/suspicious/noExplicitAny: this is fine
         type?: Type & DrizzleRef<any, Table['relations'][Field]['targetTableName']>;

--- a/packages/plugin-drizzle/src/utils/map-query.ts
+++ b/packages/plugin-drizzle/src/utils/map-query.ts
@@ -10,6 +10,7 @@ import {
   type GraphQLInterfaceType,
   type GraphQLNamedType,
   type GraphQLObjectType,
+  type GraphQLOutputType,
   type GraphQLResolveInfo,
   GraphQLSkipDirective,
   getDirectiveValues,
@@ -18,6 +19,7 @@ import {
   isAbstractType,
   isInterfaceType,
   isListType,
+  isNonNullType,
   isObjectType,
   Kind,
   type SelectionSetNode,
@@ -424,7 +426,7 @@ function addFieldSelection(
       field: selection.name.value,
       alias: selection.alias?.value ?? selection.name.value,
       parentType: type.name,
-      isList: isListType(field.type) || isListType(getNamedType(field.type)),
+      isList: isListField(field.type),
     },
   ];
 
@@ -650,7 +652,7 @@ export function stateFromInfo<T extends SelectionMap>({
             field: rootFieldNode.name.value,
             alias: rootFieldNode.alias?.value ?? rootFieldNode.name.value,
             parentType: info.parentType.name,
-            isList: isListType(rootField.type) || isListType(getNamedType(rootField.type)),
+            isList: isListField(rootField.type),
           },
         ]
       : [];
@@ -691,7 +693,11 @@ export function selectionStateFromInfo(
     );
   }
 
-  addFieldSelection(config, type, context, info, state, info.fieldNodes[0], []);
+  // The same response key can be selected more than once (through fragments); every occurrence
+  // contributes to what the resolver will read.
+  for (const fieldNode of info.fieldNodes) {
+    addFieldSelection(config, type, context, info, state, fieldNode, []);
+  }
 
   return state;
 }
@@ -715,6 +721,11 @@ export function selectsPath(info: GraphQLResolveInfo, path: string[]): boolean {
         prefix: pothosIndirectInclude?.path,
       }).length > 0,
   );
+}
+
+/** A list field, whether or not the list itself is non-null (`[Post!]!`). */
+function isListField(type: GraphQLOutputType) {
+  return isListType(type) || (isNonNullType(type) && isListType(type.ofType));
 }
 
 function createStateForSelection(

--- a/packages/plugin-drizzle/src/utils/map-query.ts
+++ b/packages/plugin-drizzle/src/utils/map-query.ts
@@ -696,6 +696,27 @@ export function selectionStateFromInfo(
   return state;
 }
 
+/**
+ * Whether the field being resolved selects `path` beneath its return type, following fragments,
+ * skip/include directives, and the return type's own indirect include prefix (a connection wrapped
+ * by the errors plugin sits under its `data` field). It is the walk the planner uses, so a
+ * resolver's view of the selection agrees with what was planned for it.
+ */
+export function selectsPath(info: GraphQLResolveInfo, path: string[]): boolean {
+  const returnType = getNamedType(info.returnType);
+  const { pothosIndirectInclude } = (returnType.extensions ?? {}) as {
+    pothosIndirectInclude?: IndirectInclude;
+  };
+  const segments = path.map((name) => ({ name }));
+
+  return info.fieldNodes.some(
+    (node) =>
+      findIndirectSelections(returnType, info, node, [segments], {
+        prefix: pothosIndirectInclude?.path,
+      }).length > 0,
+  );
+}
+
 function createStateForSelection(
   config: PothosDrizzleSchemaConfig,
   info: GraphQLResolveInfo,

--- a/packages/plugin-drizzle/tests/related-connection.test.ts
+++ b/packages/plugin-drizzle/tests/related-connection.test.ts
@@ -1169,7 +1169,7 @@ describe('related connections', () => {
     // The count should be included in the same query via extras (single query with count(*))
     expect(drizzleLogs).toMatchInlineSnapshot(`
       [
-        "Query: select "d0"."first_name" as "firstName", "d0"."last_name" as "lastName", "d0"."id" as "id", (lower("d0"."first_name")) as "lowercaseFirstName", ((select count(*) from "posts" where "posts"."author_id" = "d0"."id")) as "_posts_count", (select json_object('id', "id", 'userId', "userId", 'bio', "bio") as "r" from (select "d1"."id" as "id", "d1"."user_id" as "userId", "d1"."bio" as "bio" from "profile" as "d1" where "d0"."id" = "d1"."user_id" limit ?) as "t") as "profile", coalesce((select json_group_array(json_object('postId', "postId")) as "r" from (select "d1"."id" as "postId" from "posts" as "d1" where (("d1"."published" = ?) and ("d0"."id" = "d1"."author_id")) order by "d1"."id" desc limit ?) as "t"), jsonb_array()) as "posts" from "users" as "d0" where "d0"."id" = ? limit ? -- params: [1, 1, 3, 1, 1]",
+        "Query: select "d0"."first_name" as "firstName", "d0"."last_name" as "lastName", "d0"."id" as "id", (lower("d0"."first_name")) as "lowercaseFirstName", ((select count(*) from "posts" where (("posts"."author_id" = "d0"."id") and ("posts"."published" = ?)))) as "_posts_count", (select json_object('id', "id", 'userId', "userId", 'bio', "bio") as "r" from (select "d1"."id" as "id", "d1"."user_id" as "userId", "d1"."bio" as "bio" from "profile" as "d1" where "d0"."id" = "d1"."user_id" limit ?) as "t") as "profile", coalesce((select json_group_array(json_object('postId', "postId")) as "r" from (select "d1"."id" as "postId" from "posts" as "d1" where (("d1"."published" = ?) and ("d0"."id" = "d1"."author_id")) order by "d1"."id" desc limit ?) as "t"), jsonb_array()) as "posts" from "users" as "d0" where "d0"."id" = ? limit ? -- params: [1, 1, 1, 3, 1, 1]",
       ]
     `);
 
@@ -1190,7 +1190,7 @@ describe('related connections', () => {
                   },
                 },
               ],
-              "totalCount": 15,
+              "totalCount": 9,
             },
           },
         },
@@ -1270,7 +1270,7 @@ describe('related connections', () => {
     // When only totalCount is requested, the relation data should NOT be fetched (no json_group_array for posts)
     expect(drizzleLogs).toMatchInlineSnapshot(`
       [
-        "Query: select "d0"."first_name" as "firstName", "d0"."last_name" as "lastName", "d0"."id" as "id", (lower("d0"."first_name")) as "lowercaseFirstName", ((select count(*) from "posts" where "posts"."author_id" = "d0"."id")) as "_posts_count", (select json_object('id', "id", 'userId', "userId", 'bio', "bio") as "r" from (select "d1"."id" as "id", "d1"."user_id" as "userId", "d1"."bio" as "bio" from "profile" as "d1" where "d0"."id" = "d1"."user_id" limit ?) as "t") as "profile" from "users" as "d0" where "d0"."id" = ? limit ? -- params: [1, 1, 1]",
+        "Query: select "d0"."first_name" as "firstName", "d0"."last_name" as "lastName", "d0"."id" as "id", (lower("d0"."first_name")) as "lowercaseFirstName", ((select count(*) from "posts" where (("posts"."author_id" = "d0"."id") and ("posts"."published" = ?)))) as "_posts_count", (select json_object('id', "id", 'userId', "userId", 'bio', "bio") as "r" from (select "d1"."id" as "id", "d1"."user_id" as "userId", "d1"."bio" as "bio" from "profile" as "d1" where "d0"."id" = "d1"."user_id" limit ?) as "t") as "profile" from "users" as "d0" where "d0"."id" = ? limit ? -- params: [1, 1, 1, 1]",
       ]
     `);
 
@@ -1279,7 +1279,7 @@ describe('related connections', () => {
         "data": {
           "user": {
             "postsConnectionWithCount": {
-              "totalCount": 15,
+              "totalCount": 9,
             },
           },
         },
@@ -1315,7 +1315,7 @@ describe('related connections', () => {
             "Terga depulso curia tenus.",
           ],
           "postsConnectionWithCount": {
-            "totalCount": 15,
+            "totalCount": 9,
           },
         },
       }

--- a/packages/plugin-drizzle/tests/relation-loading.test.ts
+++ b/packages/plugin-drizzle/tests/relation-loading.test.ts
@@ -1,0 +1,82 @@
+import SchemaBuilder from '@pothos/core';
+import RelayPlugin from '@pothos/plugin-relay';
+import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
+import { execute } from '@pothos/test-utils';
+import { getTableConfig } from 'drizzle-orm/sqlite-core';
+import { gql } from 'graphql-tag';
+import DrizzlePlugin, { drizzleConnectionHelpers } from '../src';
+import { clearDrizzleLogs, type DrizzleRelations, db, drizzleLogs, relations } from './example/db';
+
+const builder = new SchemaBuilder<{
+  DrizzleRelations: DrizzleRelations;
+  Context: { user: { id: number } };
+}>({
+  plugins: [ScopeAuthPlugin, RelayPlugin, DrizzlePlugin],
+  drizzle: {
+    client: () => db,
+    getTableConfig,
+    relations,
+  },
+  scopeAuth: {
+    authScopes: () => ({}),
+  },
+});
+
+builder.drizzleObject('posts', {
+  name: 'Post',
+  fields: (t) => ({
+    id: t.exposeID('postId'),
+    title: t.exposeString('title'),
+  }),
+});
+
+builder.drizzleObject('userProfile', {
+  name: 'Profile',
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    bio: t.exposeString('bio', { nullable: true }),
+  }),
+});
+
+const User = builder.drizzleObject('users', {
+  name: 'User',
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    profile: t.relation('profile', { nullable: true }),
+    posts: t.relation('posts'),
+    postCount: t.relatedCount('posts'),
+    postsConnection: t.relatedConnection('posts', {
+      totalCount: true,
+      query: () => ({ orderBy: { postId: 'desc' } }),
+    }),
+    postsWithResolve: t.relatedConnection('posts', {
+      // A custom resolver was accepted and silently discarded; it is now rejected.
+      // @ts-expect-error resolve is not an option for relatedConnection
+      resolve: () => [],
+    }),
+  }),
+});
+
+// The third argument is optional, so a helper with no custom selection is a two-argument call.
+const commentHelpers = drizzleConnectionHelpers(builder, 'comments');
+
+builder.queryType({
+  fields: (t) => ({
+    user: t.drizzleField({
+      type: User,
+      resolve: (query) => db.query.users.findFirst(query({ where: { id: 1 } })),
+    }),
+  }),
+});
+
+const schema = builder.toSchema();
+
+describe('relation loading', () => {
+  afterEach(() => {
+    clearDrizzleLogs();
+  });
+
+  it('builds connection helpers without options', () => {
+    expect(typeof commentHelpers.getQuery).toBe('function');
+  });
+});

--- a/packages/plugin-drizzle/tests/relation-loading.test.ts
+++ b/packages/plugin-drizzle/tests/relation-loading.test.ts
@@ -272,4 +272,52 @@ describe('relation loading', () => {
     expect(drizzleLogs).toHaveLength(2);
     expect(drizzleLogs[1]).toContain('count(*)');
   });
+
+  it('plans every occurrence of the field when loading it through the fallback', async () => {
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          rawUser {
+            posts {
+              id
+            }
+            ... on User {
+              posts {
+                author {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `,
+      contextValue: { user: { id: 1 } },
+    });
+
+    expect(result.errors).toBeUndefined();
+    const posts = (result.data as { rawUser: { posts: { id: string; author: { id: string } }[] } })
+      .rawUser.posts;
+    expect(posts.length).toBeGreaterThan(0);
+    expect(posts.every((post) => post.author.id === '1')).toBe(true);
+  });
+
+  it('marks non-null list fields as lists in pathInfo segments', async () => {
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          user {
+            postsWithPath {
+              id
+            }
+          }
+        }
+      `,
+      contextValue: { user: { id: 1 } },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(recordedSegments.at(-1)).toMatchObject({ field: 'postsWithPath', isList: true });
+  });
 });

--- a/packages/plugin-drizzle/tests/relation-loading.test.ts
+++ b/packages/plugin-drizzle/tests/relation-loading.test.ts
@@ -66,6 +66,12 @@ builder.queryType({
       type: User,
       resolve: (query) => db.query.users.findFirst(query({ where: { id: 1 } })),
     }),
+    // Returns a row fetched without the planned selection, so no relation is on it. Every
+    // relation field must then load itself rather than answer from the missing data.
+    rawUser: t.drizzleField({
+      type: User,
+      resolve: () => db.query.users.findFirst({ where: { id: 1 } }),
+    }),
   }),
 });
 
@@ -78,5 +84,99 @@ describe('relation loading', () => {
 
   it('builds connection helpers without options', () => {
     expect(typeof commentHelpers.getQuery).toBe('function');
+  });
+
+  it('loads relations that are missing from a row the resolver fetched itself', async () => {
+    const planned = await execute({
+      schema,
+      document: gql`
+        query {
+          user {
+            profile {
+              id
+            }
+            posts {
+              id
+            }
+            postCount
+            postsConnection(first: 2) {
+              totalCount
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `,
+      contextValue: { user: { id: 1 } },
+    });
+
+    expect(planned.errors).toBeUndefined();
+    expect(drizzleLogs).toMatchInlineSnapshot(`
+      [
+        "Query: select "d0"."id" as "id", "d0"."username" as "username", "d0"."first_name" as "firstName", "d0"."last_name" as "lastName", ((select count(*) from "posts" where "posts"."author_id" = "d0"."id")) as "_posts_count", (select json_object('id', "id", 'userId', "userId", 'bio', "bio") as "r" from (select "d1"."id" as "id", "d1"."user_id" as "userId", "d1"."bio" as "bio" from "profile" as "d1" where "d0"."id" = "d1"."user_id" limit ?) as "t") as "profile", coalesce((select json_group_array(json_object('postId', "postId", 'slug', "slug", 'title', "title", 'content', "content", 'published', "published", 'authorId', "authorId", 'categoryId', "categoryId", 'createdAt', "createdAt", 'updatedAt', "updatedAt")) as "r" from (select "d1"."id" as "postId", "d1"."slug" as "slug", "d1"."title" as "title", "d1"."content" as "content", "d1"."published" as "published", "d1"."author_id" as "authorId", "d1"."category_id" as "categoryId", "d1"."createdAt" as "createdAt", "d1"."createdAt" as "updatedAt" from "posts" as "d1" where "d0"."id" = "d1"."author_id") as "t"), jsonb_array()) as "posts" from "users" as "d0" where "d0"."id" = ? limit ? -- params: [1, 1, 1]",
+        "Query: select "d0"."id" as "id", ((select count(*) from "posts" where "posts"."author_id" = "d0"."id")) as "_posts_count", coalesce((select json_group_array(json_object('postId', "postId", 'slug', "slug", 'title', "title", 'content', "content", 'published', "published", 'authorId', "authorId", 'categoryId', "categoryId", 'createdAt', "createdAt", 'updatedAt', "updatedAt")) as "r" from (select "d1"."id" as "postId", "d1"."slug" as "slug", "d1"."title" as "title", "d1"."content" as "content", "d1"."published" as "published", "d1"."author_id" as "authorId", "d1"."category_id" as "categoryId", "d1"."createdAt" as "createdAt", "d1"."createdAt" as "updatedAt" from "posts" as "d1" where "d0"."id" = "d1"."author_id" order by "d1"."id" desc limit ?) as "t"), jsonb_array()) as "posts" from "users" as "d0" where "d0"."id" in (?) -- params: [3, 1]",
+      ]
+    `);
+    clearDrizzleLogs();
+
+    const raw = await execute({
+      schema,
+      document: gql`
+        query {
+          rawUser {
+            profile {
+              id
+            }
+            posts {
+              id
+            }
+            postCount
+            postsConnection(first: 2) {
+              totalCount
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `,
+      contextValue: { user: { id: 1 } },
+    });
+
+    expect(raw.errors).toBeUndefined();
+    expect(raw.data).toEqual({ rawUser: (planned.data as { user: unknown }).user });
+    expect(drizzleLogs).toMatchInlineSnapshot(`
+      [
+        "Query: select "d0"."id" as "id", "d0"."username" as "username", "d0"."first_name" as "firstName", "d0"."last_name" as "lastName" from "users" as "d0" where "d0"."id" = ? limit ? -- params: [1, 1]",
+        "Query: select "d0"."id" as "id", ((select count(*) from "posts" where "posts"."author_id" = "d0"."id")) as "_posts_count", (select json_object('id', "id", 'userId', "userId", 'bio', "bio") as "r" from (select "d1"."id" as "id", "d1"."user_id" as "userId", "d1"."bio" as "bio" from "profile" as "d1" where "d0"."id" = "d1"."user_id" limit ?) as "t") as "profile", coalesce((select json_group_array(json_object('postId', "postId", 'slug', "slug", 'title', "title", 'content', "content", 'published', "published", 'authorId', "authorId", 'categoryId', "categoryId", 'createdAt', "createdAt", 'updatedAt', "updatedAt")) as "r" from (select "d1"."id" as "postId", "d1"."slug" as "slug", "d1"."title" as "title", "d1"."content" as "content", "d1"."published" as "published", "d1"."author_id" as "authorId", "d1"."category_id" as "categoryId", "d1"."createdAt" as "createdAt", "d1"."createdAt" as "updatedAt" from "posts" as "d1" where "d0"."id" = "d1"."author_id") as "t"), jsonb_array()) as "posts" from "users" as "d0" where "d0"."id" in (?) -- params: [1, 1]",
+        "Query: select "d0"."id" as "id", ((select count(*) from "posts" where "posts"."author_id" = "d0"."id")) as "_posts_count", coalesce((select json_group_array(json_object('postId', "postId", 'slug', "slug", 'title', "title", 'content', "content", 'published', "published", 'authorId', "authorId", 'categoryId', "categoryId", 'createdAt', "createdAt", 'updatedAt', "updatedAt")) as "r" from (select "d1"."id" as "postId", "d1"."slug" as "slug", "d1"."title" as "title", "d1"."content" as "content", "d1"."published" as "published", "d1"."author_id" as "authorId", "d1"."category_id" as "categoryId", "d1"."createdAt" as "createdAt", "d1"."createdAt" as "updatedAt" from "posts" as "d1" where "d0"."id" = "d1"."author_id" order by "d1"."id" desc limit ?) as "t"), jsonb_array()) as "posts" from "users" as "d0" where "d0"."id" in (?) -- params: [3, 1]",
+      ]
+    `);
+  });
+
+  it('answers a totalCount-only connection from the loaded count', async () => {
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          rawUser {
+            postsConnection {
+              totalCount
+            }
+          }
+        }
+      `,
+      contextValue: { user: { id: 1 } },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ rawUser: { postsConnection: { totalCount: 15 } } });
+    expect(drizzleLogs).toHaveLength(2);
+    expect(drizzleLogs[1]).toContain('count(*)');
   });
 });

--- a/packages/plugin-drizzle/tests/relation-loading.test.ts
+++ b/packages/plugin-drizzle/tests/relation-loading.test.ts
@@ -27,8 +27,11 @@ builder.drizzleObject('posts', {
   fields: (t) => ({
     id: t.exposeID('postId'),
     title: t.exposeString('title'),
+    author: t.relation('author'),
   }),
 });
+
+let recordedSegments: { field: string; isList: boolean }[] = [];
 
 builder.drizzleObject('userProfile', {
   name: 'Profile',
@@ -48,6 +51,12 @@ const User = builder.drizzleObject('users', {
     postsConnection: t.relatedConnection('posts', {
       totalCount: true,
       query: () => ({ orderBy: { postId: 'desc' } }),
+    }),
+    postsWithPath: t.relation('posts', {
+      query: (_args, _ctx, pathInfo) => {
+        recordedSegments = pathInfo.segments;
+        return {};
+      },
     }),
     postsWithResolve: t.relatedConnection('posts', {
       // A custom resolver was accepted and silently discarded; it is now rejected.
@@ -71,6 +80,11 @@ builder.queryType({
     rawUser: t.drizzleField({
       type: User,
       resolve: () => db.query.users.findFirst({ where: { id: 1 } }),
+    }),
+    // A row that carries the relation rows but not the count the connection also needs.
+    userWithPosts: t.drizzleField({
+      type: User,
+      resolve: () => db.query.users.findFirst({ where: { id: 1 }, with: { posts: true } }),
     }),
   }),
 });
@@ -176,6 +190,85 @@ describe('relation loading', () => {
 
     expect(result.errors).toBeUndefined();
     expect(result.data).toEqual({ rawUser: { postsConnection: { totalCount: 15 } } });
+    expect(drizzleLogs).toHaveLength(2);
+    expect(drizzleLogs[1]).toContain('count(*)');
+  });
+
+  it('answers a totalCount-only connection selected through a fragment', async () => {
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          rawUser {
+            postsConnection {
+              ... on UserPostsConnection {
+                totalCount
+              }
+            }
+          }
+        }
+      `,
+      contextValue: { user: { id: 1 } },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ rawUser: { postsConnection: { totalCount: 15 } } });
+  });
+
+  it('treats a connection whose row fields are skipped as totalCount-only', async () => {
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          rawUser {
+            postsConnection {
+              totalCount
+              edges @skip(if: true) {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `,
+      contextValue: { user: { id: 1 } },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ rawUser: { postsConnection: { totalCount: 15 } } });
+  });
+
+  it('loads the count when the row has the relation but not the count', async () => {
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          userWithPosts {
+            postsConnection(first: 2) {
+              totalCount
+              edges {
+                node {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `,
+      contextValue: { user: { id: 1 } },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      userWithPosts: {
+        postsConnection: {
+          totalCount: 15,
+          edges: [{ node: { id: '15' } }, { node: { id: '14' } }],
+        },
+      },
+    });
+    // the raw row, then the loader reloading the connection with its count
     expect(drizzleLogs).toHaveLength(2);
     expect(drizzleLogs[1]).toContain('count(*)');
   });

--- a/packages/plugin-prisma/src/prisma-field-builder.ts
+++ b/packages/plugin-prisma/src/prisma-field-builder.ts
@@ -466,11 +466,11 @@ export class PrismaObjectFieldBuilder<
               info,
             )),
       },
-      resolve: (parent) => {
+      resolve: (parent, args, context, info) => {
         const result = (parent as Record<string, never>)[name];
 
         if (typeof onNull === 'function' && result == null) {
-          return onNull(parent, {} as never, {} as never, {} as never) as never;
+          return onNull(parent, args as never, context, info) as never;
         }
 
         return result;

--- a/packages/plugin-prisma/src/util/deep-equal.ts
+++ b/packages/plugin-prisma/src/util/deep-equal.ts
@@ -31,18 +31,15 @@ export function deepEqual(left: unknown, right: unknown, ignore?: Set<string>) {
       return lValue === rValue;
     }
 
-    const keys = Object.keys(left);
-    const keyLength = keys.length;
+    // Keys holding `undefined` are treated as absent, so `{ where: cond ? filter : undefined }`
+    // compares equal to `{}` when the condition is false. Ignored keys are skipped on both sides.
+    const keys = comparedKeys(left as Record<string, unknown>, ignore);
 
-    if (keyLength !== Object.keys(right).length) {
+    if (keys.length !== comparedKeys(right as Record<string, unknown>, ignore).length) {
       return false;
     }
 
     for (const key of keys) {
-      if (ignore?.has(key)) {
-        continue;
-      }
-
       if (
         !deepEqual((left as Record<string, unknown>)[key], (right as Record<string, unknown>)[key])
       ) {
@@ -54,4 +51,8 @@ export function deepEqual(left: unknown, right: unknown, ignore?: Set<string>) {
   }
 
   return false;
+}
+
+function comparedKeys(value: Record<string, unknown>, ignore?: Set<string>) {
+  return Object.keys(value).filter((key) => value[key] !== undefined && !ignore?.has(key));
 }

--- a/packages/plugin-prisma/src/util/map-query.ts
+++ b/packages/plugin-prisma/src/util/map-query.ts
@@ -681,7 +681,11 @@ export function selectionStateFromInfo(
     );
   }
 
-  addFieldSelection(type, context, info, state, info.fieldNodes[0], []);
+  // The same response key can be selected more than once (through fragments); every occurrence
+  // contributes to what the resolver will read.
+  for (const fieldNode of info.fieldNodes) {
+    addFieldSelection(type, context, info, state, fieldNode, []);
+  }
 
   return state;
 }

--- a/packages/plugin-prisma/tests/relation-options.test.ts
+++ b/packages/plugin-prisma/tests/relation-options.test.ts
@@ -20,6 +20,7 @@ builder.prismaObject('Post', {
   fields: (t) => ({
     id: t.exposeID('id'),
     title: t.exposeString('title'),
+    author: t.relation('author'),
   }),
 });
 
@@ -55,6 +56,11 @@ builder.prismaObject('User', {
 
 builder.queryType({
   fields: (t) => ({
+    // Returns a row fetched without the planned selection, so relation fields load themselves.
+    rawUser: t.prismaField({
+      type: 'User',
+      resolve: () => prisma.user.findUniqueOrThrow({ where: { id: 1 } }),
+    }),
     user: t.prismaField({
       type: 'User',
       args: { id: t.arg.int({ required: true }) },
@@ -128,6 +134,43 @@ describe('relation field options', () => {
     expect(result.data).toEqual({ user: { profile: null } });
     expect(result.errors?.map((error) => error.message)).toEqual([
       `no profile for user ${userWithoutProfile.id} (primary) via User.profile for viewer 42`,
+    ]);
+  });
+
+  it('plans every occurrence of the field when loading it through the fallback', async () => {
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          rawUser {
+            posts {
+              id
+            }
+            ... on User {
+              posts {
+                author {
+                  id
+                }
+              }
+            }
+          }
+        }
+      `,
+      contextValue: { user: { id: 1 } },
+    });
+
+    expect(result.errors).toBeUndefined();
+    const posts = (result.data as { rawUser: { posts: { id: string; author: { id: string } }[] } })
+      .rawUser.posts;
+    expect(posts.length).toBeGreaterThan(0);
+    expect(posts.every((post) => post.author.id === '1')).toBe(true);
+    expect(queries).toEqual([
+      { action: 'findUniqueOrThrow', model: 'User', args: { where: { id: 1 } } },
+      {
+        action: 'findUniqueOrThrow',
+        model: 'User',
+        args: { include: { posts: { include: { author: true } } }, where: { id: 1 } },
+      },
     ]);
   });
 });

--- a/packages/plugin-prisma/tests/relation-options.test.ts
+++ b/packages/plugin-prisma/tests/relation-options.test.ts
@@ -42,6 +42,14 @@ builder.prismaObject('User', {
       select: { posts: { select: { title: true } } },
       resolve: (user) => user.posts.map((post) => post.title),
     }),
+    profile: t.relation('profile', {
+      nullable: true,
+      args: { label: t.arg.string() },
+      onNull: (user, args, context, info) =>
+        new Error(
+          `no profile for user ${user.id} (${args.label}) via ${info.parentType.name}.${info.fieldName} for viewer ${context.user.id}`,
+        ),
+    }),
   }),
 });
 
@@ -93,6 +101,33 @@ describe('relation field options', () => {
           where: { id: 1 },
         },
       },
+    ]);
+  });
+
+  it('passes args, context and info to onNull', async () => {
+    const userWithoutProfile = await prisma.user.findFirstOrThrow({
+      where: { profile: null },
+      select: { id: true },
+    });
+
+    const result = await execute({
+      schema,
+      document: gql`
+        query ($id: Int!) {
+          user(id: $id) {
+            profile(label: "primary") {
+              id
+            }
+          }
+        }
+      `,
+      variableValues: { id: userWithoutProfile.id },
+      contextValue: { user: { id: 42 } },
+    });
+
+    expect(result.data).toEqual({ user: { profile: null } });
+    expect(result.errors?.map((error) => error.message)).toEqual([
+      `no profile for user ${userWithoutProfile.id} (primary) via User.profile for viewer 42`,
     ]);
   });
 });

--- a/packages/plugin-prisma/tests/relation-options.test.ts
+++ b/packages/plugin-prisma/tests/relation-options.test.ts
@@ -1,0 +1,98 @@
+import SchemaBuilder from '@pothos/core';
+import { execute } from '@pothos/test-utils';
+import { gql } from 'graphql-tag';
+import PrismaPlugin, { type PrismaTypesFromClient } from '../src';
+import { prisma, queries } from './example/builder';
+import { getDatamodel } from './generated.js';
+
+const builder = new SchemaBuilder<{
+  PrismaTypes: PrismaTypesFromClient<typeof prisma>;
+  Context: { user: { id: number } };
+}>({
+  plugins: [PrismaPlugin],
+  prisma: {
+    client: () => prisma,
+    dmmf: getDatamodel(),
+  },
+});
+
+builder.prismaObject('Post', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    title: t.exposeString('title'),
+  }),
+});
+
+builder.prismaObject('Profile', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+
+builder.prismaObject('User', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    // A conditional filter. When the condition is false the relation query still carries a `where`
+    // key holding `undefined`, which must compare equal to a selection without one.
+    posts: t.relation('posts', {
+      args: { published: t.arg.boolean() },
+      query: (args) => ({ where: args.published ? { published: true } : undefined }),
+    }),
+    postTitles: t.stringList({
+      select: { posts: { select: { title: true } } },
+      resolve: (user) => user.posts.map((post) => post.title),
+    }),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    user: t.prismaField({
+      type: 'User',
+      args: { id: t.arg.int({ required: true }) },
+      resolve: (query, _root, args) =>
+        prisma.user.findUniqueOrThrow({ ...query, where: { id: args.id } }),
+    }),
+  }),
+});
+
+const schema = builder.toSchema();
+
+describe('relation field options', () => {
+  afterEach(() => {
+    queries.length = 0;
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('treats a relation query with `where: undefined` as compatible with a plain selection', async () => {
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          user(id: 1) {
+            posts {
+              id
+            }
+            postTitles
+          }
+        }
+      `,
+      contextValue: { user: { id: 1 } },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(queries).toEqual([
+      {
+        action: 'findUniqueOrThrow',
+        model: 'User',
+        args: {
+          include: { posts: { where: undefined } },
+          where: { id: 1 },
+        },
+      },
+    ]);
+  });
+});

--- a/website/content/docs/plugins/drizzle.mdx
+++ b/website/content/docs/plugins/drizzle.mdx
@@ -266,8 +266,16 @@ builder.drizzleObject('users', {
 
 The query API enables you to define args and convert them into parameters that will be passed into
 the relational query builder. The `query` callback receives `(args, ctx, pathInfo)` where `pathInfo`
-contains the GraphQL query path information (`path` and `segments`). You can read more about the
-relation query builder api [here](https://orm.drizzle.team/docs/rqb#querying)
+describes where in the GraphQL query the relation is being loaded:
+
+- `path`: a list of `ParentType.fieldName` strings, from the root field down to the field being
+  resolved (eg. `['Query.user', 'User.posts']`).
+- `segments`: one object per entry in `path`, with `field` (the field name), `alias` (the alias used
+  in the query, or the field name if none), `parentType` (the name of the type the field is defined
+  on), and `isList` (whether the field returns a list).
+
+You can read more about the relation query builder api
+[here](https://orm.drizzle.team/docs/rqb#querying)
 
 ## Drizzle Fields
 
@@ -491,9 +499,10 @@ is that the `orderBy` format is slightly changed.
 
 To comply with the relay spec and efficiently support backwards pagination, some queries need to be
 performed in reverse order, which requires inverting the orderBy clause. To do this automatically,
-the `t.relatedConnection` method accepts orderBy as an object like `{ asc: column }` or
-`{ desc: column }` rather than using the `asc(column)` and `desc(column)` helpers from drizzle.
-orderBy can still be returned as either a single column or array when ordering by multiple columns.
+the `t.relatedConnection` method accepts orderBy as an object keyed by column name with `'asc'` or
+`'desc'` values, like `{ createdAt: 'desc' }`, rather than using the `asc(column)` and
+`desc(column)` helpers from drizzle. orderBy can also be returned as a single column, or an array of
+columns when ordering by multiple columns, which orders ascending.
 
 Ordering defaults to using the table `primaryKey`, and the orderBy columns will also be used to
 derive the connections cursor.
@@ -557,6 +566,23 @@ query {
     }
   }
 }
+```
+
+The count applies the `where` returned by the field's `query`, so it counts the same rows the
+connection paginates (only published posts in the example above). To count every related row
+regardless of the filter, set `filterConnectionTotalCount: false` in the `drizzle` plugin options:
+
+```ts
+const builder = new SchemaBuilder<PothosTypes>({
+  plugins: [DrizzlePlugin],
+  drizzle: {
+    client: db,
+    getTableConfig,
+    relations,
+    // count every related row for totalCount, ignoring the where from query (defaults to true)
+    filterConnectionTotalCount: false,
+  },
+});
 ```
 
 ## Ordering and cursors
@@ -769,7 +795,7 @@ const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
   resolveNode: (userRole) => userRole.role,
 });
 
-builder.drizzleObjectField('User', 'rolesConnection', (t) =>
+builder.drizzleObjectField('users', 'rolesConnection', (t) =>
   t.connection({
     // The type for the Node
     type: Role,
@@ -797,7 +823,7 @@ connections share the same model, and pagination happens directly on a relation 
 if that relation is nested).
 
 ```ts
-const commentConnectionHelpers = drizzleConnectionHelpers(builder, 'Comment');
+const commentConnectionHelpers = drizzleConnectionHelpers(builder, 'comments');
 
 const SelectPost = builder.drizzleObject('posts', {
   fields: (t) => ({
@@ -843,7 +869,7 @@ const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
 });
 
 
-builder.drizzleObjectField('User', 'rolesConnection', (t) =>
+builder.drizzleObjectField('users', 'rolesConnection', (t) =>
   t.connection({
     type: Role,
     // add the args from the connection helper to the field
@@ -872,7 +898,7 @@ const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
   resolveNode: (userRole) => userRole.role,
 });
 
-builder.drizzleObjectFields('User', (t) => ({
+builder.drizzleObjectFields('users', (t) => ({
   rolesConnection: t.connection(
     {
       type: Role,

--- a/website/content/docs/plugins/prisma/connections.mdx
+++ b/website/content/docs/plugins/prisma/connections.mdx
@@ -43,11 +43,17 @@ builder.queryType({
 
 The created connection queries currently support the following combinations of connection arguments:
 
-- `first`, `last`, or `before`
+- `first`, `last`, `before`, or `after` on their own
+- `first` and `after`
+- `last` and `before`
+
+The following combinations are not supported:
+
+- `before` and `after`
 - `first` and `before`
 - `last` and `after`
 
-Queries for other combinations are not as useful, and generally requiring loading all records
+Queries for these combinations are not as useful, and generally requiring loading all records
 between 2 cursors, or between a cursor and the end of the set. Generating query options for these
 cases is more complex and likely very inefficient, so they will currently throw an Error indicating
 the argument combinations are not supported.
@@ -98,8 +104,8 @@ builder.prismaNode('User', {
 - `query`: A method that accepts the `args` and `context` for the connection field, and returns
   filtering and sorting logic that will be merged into the query for the relation.
 - `totalCount`: when set to true, this will add a `totalCount` field to the connection object. see
-  `relationCount` above for more details. Note that this will not work when using a shared
-  connection object (see details below)
+  [`relationCount`](./relations#relationcount) for more details. Note that this will not work when
+  using a shared connection object (see details below)
 
 ### Indirect relations as connections
 
@@ -319,18 +325,22 @@ builder.prismaObjectFields('Post', (t) => ({
     {
       type: Media,
       select: (args, ctx, nestedSelection) => ({
-        media: mediaConnectionHelpers.getQuery(args, ctx, nestedSelection),
-        select: {
-          media: nestedSelection({}, ['edges', 'node']),
+        // count the join table rows for totalCount
+        _count: {
+          select: {
+            media: true,
+          },
+        },
+        // select the join table rows, with the pagination and node selection from the helpers
+        media: {
+          ...mediaConnectionHelpers.getQuery(args, ctx, nestedSelection),
         },
       }),
 
-      resolve: (post, args, ctx) =>
-        mediaConnectionHelpers.resolve(
-          post.media.map(({ media }) => media),
-          args,
-          ctx,
-        ),
+      resolve: (post, args, ctx) => ({
+        totalCount: post._count.media,
+        ...mediaConnectionHelpers.resolve(post.media, args, ctx),
+      }),
     },
     {},
     // options for the edge object

--- a/website/content/docs/plugins/prisma/index.mdx
+++ b/website/content/docs/plugins/prisma/index.mdx
@@ -38,6 +38,8 @@ builder.prismaObject('User', {
     id: t.exposeID('id'),
     email: t.exposeString('email'),
     bio: t.string({
+      // the profile relation is nullable, so this field is too
+      nullable: true,
       // automatically load the bio from the profile
       // when this field is queried
       select: {
@@ -49,7 +51,7 @@ builder.prismaObject('User', {
       },
       // user will be typed correctly to include the
       // selected fields from above
-      resolve: (user) => user.profile.bio,
+      resolve: (user) => user.profile?.bio,
     }),
     // Load posts as list field.
     posts: t.relation('posts', {

--- a/website/content/docs/plugins/prisma/selections.mdx
+++ b/website/content/docs/plugins/prisma/selections.mdx
@@ -19,9 +19,11 @@ builder.prismaObject('User', {
     id: t.exposeID('id'),
     email: t.exposeString('email'),
     bio: t.string({
+      // The profile relation is nullable, so this field is too.
+      nullable: true,
       // The profile relation will always be loaded, and user will now be typed to include the
       // profile field so you can return the bio from the nested profile relation.
-      resolve: (user) => user.profile.bio,
+      resolve: (user) => user.profile?.bio,
     }),
   }),
 });


### PR DESCRIPTION
Stacked on #1669. Second PR in the selection-mapper stack; each commit is one fix with its own test.

## Prisma

- **`where: undefined` no longer splits a relation selection.** A relation `query` returning `{ where: cond ? filter : undefined }` was incompatible with a sibling selection of the same relation whenever the condition was false, so the sibling fell back to a per-row query. `deepEqual` now treats keys holding `undefined` as absent on both sides. (`tests/relation-options.test.ts`)
- **`onNull` receives `args`, `context`, `info`.** It was called with empty objects, so any callback reading them threw. (`tests/relation-options.test.ts`)

## Drizzle

- **`relatedConnection` `totalCount` applies the field's `where`.** The count was built from the relation columns only, so a filtered connection reported the unfiltered count; the package's own snapshot asserted the wrong number. New builder option `drizzle.filterConnectionTotalCount` (default `true`) restores the old count when set to `false`, matching prisma's option. (`tests/related-connection.test.ts` snapshots: count 15 → 9 published posts)
- **`relatedConnection` rejects `resolve` in its types.** It was accepted and silently discarded. (`tests/relation-loading.test.ts`)
- **`drizzleConnectionHelpers(builder, table)` works without an options argument**, as the docs show. It threw on destructuring. (`tests/relation-loading.test.ts`)
- **Relations missing from a parent row are loaded instead of answered from missing data.** When a resolver returned a row it fetched itself, `t.relation` returned `undefined`, `t.relatedCount` returned `undefined`, and `t.relatedConnection` returned an empty page, because the loader mapping alone was trusted. Fields now declare a `pothosDrizzleLoaded` check mirroring prisma's `pothosPrismaLoaded`, and `wrapResolve` falls back to the model loader when the data is not on the row. `t.relatedField` (and so `t.relatedCount`) now forwards every option and merges `extensions`. (`tests/relation-loading.test.ts`)

## Docs

Corrections from the API audit: the prisma pagination-combination list was inverted; the "Extending connection edges" example returned a `select` key Prisma rejects; strict-null examples; drizzle `orderBy` prose contradicted its own examples; `drizzleConnectionHelpers` and `drizzleObjectField(s)` examples passed GraphQL type names where table names are required; `totalCount` filtering and the new option; the shape of `pathInfo`.

## Not in this PR

The drizzle `relatedConnection` `pathInfo` mismatch between the select path and the resolve path is deferred to the shared-walker PR, where the mapping record that carries it is redesigned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf25mwTTUmeM2ogHxq3idp