### PR TITLE
feat(prisma, drizzle): async selection callbacks with a zero-cost synchronous path

### DIFF
--- a/.changeset/selection-mapper-async.md
+++ b/.changeset/selection-mapper-async.md
@@ -13,7 +13,8 @@ Allow the callbacks that build a selection to be async.
   `select` and silently dropped it.
 - The plugin still builds one query: callbacks start in the same tick, and what they return is
   merged after every synchronous selection, in document order. Schemas without async callbacks are
-  unaffected: no promise is created until a callback returns one.
+  unaffected: until a callback returns a promise, planning and resolving create no promise and no
+  closure they did not create before.
 - Inside an async `select`, `await` the result of `nestedSelection` (and of `getQuery` from the
   connection helpers) before adding it to the selection; a selection holding the promise itself
   throws with a message naming the relation. `queryFromInfo` (prisma) and the `query()` builder

--- a/.changeset/selection-mapper-async.md
+++ b/.changeset/selection-mapper-async.md
@@ -17,7 +17,8 @@ Allow the callbacks that build a selection to be async.
   closure they did not create before.
 - Inside an async `select`, `await` the result of `nestedSelection` (and of `getQuery` from the
   connection helpers) before adding it to the selection; a selection holding the promise itself
-  throws with a message naming the relation. `queryFromInfo` returns a promise when a callback
+  throws with a message naming the relation, and a `select` that returns while a nested selection
+  it started is still pending throws with a message naming the field. `queryFromInfo` returns a promise when a callback
   beneath the field is async, and must then be awaited; its declared type stays synchronous. The
   `query()` builder handed to a `drizzleField` or `drizzleConnection` resolver never returns a
   promise: the plan is settled before the resolver runs, and the builder merges into it.

--- a/.changeset/selection-mapper-async.md
+++ b/.changeset/selection-mapper-async.md
@@ -17,6 +17,7 @@ Allow the callbacks that build a selection to be async.
   closure they did not create before.
 - Inside an async `select`, `await` the result of `nestedSelection` (and of `getQuery` from the
   connection helpers) before adding it to the selection; a selection holding the promise itself
-  throws with a message naming the relation. `queryFromInfo` (prisma) and the `query()` builder
-  handed to a `drizzleField` resolver return a promise when a callback beneath the field is async,
-  and must then be awaited; their declared types stay synchronous.
+  throws with a message naming the relation. `queryFromInfo` returns a promise when a callback
+  beneath the field is async, and must then be awaited; its declared type stays synchronous. The
+  `query()` builder handed to a `drizzleField` or `drizzleConnection` resolver never returns a
+  promise: the plan is settled before the resolver runs, and the builder merges into it.

--- a/.changeset/selection-mapper-async.md
+++ b/.changeset/selection-mapper-async.md
@@ -1,0 +1,21 @@
+---
+'@pothos/selection-mapper': patch
+'@pothos/plugin-prisma': patch
+'@pothos/plugin-drizzle': patch
+---
+
+Allow the callbacks that build a selection to be async.
+
+- A field's `select` function, a relation `query` callback, a `relationCount` / `relatedCount`
+  `where` callback, and the `select` / `query` callbacks of `prismaConnectionHelpers` and
+  `drizzleConnectionHelpers` may return promises. Async argument mappers (such as the validation
+  plugin's) are awaited before the field's `select` runs. Prisma previously accepted an async
+  `select` and silently dropped it.
+- The plugin still builds one query: callbacks start in the same tick, and what they return is
+  merged after every synchronous selection, in document order. Schemas without async callbacks are
+  unaffected: no promise is created until a callback returns one.
+- Inside an async `select`, `await` the result of `nestedSelection` (and of `getQuery` from the
+  connection helpers) before adding it to the selection; a selection holding the promise itself
+  throws with a message naming the relation. `queryFromInfo` (prisma) and the `query()` builder
+  handed to a `drizzleField` resolver return a promise when a callback beneath the field is async,
+  and must then be awaited; their declared types stay synchronous.

--- a/packages/plugin-drizzle/src/connection-helpers.ts
+++ b/packages/plugin-drizzle/src/connection-helpers.ts
@@ -1,9 +1,16 @@
-import type { InputFieldMap, InputShapeFromFields, SchemaTypes } from '@pothos/core';
+import {
+  completeValue,
+  type InputFieldMap,
+  type InputShapeFromFields,
+  type MaybePromise,
+  type SchemaTypes,
+} from '@pothos/core';
 import { createNode } from '@pothos/selection-mapper';
 import type {
   BuildQueryResult,
   DBQueryConfig,
   RelationsFilter,
+  SQL,
   TableRelationalConfig,
 } from 'drizzle-orm';
 import type { GraphQLResolveInfo } from 'graphql';
@@ -19,7 +26,7 @@ import {
 } from './utils/cursors.js';
 import { queryFromInfo } from './utils/map-query.js';
 import { getRefFromModel } from './utils/refs.js';
-import { omitUndefinedKeys } from './utils/selections.js';
+import { omitUndefinedKeys, type SelectionMap } from './utils/selections.js';
 
 export function drizzleConnectionHelpers<
   Types extends SchemaTypes,
@@ -60,11 +67,14 @@ export function drizzleConnectionHelpers<
       nestedSelection: <T extends true | {}>(selection?: T) => T,
       args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
       ctx: Types['Context'],
-    ) => Selection;
+    ) => MaybePromise<Selection>;
     query?: QueryForDrizzleConnection<Types, TableConfig> extends infer QueryConfig
       ?
           | QueryConfig
-          | ((args: InputShapeFromFields<ExtraArgs>, context: Types['Context']) => QueryConfig)
+          | ((
+              args: InputShapeFromFields<ExtraArgs>,
+              context: Types['Context'],
+            ) => MaybePromise<QueryConfig>)
       : never;
     defaultSize?:
       | number
@@ -86,22 +96,45 @@ export function drizzleConnectionHelpers<
       : (refOrType as DrizzleRef<Types, Type extends DrizzleRef<Types, infer T> ? T : Type>)
           .tableName;
 
+  interface BaseQuery {
+    limit?: number;
+    orderBy?: unknown;
+    where?: SQL;
+    columns?: Record<string, boolean>;
+    extras?: DrizzleCursorConnectionQueryOptions['extras'];
+  }
+
+  /** The user's `query`, a promise when its callback is async (A-7: awaited by the caller). */
+  const baseQueryFor = (
+    args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
+    ctx: Types['Context'],
+  ): MaybePromise<BaseQuery> =>
+    completeValue(
+      (typeof query === 'function' ? query(args, ctx) : query) as MaybePromise<
+        BaseQuery | null | undefined
+      >,
+      orEmpty,
+    );
+
   function resolve<Parent = undefined>(
     list: (EdgeShape & {})[],
     args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
     ctx: Types['Context'],
     parent?: Parent,
   ) {
-    const { select, cursorFields } = getQueryArgs(args, ctx);
-    const formatCursor = getCursorFormatter(cursorFields, config);
-    return wrapConnectionResult(
-      list,
-      args,
-      select.limit,
-      formatCursor,
-      (resolveNode as never) ?? ((edge: unknown) => edge),
-      parent,
-    ) as unknown as {
+    return completeValue(baseQueryFor(args, ctx), (baseQuery) => {
+      const { select, cursorFields } = getQueryArgs(args, ctx, baseQuery);
+      const formatCursor = getCursorFormatter(cursorFields, config);
+
+      return wrapConnectionResult(
+        list,
+        args,
+        select.limit,
+        formatCursor,
+        (resolveNode as never) ?? ((edge: unknown) => edge),
+        parent,
+      );
+    }) as unknown as {
       parent: Parent;
       edges: (Omit<EdgeShape, 'cursor' | 'node'> & { node: NodeShape; cursor: string })[];
       pageInfo: {
@@ -116,9 +149,9 @@ export function drizzleConnectionHelpers<
   const getQueryArgs = (
     args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
     ctx: {},
+    baseQuery: BaseQuery,
   ) => {
-    const { limit, orderBy, where, ...fieldQuery } =
-      (typeof query === 'function' ? query(args, ctx) : query) ?? {};
+    const { limit, orderBy, where, ...fieldQuery } = baseQuery;
     const table = config.relations[tableName];
 
     const { cursorFields, columns, ...connectionQuery } = drizzleCursorConnectionQuery({
@@ -167,26 +200,29 @@ export function drizzleConnectionHelpers<
               select,
               path,
             });
-    const nestedSelect: Record<string, unknown> | true = select
+    // Both callbacks start now; the query waits for whichever of them is async (A-3, A-7: the
+    // declared type stays synchronous, so an async schema awaits the result).
+    const nestedSelect: MaybePromise<Record<string, unknown> | true> = select
       ? select((sel) => nestedSelection(sel, ['edges', 'node']), args, ctx)
       : nestedSelection(true, ['edges', 'node']);
-    const queryArgs = getQueryArgs(args, ctx);
+    const baseQuery = baseQueryFor(args, ctx);
 
-    const node = createNode(config.relations[tableName]);
+    return completeValue(nestedSelect, (nestedSelect) =>
+      completeValue(baseQuery, (baseQuery) => {
+        const node = createNode(config.relations[tableName]);
 
-    adapter.merge(node, queryArgs.select);
+        adapter.merge(node, getQueryArgs(args, ctx, baseQuery).select as SelectionMap);
 
-    if (typeof nestedSelect === 'object' && nestedSelect) {
-      adapter.merge(node, nestedSelect);
-    }
+        if (typeof nestedSelect === 'object' && nestedSelect) {
+          adapter.merge(node, nestedSelect);
+        }
 
-    const baseQuery = typeof query === 'function' ? query(args, ctx) : (query ?? {});
-    const queryResult = adapter.serialize(node);
-
-    return omitUndefinedKeys({
-      ...baseQuery,
-      ...queryResult,
-    }) as unknown as Omit<Selection, 'orderBy'> & {
+        return omitUndefinedKeys({
+          ...baseQuery,
+          ...adapter.serialize(node),
+        });
+      }),
+    ) as unknown as Omit<Selection, 'orderBy'> & {
       orderBy: {
         [K in TableConfig['table']['_'] extends { columns: infer Columns }
           ? keyof Columns
@@ -197,6 +233,10 @@ export function drizzleConnectionHelpers<
   }
 
   const getArgs = () => (createArgs ? builder.args(createArgs) : {}) as ExtraArgs;
+
+  function orEmpty(baseQuery: BaseQuery | null | undefined): BaseQuery {
+    return baseQuery ?? ({} as BaseQuery);
+  }
 
   return {
     ref: (typeof refOrType === 'string'

--- a/packages/plugin-drizzle/src/connection-helpers.ts
+++ b/packages/plugin-drizzle/src/connection-helpers.ts
@@ -2,6 +2,7 @@ import {
   completeValue,
   type InputFieldMap,
   type InputShapeFromFields,
+  isThenable,
   type MaybePromise,
   type SchemaTypes,
 } from '@pothos/core';
@@ -116,25 +117,38 @@ export function drizzleConnectionHelpers<
       orEmpty,
     );
 
+  // Built once per helper, so a synchronous `resolve` allocates nothing beyond the connection.
+  const resolveList = (
+    baseQuery: BaseQuery,
+    list: (EdgeShape & {})[],
+    args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
+    ctx: Types['Context'],
+    parent: unknown,
+  ) => {
+    const { select, cursorFields } = getQueryArgs(args, ctx, baseQuery);
+    const formatCursor = getCursorFormatter(cursorFields, config);
+
+    return wrapConnectionResult(
+      list,
+      args,
+      select.limit,
+      formatCursor,
+      (resolveNode as never) ?? ((edge: unknown) => edge),
+      parent,
+    );
+  };
+
   function resolve<Parent = undefined>(
     list: (EdgeShape & {})[],
     args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
     ctx: Types['Context'],
     parent?: Parent,
   ) {
-    return completeValue(baseQueryFor(args, ctx), (baseQuery) => {
-      const { select, cursorFields } = getQueryArgs(args, ctx, baseQuery);
-      const formatCursor = getCursorFormatter(cursorFields, config);
+    const baseQuery = baseQueryFor(args, ctx);
 
-      return wrapConnectionResult(
-        list,
-        args,
-        select.limit,
-        formatCursor,
-        (resolveNode as never) ?? ((edge: unknown) => edge),
-        parent,
-      );
-    }) as unknown as {
+    return (isThenable(baseQuery)
+      ? baseQuery.then((resolved) => resolveList(resolved, list, args, ctx, parent))
+      : resolveList(baseQuery, list, args, ctx, parent)) as unknown as {
       parent: Parent;
       edges: (Omit<EdgeShape, 'cursor' | 'node'> & { node: NodeShape; cursor: string })[];
       pageInfo: {
@@ -207,22 +221,11 @@ export function drizzleConnectionHelpers<
       : nestedSelection(true, ['edges', 'node']);
     const baseQuery = baseQueryFor(args, ctx);
 
-    return completeValue(nestedSelect, (nestedSelect) =>
-      completeValue(baseQuery, (baseQuery) => {
-        const node = createNode(config.relations[tableName]);
-
-        adapter.merge(node, getQueryArgs(args, ctx, baseQuery).select as SelectionMap);
-
-        if (typeof nestedSelect === 'object' && nestedSelect) {
-          adapter.merge(node, nestedSelect);
-        }
-
-        return omitUndefinedKeys({
-          ...baseQuery,
-          ...adapter.serialize(node),
-        });
-      }),
-    ) as unknown as Omit<Selection, 'orderBy'> & {
+    return (isThenable(nestedSelect) || isThenable(baseQuery)
+      ? Promise.all([nestedSelect, baseQuery]).then(([nested, base]) =>
+          buildQuery(nested, base, args, ctx),
+        )
+      : buildQuery(nestedSelect, baseQuery, args, ctx)) as unknown as Omit<Selection, 'orderBy'> & {
       orderBy: {
         [K in TableConfig['table']['_'] extends { columns: infer Columns }
           ? keyof Columns
@@ -230,6 +233,27 @@ export function drizzleConnectionHelpers<
       };
       where: RelationsFilter<TableConfig, Types['DrizzleRelations']>;
     };
+  }
+
+  // Built once per helper, so a synchronous `getQuery` allocates nothing beyond the query.
+  function buildQuery(
+    nestedSelect: Record<string, unknown> | true,
+    baseQuery: BaseQuery,
+    args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
+    ctx: Types['Context'],
+  ) {
+    const node = createNode(config.relations[tableName]);
+
+    adapter.merge(node, getQueryArgs(args, ctx, baseQuery).select as SelectionMap);
+
+    if (typeof nestedSelect === 'object' && nestedSelect) {
+      adapter.merge(node, nestedSelect);
+    }
+
+    return omitUndefinedKeys({
+      ...baseQuery,
+      ...adapter.serialize(node),
+    });
   }
 
   const getArgs = () => (createArgs ? builder.args(createArgs) : {}) as ExtraArgs;

--- a/packages/plugin-drizzle/src/drizzle-field-builder.ts
+++ b/packages/plugin-drizzle/src/drizzle-field-builder.ts
@@ -311,6 +311,39 @@ export class DrizzleObjectFieldBuilder<
       return { hasTotalCount, totalCountOnly: hasTotalCount && !hasRows };
     };
 
+    // Built once per field, so a synchronous plan allocates nothing beyond the map itself.
+    const selectConnection = (
+      fieldQuery: ConnectionFieldQuery,
+      nested: SelectionMap | undefined,
+      context: object,
+      hasTotalCount: boolean,
+      totalCountOnly: boolean,
+    ) => {
+      const countSelection = {
+        [countKey]: (parent: TableConfig['table']) =>
+          getClient(this.builder, context).$count(
+            relatedTable.table as Table,
+            buildCountFilter(parent, fieldQuery.where),
+          ),
+      };
+
+      if (totalCountOnly) {
+        return {
+          columns: {},
+          with: {},
+          extras: countSelection,
+        };
+      }
+
+      return {
+        columns: {},
+        with: {
+          [name]: nested,
+        },
+        extras: hasTotalCount ? countSelection : {},
+      };
+    };
+
     const relationSelect = (
       args: object,
       context: object,
@@ -320,7 +353,7 @@ export class DrizzleObjectFieldBuilder<
     ) => {
       typeName ??= this.builder.configStore.getTypeConfig(ref).name;
 
-      const hasTotalCount = totalCount && !!getSelection(['totalCount']);
+      const hasTotalCount = !!totalCount && !!getSelection(['totalCount']);
       const hasEdges = !!getSelection(['edges']);
       const hasNodes = !!getSelection(['nodes']);
       const hasPageInfo = !!getSelection(['pageInfo']);
@@ -340,31 +373,32 @@ export class DrizzleObjectFieldBuilder<
             },
           ) as MaybePromise<SelectionMap>);
 
-      return completeValue(fieldQuery, (fieldQuery) => {
-        const countSelection = {
-          [countKey]: (parent: TableConfig['table']) =>
-            getClient(this.builder, context).$count(
-              relatedTable.table as Table,
-              buildCountFilter(parent, fieldQuery.where),
-            ),
-        };
+      return isThenable(fieldQuery) || isThenable(nested)
+        ? Promise.all([fieldQuery, nested]).then(([resolvedQuery, resolvedNested]) =>
+            selectConnection(resolvedQuery, resolvedNested, context, hasTotalCount, totalCountOnly),
+          )
+        : selectConnection(fieldQuery, nested, context, hasTotalCount, totalCountOnly);
+    };
 
-        if (totalCountOnly) {
-          return {
-            columns: {},
-            with: {},
-            extras: countSelection,
-          };
-        }
+    // The loaded path, per parent row: the rows are on the parent, only the page is needed.
+    const resolveLoaded = (
+      fieldQuery: ConnectionFieldQuery,
+      parent: unknown,
+      args: PothosSchemaTypes.DefaultConnectionArguments,
+      context: {},
+      countValue: number | undefined,
+    ) => {
+      const { select, cursorFields } = getQuery(args, context, fieldQuery);
 
-        return completeValue(nested, (nested) => ({
-          columns: {},
-          with: {
-            [name]: nested,
-          },
-          extras: hasTotalCount ? countSelection : {},
-        }));
-      });
+      return wrapConnectionResult(
+        (parent as Record<string, unknown>)[name] as readonly {}[],
+        args,
+        select.limit,
+        getCursorFormatter(cursorFields, schemaConfig),
+        undefined,
+        parent,
+        countValue,
+      );
     };
     const fieldRef = (
       this as unknown as {
@@ -424,19 +458,13 @@ export class DrizzleObjectFieldBuilder<
             | PathInfo
             | undefined;
 
-          return completeValue(resolveFieldQuery(args, context, pathInfo), (fieldQuery) => {
-            const { select, cursorFields } = getQuery(args, context, fieldQuery);
+          const fieldQuery = resolveFieldQuery(args, context, pathInfo);
 
-            return wrapConnectionResult(
-              parentRecord[name] as readonly {}[],
-              args,
-              select.limit,
-              getCursorFormatter(cursorFields, schemaConfig),
-              undefined,
-              parent,
-              countValue,
-            );
-          });
+          return isThenable(fieldQuery)
+            ? fieldQuery.then((resolved) =>
+                resolveLoaded(resolved, parent, args, context, countValue),
+              )
+            : resolveLoaded(fieldQuery, parent, args, context, countValue);
         },
       },
       connectionOptions instanceof ObjectRef
@@ -688,6 +716,22 @@ export class DrizzleObjectFieldBuilder<
     const relationField = schemaConfig.relations?.[this.table].relations[relationName as string];
     const relatedTable = schemaConfig.relations[relationField.targetTableName];
 
+    // Built once per field; the `extras` function it returns is what the plan carried before.
+    const countExtras = (
+      whereClause: SQL | undefined,
+      ctx: Types['Context'],
+      buildFilter: (parent: TableConfig['table']) => SQL,
+    ) =>
+      ({
+        extras: {
+          [countKey]: (parent: TableConfig['table']) =>
+            getClient(this.builder, ctx).$count(
+              relatedTable.table as Table,
+              whereClause ? and(buildFilter(parent), whereClause) : buildFilter(parent),
+            ),
+        },
+      }) as never;
+
     return this.relatedField(relationName, {
       ...options,
       type: 'Int' as never,
@@ -700,22 +744,18 @@ export class DrizzleObjectFieldBuilder<
         buildFilter: (parent: TableConfig['table']) => SQL,
         args: object,
         ctx: Types['Context'],
-      ) =>
-        completeValue(
+      ) => {
+        const whereClause =
           typeof where === 'function'
             ? (where as (args: unknown, ctx: unknown) => MaybePromise<SQL | undefined>)(args, ctx)
-            : where,
-          (whereClause) =>
-            ({
-              extras: {
-                [countKey]: (parent: TableConfig['table']) =>
-                  getClient(this.builder, ctx).$count(
-                    relatedTable.table as Table,
-                    whereClause ? and(buildFilter(parent), whereClause) : buildFilter(parent),
-                  ),
-              },
-            }) as never,
-        ),
+            : where;
+
+        return isThenable(whereClause)
+          ? whereClause.then((resolved) =>
+              countExtras(resolved as SQL | undefined, ctx, buildFilter),
+            )
+          : countExtras(whereClause, ctx, buildFilter);
+      },
       resolve: (parent: Record<string, number>) => parent[countKey],
     } as never) as FieldRef<Types, number, 'DrizzleObject'>;
   }

--- a/packages/plugin-drizzle/src/drizzle-field-builder.ts
+++ b/packages/plugin-drizzle/src/drizzle-field-builder.ts
@@ -1,5 +1,6 @@
 import {
   type CompatibleTypes,
+  completeValue,
   type ExposeNullability,
   type FieldKind,
   type FieldRef,
@@ -8,6 +9,7 @@ import {
   type InputShapeFromFields,
   type InterfaceParam,
   isThenable,
+  type MaybePromise,
   type NormalizeArgs,
   ObjectRef,
   type PluginName,
@@ -53,7 +55,7 @@ import {
 } from './utils/cursors.js';
 import { selectedFieldNames } from './utils/map-query.js';
 import { getRefFromModel } from './utils/refs.js';
-import { omitUndefinedKeys, type SelectionMap } from './utils/selections.js';
+import type { SelectionMap } from './utils/selections.js';
 
 // Workaround for FieldKind not being extended on Builder classes
 const RootBuilder: {
@@ -244,18 +246,24 @@ export class DrizzleObjectFieldBuilder<
       extras?: DrizzleCursorConnectionQueryOptions['extras'];
     }
 
+    // The field's `query` may be async, so the result is a promise when it is (A-5).
     const resolveFieldQuery = (
       args: PothosSchemaTypes.DefaultConnectionArguments,
       ctx: {},
       pathInfo?: import('./types').PathInfo,
-    ): ConnectionFieldQuery =>
-      ((typeof query === 'function'
-        ? (query as (args: {}, ctx: {}, pathInfo?: import('./types').PathInfo) => {})(
-            args,
-            ctx,
-            pathInfo,
-          )
-        : query) ?? {}) as ConnectionFieldQuery;
+    ): MaybePromise<ConnectionFieldQuery> =>
+      completeValue(
+        (typeof query === 'function'
+          ? (
+              query as (
+                args: {},
+                ctx: {},
+                pathInfo?: import('./types').PathInfo,
+              ) => MaybePromise<{} | null | undefined>
+            )(args, ctx, pathInfo)
+          : query) as MaybePromise<ConnectionFieldQuery | null | undefined>,
+        orEmpty,
+      );
 
     const getQuery = (
       args: PothosSchemaTypes.DefaultConnectionArguments,
@@ -318,34 +326,45 @@ export class DrizzleObjectFieldBuilder<
       const hasPageInfo = !!getSelection(['pageInfo']);
       const totalCountOnly = hasTotalCount && !hasEdges && !hasNodes && !hasPageInfo;
       const fieldQuery = resolveFieldQuery(args, context, pathInfo);
-      const countSelection = {
-        [countKey]: (parent: TableConfig['table']) =>
-          getClient(this.builder, context).$count(
-            relatedTable.table as Table,
-            buildCountFilter(parent, fieldQuery.where),
-          ),
-      };
+      // The nested walk starts now, with a query that waits for the field's `query` when that is
+      // async, so every callback beneath the connection runs in the same tick (A-3).
+      const nested = totalCountOnly
+        ? undefined
+        : (nestedQuery(
+            isThenable(fieldQuery)
+              ? fieldQuery.then((resolved) => getQuery(args, context, resolved).select)
+              : getQuery(args, context, fieldQuery).select,
+            {
+              getType: () => typeName!,
+              paths: [[{ name: 'nodes' }], [{ name: 'edges' }, { name: 'node' }]],
+            },
+          ) as MaybePromise<SelectionMap>);
 
-      if (totalCountOnly) {
-        return {
-          columns: {},
-          with: {},
-          extras: countSelection,
+      return completeValue(fieldQuery, (fieldQuery) => {
+        const countSelection = {
+          [countKey]: (parent: TableConfig['table']) =>
+            getClient(this.builder, context).$count(
+              relatedTable.table as Table,
+              buildCountFilter(parent, fieldQuery.where),
+            ),
         };
-      }
 
-      const nested = nestedQuery(getQuery(args, context, fieldQuery).select, {
-        getType: () => typeName!,
-        paths: [[{ name: 'nodes' }], [{ name: 'edges' }, { name: 'node' }]],
-      }) as SelectionMap;
+        if (totalCountOnly) {
+          return {
+            columns: {},
+            with: {},
+            extras: countSelection,
+          };
+        }
 
-      return {
-        columns: {},
-        with: {
-          [name]: nested,
-        },
-        extras: hasTotalCount ? countSelection : {},
-      };
+        return completeValue(nested, (nested) => ({
+          columns: {},
+          with: {
+            [name]: nested,
+          },
+          extras: hasTotalCount ? countSelection : {},
+        }));
+      });
     };
     const fieldRef = (
       this as unknown as {
@@ -404,21 +423,20 @@ export class DrizzleObjectFieldBuilder<
           const pathInfo = getLoaderMapping(context, info.path, info.parentType.name)?.extra as
             | PathInfo
             | undefined;
-          const { select, cursorFields } = getQuery(
-            args,
-            context,
-            resolveFieldQuery(args, context, pathInfo),
-          );
 
-          return wrapConnectionResult(
-            parentRecord[name] as readonly {}[],
-            args,
-            select.limit,
-            getCursorFormatter(cursorFields, schemaConfig),
-            undefined,
-            parent,
-            countValue,
-          );
+          return completeValue(resolveFieldQuery(args, context, pathInfo), (fieldQuery) => {
+            const { select, cursorFields } = getQuery(args, context, fieldQuery);
+
+            return wrapConnectionResult(
+              parentRecord[name] as readonly {}[],
+              args,
+              select.limit,
+              getCursorFormatter(cursorFields, schemaConfig),
+              undefined,
+              parent,
+              countValue,
+            );
+          });
         },
       },
       connectionOptions instanceof ObjectRef
@@ -548,31 +566,25 @@ export class DrizzleObjectFieldBuilder<
 
     const { query = {}, extensions, ...rest } = options;
 
+    // Built once per field: the select allocates nothing when the nested selection is sync. The
+    // nested selection already carries the field's `query` (it is merged into the child first),
+    // so nothing is spread over it.
+    const selectRelation = (nested: unknown) => ({ columns: {}, with: { [name]: nested } });
     const relationSelect = (
       args: object,
       context: object,
       nestedQuery: (query: unknown) => {},
       _resolveSelection: unknown,
       pathInfo: PathInfo,
-    ) => {
-      // Evaluate a `query` callback once, with `pathInfo`; it used to be called a second time
-      // (without `pathInfo`) when the nested selection was built.
-      const fieldQuery = (
-        typeof query === 'function'
-          ? (query as (args: {}, context: {}, pathInfo: PathInfo) => {})(args, context, pathInfo)
-          : query
-      ) as {};
-
-      return {
-        columns: {},
-        with: {
-          [name]: omitUndefinedKeys({
-            ...nestedQuery(fieldQuery),
-            ...fieldQuery,
-          }),
-        },
-      };
-    };
+    ) =>
+      completeValue(
+        nestedQuery(
+          typeof query === 'function'
+            ? (query as (args: {}, context: {}, pathInfo: PathInfo) => {})(args, context, pathInfo)
+            : query,
+        ),
+        selectRelation,
+      );
 
     return this.field({
       ...(rest as {}),
@@ -609,7 +621,7 @@ export class DrizzleObjectFieldBuilder<
         nestedQuery: (
           query: DBQueryConfig<'many', Types['DrizzleRelations'], TableConfig>,
         ) => DBQueryConfig<'many', Types['DrizzleRelations'], TableConfig>,
-      ) => Select;
+      ) => MaybePromise<Select>;
       resolve: (
         parent: ShapeWithSelection,
         args: Args extends InputFieldMap ? InputShapeFromFields<Args> : {},
@@ -642,19 +654,13 @@ export class DrizzleObjectFieldBuilder<
       args: object,
       context: Types['Context'],
       nestedQuery: (query: unknown) => unknown,
-    ) => {
-      const selection = options.select(
-        buildFilter as never,
-        args as never,
-        context,
-        nestedQuery as never,
-      ) as Select & { with?: unknown };
-      return {
-        columns: selection.columns ?? {},
-        extras: selection.extras,
-        with: selection.with,
-      };
-    };
+    ) =>
+      completeValue(
+        options.select(buildFilter as never, args as never, context, nestedQuery as never) as
+          | MaybePromise<Select & { with?: unknown }>
+          | undefined,
+        pickSelection,
+      );
 
     const { select: _select, extensions, ...fieldOptions } = options;
 
@@ -694,22 +700,22 @@ export class DrizzleObjectFieldBuilder<
         buildFilter: (parent: TableConfig['table']) => SQL,
         args: object,
         ctx: Types['Context'],
-      ) => {
-        const whereClause =
+      ) =>
+        completeValue(
           typeof where === 'function'
-            ? (where as (args: unknown, ctx: unknown) => SQL | undefined)(args, ctx)
-            : where;
-
-        return {
-          extras: {
-            [countKey]: (parent: TableConfig['table']) =>
-              getClient(this.builder, ctx).$count(
-                relatedTable.table as Table,
-                whereClause ? and(buildFilter(parent), whereClause) : buildFilter(parent),
-              ),
-          },
-        } as never;
-      },
+            ? (where as (args: unknown, ctx: unknown) => MaybePromise<SQL | undefined>)(args, ctx)
+            : where,
+          (whereClause) =>
+            ({
+              extras: {
+                [countKey]: (parent: TableConfig['table']) =>
+                  getClient(this.builder, ctx).$count(
+                    relatedTable.table as Table,
+                    whereClause ? and(buildFilter(parent), whereClause) : buildFilter(parent),
+                  ),
+              },
+            }) as never,
+        ),
       resolve: (parent: Record<string, number>) => parent[countKey],
     } as never) as FieldRef<Types, number, 'DrizzleObject'>;
   }
@@ -797,4 +803,18 @@ export class DrizzleObjectFieldBuilder<
       ) as never;
     };
   }
+}
+
+/** A relation `query` callback may return nothing; the connection then adds no filter. */
+function orEmpty<T extends object>(query: T | null | undefined): T {
+  return query ?? ({} as T);
+}
+
+/** A `relatedField` select's map, with the columns it may have left out defaulted. */
+function pickSelection(selection: { columns?: {}; extras?: unknown; with?: unknown } | undefined) {
+  return {
+    columns: selection?.columns ?? {},
+    extras: selection?.extras,
+    with: selection?.with,
+  };
 }

--- a/packages/plugin-drizzle/src/field-builder.ts
+++ b/packages/plugin-drizzle/src/field-builder.ts
@@ -1,13 +1,20 @@
 import type { FieldRef, MaybePromise } from '@pothos/core';
-import { type FieldKind, ObjectRef, RootFieldBuilder, type SchemaTypes } from '@pothos/core';
+import {
+  type FieldKind,
+  isThenable,
+  ObjectRef,
+  RootFieldBuilder,
+  type SchemaTypes,
+} from '@pothos/core';
 import type { TableRelationalConfig } from 'drizzle-orm';
 import type { GraphQLResolveInfo } from 'graphql';
 import { isInterfaceType, isObjectType, Kind } from 'graphql';
 import type { DrizzleRef } from './interface-ref.js';
 import type { DrizzleConnectionFieldOptions } from './types.js';
-import { getSchemaConfig } from './utils/config.js';
+import type { DrizzleWalk } from './utils/adapter.js';
+import { getSchemaConfig, type PothosDrizzleSchemaConfig } from './utils/config.js';
 import { resolveDrizzleCursorConnection } from './utils/cursors.js';
-import { queryFromInfo } from './utils/map-query.js';
+import { queryFromWalk, walkFromInfo } from './utils/map-query.js';
 import { getRefFromModel } from './utils/refs.js';
 import type { SelectionMap } from './utils/selections.js';
 
@@ -30,20 +37,24 @@ fieldBuilderProto.drizzleField = function drizzleField({ type, resolve, ...optio
     ...(options as {}),
     type: typeParam,
     resolve: (parent: unknown, args: unknown, context: {}, info: GraphQLResolveInfo) => {
-      return resolve(
-        (select) =>
-          queryFromInfo({
-            config: getSchemaConfig(this.builder),
-            context,
-            select,
-            info,
-            // withUsageCheck: !!this.builder.options.drizzle?.onUnusedQuery,
-          }) as never,
-        parent,
-        args as never,
-        context,
-        info,
-      ) as never;
+      const config = getSchemaConfig(this.builder);
+      // A promise while a selection beneath the field is async: the resolver runs once it has
+      // settled, so the builder it is handed never returns one.
+      const walk = walkFromInfo({ config, context, info });
+
+      return isThenable(walk)
+        ? walk.then((settled) =>
+            resolveWithWalk(
+              config,
+              resolve as never,
+              settled as DrizzleWalk | undefined,
+              parent,
+              args,
+              context,
+              info,
+            ),
+          )
+        : resolveWithWalk(config, resolve as never, walk, parent, args, context, info);
     },
   }) as never;
 };
@@ -71,23 +82,54 @@ fieldBuilderProto.drizzleFieldWithInput = function drizzleFieldWithInput(
     ...(options as {}),
     type: typeParam,
     resolve: (parent: unknown, args: unknown, context: {}, info: GraphQLResolveInfo) => {
-      return resolve(
-        (select: SelectionMap) =>
-          queryFromInfo({
-            config: getSchemaConfig(this.builder),
-            context,
-            select,
-            info,
-            // withUsageCheck: !!this.builder.options.drizzle?.onUnusedQuery,
-          }),
-        parent,
-        args as never,
-        context,
-        info,
-      ) as never;
+      const config = getSchemaConfig(this.builder);
+      const walk = walkFromInfo({ config, context, info });
+
+      return isThenable(walk)
+        ? walk.then((settled) =>
+            resolveWithWalk(
+              config,
+              resolve,
+              settled as DrizzleWalk | undefined,
+              parent,
+              args,
+              context,
+              info,
+            ),
+          )
+        : resolveWithWalk(config, resolve, walk, parent, args, context, info);
     },
   }) as never;
 } as never;
+
+/**
+ * Runs a `drizzleField` resolver with a builder over its settled plan; built once so a
+ * synchronous plan allocates nothing but the builder itself.
+ */
+function resolveWithWalk(
+  config: PothosDrizzleSchemaConfig,
+  resolve: (...args: unknown[]) => unknown,
+  walk: DrizzleWalk | undefined,
+  parent: unknown,
+  args: unknown,
+  context: {},
+  info: GraphQLResolveInfo,
+) {
+  return resolve(
+    (select?: SelectionMap) =>
+      queryFromWalk(walk, {
+        config,
+        context,
+        select,
+        info,
+        // withUsageCheck: !!this.builder.options.drizzle?.onUnusedQuery,
+      }),
+    parent,
+    args,
+    context,
+    info,
+  );
+}
 
 fieldBuilderProto.drizzleConnection = function drizzleConnection<
   Type extends
@@ -121,6 +163,45 @@ fieldBuilderProto.drizzleConnection = function drizzleConnection<
   const ref = typeof type === 'string' ? getRefFromModel(type, this.builder) : type;
   const typeName = this.builder.configStore.getTypeConfig(ref).name;
   const tableName = typeof type === 'string' ? type : (ref as DrizzleRef<SchemaTypes>).tableName;
+
+  // Built once per field: resolving with a synchronous plan allocates nothing beyond the
+  // callback `resolveDrizzleCursorConnection` was already handed.
+  const resolveConnection = (
+    walk: DrizzleWalk | undefined,
+    parent: unknown,
+    args: PothosSchemaTypes.DefaultConnectionArguments,
+    context: {},
+    info: GraphQLResolveInfo,
+    totalCountOnly: boolean,
+  ) =>
+    resolveDrizzleCursorConnection(
+      tableName,
+      info,
+      walk,
+      typeName,
+      getSchemaConfig(this.builder),
+      {
+        ctx: context,
+        maxSize,
+        defaultSize,
+        args,
+        totalCount: totalCount && (() => totalCount(parent, args as never, context, info)),
+      },
+      (q) => {
+        if (totalCountOnly) {
+          return [];
+        }
+
+        // return checkIfQueryIsUsed(
+        //   this.builder,
+        //   query,
+        //   info,
+        return resolve(q as never, parent, args as never, context, info) as never;
+        // );
+      },
+      parent,
+    );
+
   const fieldRef = (
     this as typeof fieldBuilderProto & {
       connection: (...args: unknown[]) => FieldRef<SchemaTypes, unknown>;
@@ -150,32 +231,28 @@ fieldBuilderProto.drizzleConnection = function drizzleConnection<
           ),
         );
 
-        return resolveDrizzleCursorConnection(
-          tableName,
+        // Planned before the resolver runs, so the builder it is handed is synchronous even when
+        // a selection beneath the connection is async.
+        const walk = walkFromInfo({
+          config: getSchemaConfig(this.builder),
+          context,
           info,
+          paths: [['nodes'], ['edges', 'node']],
           typeName,
-          getSchemaConfig(this.builder),
-          {
-            ctx: context,
-            maxSize,
-            defaultSize,
-            args,
-            totalCount: totalCount && (() => totalCount(parent, args as never, context, info)),
-          },
-          (q) => {
-            if (totalCountOnly) {
-              return [];
-            }
+        });
 
-            // return checkIfQueryIsUsed(
-            //   this.builder,
-            //   query,
-            //   info,
-            return resolve(q as never, parent, args as never, context, info) as never;
-            // );
-          },
-          parent,
-        );
+        return isThenable(walk)
+          ? walk.then((settled) =>
+              resolveConnection(
+                settled as DrizzleWalk | undefined,
+                parent,
+                args,
+                context,
+                info,
+                totalCountOnly,
+              ),
+            )
+          : resolveConnection(walk, parent, args, context, info, totalCountOnly);
       },
     },
     connectionOptions instanceof ObjectRef

--- a/packages/plugin-drizzle/src/index.ts
+++ b/packages/plugin-drizzle/src/index.ts
@@ -3,6 +3,7 @@ import './field-builder.js';
 import './schema-builder.js';
 import SchemaBuilder, {
   BasePlugin,
+  completeValue,
   type PothosOutputFieldConfig,
   PothosSchemaError,
   type PothosTypeConfig,
@@ -137,12 +138,14 @@ export class PothosDrizzlePlugin<Types extends SchemaTypes> extends BasePlugin<T
                     path: pathInfo.path,
                     segments: pathInfo.segments,
                   });
-                  const selected = (
-                    select as (args: unknown, ctx: unknown, nestedQuery: unknown) => {} | null
-                  )(args, ctx, nestedQueryWithPath);
-
-                  // A falsy selection means the field selects nothing from the parent row.
-                  return selected ? { columns: {}, ...selected } : null;
+                  return completeValue(
+                    (select as (args: unknown, ctx: unknown, nestedQuery: unknown) => {} | null)(
+                      args,
+                      ctx,
+                      nestedQueryWithPath,
+                    ),
+                    wrapSelect,
+                  );
                 }
               : {
                   columns: {},
@@ -218,6 +221,11 @@ export class PothosDrizzlePlugin<Types extends SchemaTypes> extends BasePlugin<T
         .then((result) => resolver(result, args, context, info));
     };
   }
+}
+
+/** A falsy selection means the field selects nothing from the parent row. */
+function wrapSelect(selected: {} | null) {
+  return selected ? { columns: {}, ...selected } : null;
 }
 
 SchemaBuilder.registerPlugin(pluginName, PothosDrizzlePlugin, {});

--- a/packages/plugin-drizzle/src/model-loader.ts
+++ b/packages/plugin-drizzle/src/model-loader.ts
@@ -107,7 +107,7 @@ export class ModelLoader {
     if (!this.queryCache.has(key)) {
       this.queryCache.set(
         key,
-        completeValue(selectionStateFromInfo(this.config, this.context, info), this.selectionOf),
+        completeValue(selectionStateFromInfo(this.config, this.context, info), selectionOf),
       );
     }
 
@@ -122,15 +122,13 @@ export class ModelLoader {
         completeValue(
           // Walked without paths, so there is always a walk.
           walkFromInfo({ config: this.config, context: this.context, info, typeName })!,
-          this.selectionOf,
+          selectionOf,
         ),
       );
     }
 
     return this.queryCache.get(key)!;
   }
-
-  selectionOf = (walk: DrizzleWalk) => ({ walk, query: this.adapter.serialize(walk.root) });
 
   /**
    * L-3: `model` reloaded with the selection of the field `info` resolves. A synchronous
@@ -269,6 +267,11 @@ export class ModelLoader {
 
     return promise.promise;
   }
+}
+
+/** The walk carries the adapter it was built with, so no loader instance is needed here. */
+function selectionOf(walk: DrizzleWalk): Selection {
+  return { walk, query: walk.env.adapter.serialize(walk.root) };
 }
 
 function createResolvablePromise<T = unknown>(): ResolvablePromise<T> {

--- a/packages/plugin-drizzle/src/model-loader.ts
+++ b/packages/plugin-drizzle/src/model-loader.ts
@@ -112,7 +112,8 @@ export class ModelLoader {
       this.queryCache.set(
         key,
         completeValue(
-          walkFromInfo({ config: this.config, context: this.context, info, typeName }),
+          // Walked without paths, so there is always a walk.
+          walkFromInfo({ config: this.config, context: this.context, info, typeName })!,
           this.selectionOf,
         ),
       );

--- a/packages/plugin-drizzle/src/model-loader.ts
+++ b/packages/plugin-drizzle/src/model-loader.ts
@@ -1,4 +1,9 @@
-import { createContextCache, type SchemaTypes } from '@pothos/core';
+import {
+  completeValue,
+  createContextCache,
+  type MaybePromise,
+  type SchemaTypes,
+} from '@pothos/core';
 import { cacheKey, setFieldMapping, setLoaderMappings } from '@pothos/selection-mapper';
 import {
   type AnyTable,
@@ -27,7 +32,8 @@ export class ModelLoader {
 
   modelName: string;
 
-  queryCache = new Map<string, { walk: DrizzleWalk; query: SelectionMap }>();
+  // L-4: one selection per `Type@path`, a promise while a select beneath the field is async.
+  queryCache = new Map<string, MaybePromise<{ walk: DrizzleWalk; query: SelectionMap }>>();
 
   staged = new Set<{
     walk: DrizzleWalk;
@@ -91,11 +97,10 @@ export class ModelLoader {
   getSelection(info: GraphQLResolveInfo) {
     const key = cacheKey(info.parentType.name, info.path);
     if (!this.queryCache.has(key)) {
-      const walk = selectionStateFromInfo(this.config, this.context, info);
-      this.queryCache.set(key, {
-        walk,
-        query: this.adapter.serialize(walk.root),
-      });
+      this.queryCache.set(
+        key,
+        completeValue(selectionStateFromInfo(this.config, this.context, info), this.selectionOf),
+      );
     }
 
     return this.queryCache.get(key)!;
@@ -104,24 +109,22 @@ export class ModelLoader {
   getSelectionForField(info: GraphQLResolveInfo, typeName: string) {
     const key = cacheKey(typeName, info.path);
     if (!this.queryCache.has(key)) {
-      const walk = walkFromInfo({
-        config: this.config,
-        context: this.context,
-        info,
-        typeName,
-      });
-
-      this.queryCache.set(key, {
-        walk,
-        query: this.adapter.serialize(walk.root),
-      });
+      this.queryCache.set(
+        key,
+        completeValue(
+          walkFromInfo({ config: this.config, context: this.context, info, typeName }),
+          this.selectionOf,
+        ),
+      );
     }
 
     return this.queryCache.get(key)!;
   }
 
+  selectionOf = (walk: DrizzleWalk) => ({ walk, query: this.adapter.serialize(walk.root) });
+
   async loadSelection(info: GraphQLResolveInfo, model: object) {
-    const { walk, query } = this.getSelection(info);
+    const { walk, query } = await this.getSelection(info);
 
     const result = await this.stageQuery(walk, query, model);
 
@@ -139,7 +142,7 @@ export class ModelLoader {
   }
 
   async loadSelectionForField(info: GraphQLResolveInfo, model: object, returnType: string) {
-    const { walk, query } = this.getSelectionForField(info, returnType);
+    const { walk, query } = await this.getSelectionForField(info, returnType);
 
     const result = await this.stageQuery(walk, query, model);
 

--- a/packages/plugin-drizzle/src/model-loader.ts
+++ b/packages/plugin-drizzle/src/model-loader.ts
@@ -1,6 +1,7 @@
 import {
   completeValue,
   createContextCache,
+  isThenable,
   type MaybePromise,
   type SchemaTypes,
 } from '@pothos/core';
@@ -25,6 +26,13 @@ interface ResolvablePromise<T> {
   resolve: (value: T) => void;
   reject: (err: unknown) => void;
 }
+
+/** A field's loader walk and the query it serializes to. */
+interface Selection {
+  walk: DrizzleWalk;
+  query: SelectionMap;
+}
+
 export class ModelLoader {
   context: object;
 
@@ -33,7 +41,7 @@ export class ModelLoader {
   modelName: string;
 
   // L-4: one selection per `Type@path`, a promise while a select beneath the field is async.
-  queryCache = new Map<string, MaybePromise<{ walk: DrizzleWalk; query: SelectionMap }>>();
+  queryCache = new Map<string, MaybePromise<Selection>>();
 
   staged = new Set<{
     walk: DrizzleWalk;
@@ -124,34 +132,56 @@ export class ModelLoader {
 
   selectionOf = (walk: DrizzleWalk) => ({ walk, query: this.adapter.serialize(walk.root) });
 
-  async loadSelection(info: GraphQLResolveInfo, model: object) {
-    const { walk, query } = await this.getSelection(info);
+  /**
+   * L-3: `model` reloaded with the selection of the field `info` resolves. A synchronous
+   * selection stages synchronously, so every row resolved in a tick joins the same batch; only a
+   * selection with an async select beneath the field waits for it.
+   */
+  loadSelection(info: GraphQLResolveInfo, model: object): Promise<Record<string, unknown> | null> {
+    const selection = this.getSelection(info);
 
-    const result = await this.stageQuery(walk, query, model);
-
-    if (result) {
-      const mapping = walk.mappings[`${info.parentType.name}@${info.path.key}`];
-
-      if (mapping) {
-        // Recorded for the field itself too, so its resolver finds the pathInfo it was planned
-        // with, along with the mappings of the fields beneath it.
-        setFieldMapping(this.context, info, mapping);
-      }
-    }
-
-    return result;
+    return isThenable(selection)
+      ? selection.then((settled) => this.loadWith(settled as Selection, info, model))
+      : this.loadWith(selection, info, model);
   }
 
-  async loadSelectionForField(info: GraphQLResolveInfo, model: object, returnType: string) {
-    const { walk, query } = await this.getSelectionForField(info, returnType);
+  private loadWith({ walk, query }: Selection, info: GraphQLResolveInfo, model: object) {
+    return this.stageQuery(walk, query, model).then((result) => {
+      if (result) {
+        const mapping = walk.mappings[`${info.parentType.name}@${info.path.key}`];
 
-    const result = await this.stageQuery(walk, query, model);
+        if (mapping) {
+          // Recorded for the field itself too, so its resolver finds the pathInfo it was planned
+          // with, along with the mappings of the fields beneath it.
+          setFieldMapping(this.context, info, mapping);
+        }
+      }
 
-    if (result) {
-      setLoaderMappings(this.context, info, walk.mappings);
-    }
+      return result;
+    });
+  }
 
-    return result;
+  /** A node loaded by id with the selection beneath the field `info` resolves, as `returnType`. */
+  loadSelectionForField(
+    info: GraphQLResolveInfo,
+    model: object,
+    returnType: string,
+  ): Promise<Record<string, unknown> | null> {
+    const selection = this.getSelectionForField(info, returnType);
+
+    return isThenable(selection)
+      ? selection.then((settled) => this.loadFieldWith(settled as Selection, info, model))
+      : this.loadFieldWith(selection, info, model);
+  }
+
+  private loadFieldWith({ walk, query }: Selection, info: GraphQLResolveInfo, model: object) {
+    return this.stageQuery(walk, query, model).then((result) => {
+      if (result) {
+        setLoaderMappings(this.context, info, walk.mappings);
+      }
+
+      return result;
+    });
   }
 
   stageQuery(walk: DrizzleWalk, query: SelectionMap, model: object) {

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -311,7 +311,7 @@ export type DrizzleObjectFieldOptions<
             Record<string, unknown> &
               // biome-ignore lint/suspicious/noExplicitAny: this is fine
               Select extends (...args: any[]) => infer R
-              ? R & { columns: {} }
+              ? Awaited<R> & { columns: {} }
               : Select & { columns: {} }
           > &
             ParentShape,
@@ -335,6 +335,10 @@ export type DrizzleObjectFieldOptions<
     Args,
     ResolveReturnShape
   > & {
+    /**
+     * What the field needs from its parent row. A function may be async; `nestedSelection` is
+     * then a promise when a selection beneath it is async, and must be awaited.
+     */
     select?: Select &
       (
         | DBQueryConfig<'one', Types['DrizzleRelations'], ExtractTable<Types, ParentShape>>
@@ -346,7 +350,9 @@ export type DrizzleObjectFieldOptions<
               path?: string[],
             ) => Selection) &
               PathInfo,
-          ) => DBQueryConfig<'one', Types['DrizzleRelations'], ExtractTable<Types, ParentShape>>)
+          ) => MaybePromise<
+            DBQueryConfig<'one', Types['DrizzleRelations'], ExtractTable<Types, ParentShape>>
+          >)
       );
   };
 
@@ -359,13 +365,13 @@ export type DrizzleFieldSelection =
         selection:
           | SelectionMap
           | boolean
-          | ((args: object, context: object) => DBQueryConfig<'one'>),
+          | ((args: object, context: object) => MaybePromise<DBQueryConfig<'one'>>),
         path?: IndirectInclude | string[],
         type?: string,
       ) => DBQueryConfig<'one'> | boolean,
       resolveSelection: (path: string[]) => FieldNode | null,
       pathInfo: PathInfo,
-    ) => SelectionMap | false | null | undefined);
+    ) => MaybePromise<SelectionMap | false | null | undefined>);
 
 export type ExtractTable<Types extends SchemaTypes, Shape> = Shape extends {
   [drizzleTableName]?: keyof Types['DrizzleRelations'];
@@ -466,7 +472,9 @@ export type RelatedCountOptions<
   PothosSchemaTypes.ObjectFieldOptions<Types, Shape, 'Int', false, Args, number>,
   'type' | InferredFieldOptionKeys
 > & {
-  where?: Where | ((args: InputShapeFromFields<Args>, context: Types['Context']) => Where);
+  where?:
+    | Where
+    | ((args: InputShapeFromFields<Args>, context: Types['Context']) => MaybePromise<Where>);
 };
 
 export type TypesForRelation<Types extends SchemaTypes, Rel extends Relation> = BuildQueryResult<
@@ -506,7 +514,7 @@ export type QueryForField<
           args: InputShapeFromFields<Args>,
           context: Types['Context'],
           pathInfo: PathInfo,
-        ) => QueryConfig)
+        ) => MaybePromise<QueryConfig>)
   : never;
 
 export type QueryForDrizzleField<
@@ -529,7 +537,9 @@ export type QueryForRelatedConnection<
 > & {
   orderBy?: ConnectionOrderBy<Table> | ((table: Table) => ConnectionOrderBy<Table>);
 } extends infer QueryConfig
-  ? QueryConfig | ((args: Args, context: Types['Context'], pathInfo: PathInfo) => QueryConfig)
+  ?
+      | QueryConfig
+      | ((args: Args, context: Types['Context'], pathInfo: PathInfo) => MaybePromise<QueryConfig>)
   : never;
 
 export type QueryForDrizzleConnection<

--- a/packages/plugin-drizzle/src/utils/cursors.ts
+++ b/packages/plugin-drizzle/src/utils/cursors.ts
@@ -1,6 +1,7 @@
 import {
   decodeBase64,
   encodeBase64,
+  isThenable,
   type MaybePromise,
   PothosValidationError,
   type SchemaTypes,
@@ -683,7 +684,8 @@ export async function resolveDrizzleCursorConnection<T extends {}>(
   parent: unknown,
 ) {
   const table = config.relations[tableName];
-  let query: DBQueryConfig<'many'> | undefined;
+  // A promise when a select beneath the connection is async; the resolver awaits it (A-7).
+  let query: MaybePromise<DBQueryConfig<'many'>> | undefined;
   let formatter: (node: Record<string, unknown>) => string;
   const results = await resolve((q = {}) => {
     const { cursorFields, ...connectionQuery } = drizzleCursorConnectionQuery({
@@ -743,10 +745,12 @@ export async function resolveDrizzleCursorConnection<T extends {}>(
     };
   }
 
+  const { limit } = isThenable(query) ? await query : query;
+
   return wrapConnectionResult(
     results,
     options.args,
-    query.limit as number,
+    limit as number,
     formatter!,
     undefined,
     parent,

--- a/packages/plugin-drizzle/src/utils/cursors.ts
+++ b/packages/plugin-drizzle/src/utils/cursors.ts
@@ -1,7 +1,6 @@
 import {
   decodeBase64,
   encodeBase64,
-  isThenable,
   type MaybePromise,
   PothosValidationError,
   type SchemaTypes,
@@ -23,8 +22,9 @@ import {
 } from 'drizzle-orm';
 import type { GraphQLResolveInfo } from 'graphql';
 import type { ConnectionOrderBy, QueryForDrizzleConnection } from '../types.js';
+import type { DrizzleWalk } from './adapter.js';
 import type { PothosDrizzleSchemaConfig } from './config.js';
-import { queryFromInfo } from './map-query.js';
+import { queryFromWalk } from './map-query.js';
 import { omitUndefinedKeys, type SelectionMap } from './selections.js';
 
 const DEFAULT_MAX_SIZE = 100;
@@ -673,6 +673,8 @@ export function wrapConnectionResult<T extends {}>(
 export async function resolveDrizzleCursorConnection<T extends {}>(
   tableName: string,
   info: GraphQLResolveInfo,
+  // The settled plan of the connection's rows; the builder handed to `resolve` merges into it.
+  walk: DrizzleWalk | undefined,
   typeName: string,
   config: PothosDrizzleSchemaConfig,
   options: Omit<DrizzleCursorConnectionQueryOptions, 'orderBy' | 'config' | 'table'> & {
@@ -684,8 +686,7 @@ export async function resolveDrizzleCursorConnection<T extends {}>(
   parent: unknown,
 ) {
   const table = config.relations[tableName];
-  // A promise when a select beneath the connection is async; the resolver awaits it (A-7).
-  let query: MaybePromise<DBQueryConfig<'many'>> | undefined;
+  let query: DBQueryConfig<'many'> | undefined;
   let formatter: (node: Record<string, unknown>) => string;
   const results = await resolve((q = {}) => {
     const { cursorFields, ...connectionQuery } = drizzleCursorConnectionQuery({
@@ -699,7 +700,7 @@ export async function resolveDrizzleCursorConnection<T extends {}>(
     });
     formatter = getCursorFormatter(cursorFields, config);
 
-    query = queryFromInfo({
+    query = queryFromWalk(walk, {
       context: options.ctx,
       info,
       select: omitUndefinedKeys({
@@ -745,7 +746,7 @@ export async function resolveDrizzleCursorConnection<T extends {}>(
     };
   }
 
-  const { limit } = isThenable(query) ? await query : query;
+  const { limit } = query;
 
   return wrapConnectionResult(
     results,

--- a/packages/plugin-drizzle/src/utils/map-query.ts
+++ b/packages/plugin-drizzle/src/utils/map-query.ts
@@ -1,7 +1,9 @@
+import { isThenable, PothosValidationError } from '@pothos/core';
 import {
   type IndirectInclude,
   selectedFieldNames,
   queryFromInfo as walkQueryFromInfo,
+  queryFromWalk as walkQueryFromWalk,
   selectionStateFromInfo as walkSelectionStateFromInfo,
   walkFromInfo as walkWalkFromInfo,
 } from '@pothos/selection-mapper';
@@ -38,16 +40,56 @@ export function queryFromInfo<T extends SelectionMap>({
   }) as T;
 }
 
-/** The walk for a field's return type (or `typeName`), nothing recorded; the model loader's. */
-export function walkFromInfo<T extends SelectionMap>({
+/**
+ * The walk for the field `info` resolves (or `typeName`), nothing recorded: a promise while a
+ * select beneath the field is async, undefined when `paths` are given and nothing is selected
+ * under them. The model loader's, and the first step of a `drizzleField` resolve.
+ */
+export function walkFromInfo({
   config,
-  select,
   ...options
-}: QueryFromInfoOptions<T>): DrizzleWalk {
-  return walkWalkFromInfo(drizzleAdapter(config), {
-    ...options,
-    initial: select ? { columns: {}, ...select } : undefined,
-  });
+}: Omit<QueryFromInfoOptions<SelectionMap>, 'select'>): DrizzleWalk | undefined {
+  return walkWalkFromInfo(drizzleAdapter(config), options);
+}
+
+/**
+ * The query for a walk `walkFromInfo` returned, settled: the caller's `select` merged into it,
+ * the mappings recorded, and the query serialized. This is how the `query()` builder handed to a
+ * `drizzleField` or `drizzleConnection` resolver stays synchronous once a selection beneath the
+ * field is async: the document is planned first, and `select` is merged into the settled plan.
+ * A `select` that repeats a planned relation or extra with other arguments keeps the precedence
+ * of `queryFromInfo` (the caller's selection first, the document after it) by planning again,
+ * which is only possible while nothing beneath the field is async.
+ */
+export function queryFromWalk<T extends SelectionMap>(
+  walk: DrizzleWalk | undefined,
+  options: QueryFromInfoOptions<T>,
+): T {
+  const { config, select, withUsageCheck } = options;
+
+  if (!walk) {
+    // Nothing is selected under the paths: the caller gets its own selection back.
+    return (select ?? {}) as T;
+  }
+
+  const initial = select ? { columns: {}, ...select } : undefined;
+  const conflict = initial && drizzleAdapter(config).typeLevelConflict(walk.root, initial);
+
+  if (!conflict) {
+    return walkQueryFromWalk(walk, initial, withUsageCheck) as T;
+  }
+
+  const query = queryFromInfo(options);
+
+  if (isThenable(query)) {
+    const { info } = walk.env;
+
+    throw new PothosValidationError(
+      `The ${conflict.kind} "${conflict.name}" passed to query() in the resolver for ${info.parentType.name}.${info.fieldName} conflicts with the arguments a selection beneath the field planned for it, and a selection beneath the field is async. Move the ${conflict.kind}'s arguments to the field that selects it.`,
+    );
+  }
+
+  return query;
 }
 
 /** The walk loading the field `info` resolves for its parent row (the model loader's query). */

--- a/packages/plugin-drizzle/tests/async-selections.test.ts
+++ b/packages/plugin-drizzle/tests/async-selections.test.ts
@@ -5,6 +5,7 @@ import SchemaBuilder, {
 } from '@pothos/core';
 import RelayPlugin from '@pothos/plugin-relay';
 import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
+import { getLoaderMapping } from '@pothos/selection-mapper';
 import { execute } from '@pothos/test-utils';
 import { eq } from 'drizzle-orm';
 import { getTableConfig } from 'drizzle-orm/sqlite-core';
@@ -64,6 +65,16 @@ const builder = new SchemaBuilder<{
 });
 
 const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 1));
+
+function pathOf(...keys: (string | number)[]) {
+  let path: { prev: unknown; key: string | number; typename: undefined } | undefined;
+
+  for (const key of keys) {
+    path = { prev: path, key, typename: undefined };
+  }
+
+  return path as never;
+}
 
 const Comment = builder.drizzleObject('comments', {
   name: 'Comment',
@@ -160,6 +171,17 @@ const User = builder.drizzleObject('users', {
       select: async (_args, _ctx, nestedSelection) => ({
         with: { posts: nestedSelection({ limit: 1, orderBy: { postId: 'asc' as const } }) },
       }),
+      resolve: (user) => user.posts,
+    }),
+    // Starts a nested selection and returns without it: its walk is async when a selection
+    // beneath the posts is, and would otherwise record mappings for data this never loads.
+    discardedPosts: t.field({
+      type: [Post],
+      select: async (_args, _ctx, nestedSelection) => {
+        nestedSelection({ limit: 1, orderBy: { postId: 'asc' as const } });
+
+        return { with: { posts: { limit: 1, orderBy: { postId: 'asc' as const } } } };
+      },
       resolve: (user) => user.posts,
     }),
     publishedCount: t.relatedCount('posts', { where: eq(posts.published, 1) }),
@@ -385,6 +407,18 @@ describe('async selections', () => {
     expect(result.errors?.map((error) => error.message)).toEqual([
       'Relation "posts" was given a promise. Await nestedSelection() (or a helper built on it, such as getQuery) inside an async selection function.',
     ]);
+  });
+
+  it('rejects a nested selection that was discarded, recording no mapping for it', async () => {
+    const { result, logs, context } = await run(
+      gql`{ user { discardedPosts { id comments: asyncComments { id } } } }`,
+    );
+
+    expect(logs).toHaveLength(0);
+    expect(result.errors?.map((error) => error.message)).toEqual([
+      'The selection function of User.discardedPosts returned while a nested selection it started was still pending. Await nestedSelection() (or a helper built on it, such as getQuery) inside an async selection function.',
+    ]);
+    expect(getLoaderMapping(context, pathOf('user', 'discardedPosts'), 'User')).toBe(null);
   });
 
   it('merges the sync sibling first when it conflicts with an async one (D-5)', async () => {

--- a/packages/plugin-drizzle/tests/async-selections.test.ts
+++ b/packages/plugin-drizzle/tests/async-selections.test.ts
@@ -29,8 +29,8 @@ class AsyncArgsPlugin<Types extends SchemaTypes> extends BasePlugin<Types> {
 }
 
 declare global {
-  export namespace PothosSchemaTypes {
-    export interface Plugins<Types extends SchemaTypes> {
+  namespace PothosSchemaTypes {
+    interface Plugins<Types extends SchemaTypes> {
       asyncArgs: AsyncArgsPlugin<Types>;
     }
   }

--- a/packages/plugin-drizzle/tests/async-selections.test.ts
+++ b/packages/plugin-drizzle/tests/async-selections.test.ts
@@ -8,7 +8,7 @@ import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
 import { execute } from '@pothos/test-utils';
 import { eq } from 'drizzle-orm';
 import { getTableConfig } from 'drizzle-orm/sqlite-core';
-import type { DocumentNode } from 'graphql';
+import type { DocumentNode, GraphQLObjectType } from 'graphql';
 import { gql } from 'graphql-tag';
 import DrizzlePlugin, { drizzleConnectionHelpers } from '../src';
 import { clearDrizzleLogs, type DrizzleRelations, db, drizzleLogs, relations } from './example/db';
@@ -40,7 +40,12 @@ SchemaBuilder.registerPlugin('asyncArgs', AsyncArgsPlugin);
 
 interface Context {
   user: { id: number };
+  /** The query `user` planned, and a row loaded with it, returned by `spiedUser` as is. */
+  planned?: object;
+  row?: object;
+  /** Promise count and call count of the resolvers wrapped by `spyResolvers`. */
   promises?: number;
+  resolved?: number;
 }
 
 const builder = new SchemaBuilder<{
@@ -213,7 +218,11 @@ builder.queryType({
     // The query is a promise when a selection beneath the field is async (A-7).
     user: t.drizzleField({
       type: User,
-      resolve: async (query) => db.query.users.findFirst(await query({ where: { id: 1 } })),
+      resolve: async (query, _root, _args, ctx) => {
+        ctx.planned = await query({ where: { id: 1 } });
+
+        return db.query.users.findFirst(ctx.planned);
+      },
     }),
     // A row fetched without the planned selection: every field with a `select` loads its own
     // data through the model loader.
@@ -221,21 +230,47 @@ builder.queryType({
       type: User,
       resolve: () => db.query.users.findFirst({ where: { id: 1 } }),
     }),
-    // Plans the document under a Promise spy and reports the count on the context.
+    // Returns a row the test loaded with the planned query, so the whole resolution (planning
+    // included) can run under the Promise spy without a database round trip.
     spiedUser: t.drizzleField({
       type: User,
       resolve: (query, _root, _args, ctx) => {
-        const { result, promises } = countPromises(() => query({ where: { id: 1 } }));
+        query({ where: { id: 1 } });
 
-        ctx.promises = promises;
-
-        return db.query.users.findFirst(result);
+        return ctx.row as never;
       },
     }),
   }),
 });
 
 const schema = builder.toSchema();
+
+/** Wraps the built resolvers of `fields` so every call is counted under the Promise spy. */
+function spyResolvers(fields: [string, string][]) {
+  for (const [typeName, fieldName] of fields) {
+    const field = (schema.getType(typeName) as GraphQLObjectType).getFields()[fieldName];
+    const { resolve } = field;
+
+    field.resolve = (parent, args, ctx: Context, info) => {
+      const { result, promises } = countPromises(() => resolve!(parent, args, ctx, info));
+
+      ctx.promises = (ctx.promises ?? 0) + promises;
+      ctx.resolved = (ctx.resolved ?? 0) + 1;
+
+      return result;
+    };
+  }
+}
+
+spyResolvers([
+  ['Query', 'spiedUser'],
+  ['User', 'posts'],
+  ['User', 'publishedCount'],
+  ['User', 'postsTotal'],
+  ['User', 'postsConnection'],
+  ['User', 'commentsConnection'],
+  ['Post', 'comments'],
+]);
 
 async function run(document: DocumentNode) {
   clearDrizzleLogs();
@@ -367,21 +402,36 @@ describe('async selections', () => {
     expect(logs[1]).toContain('"d0"."id" in (?)');
   });
 
-  it('creates no promise while planning a synchronous document (A-1)', async () => {
-    const { result, logs, context } = await run(gql`
-      {
-        spiedUser {
-          id
-          ... on User { posts(limit: 2) { id comments { id } } }
-          publishedCount
-          postsTotal
-          commentsConnection(first: 1) { edges { node { id } } }
-        }
-      }
-    `);
+  it('creates no promise while planning and resolving a synchronous document (A-1)', async () => {
+    const selection = /* GraphQL */ `{
+      id
+      ... on User { publishedCount }
+      postsTotal
+      postsConnection(first: 2) { edges { node { id comments { id } } } }
+      commentsConnection(first: 1) { edges { node { id } } }
+    }`;
+    // The row `spiedUser` hands back: loaded with the query the same document plans.
+    const planned = await run(gql`{ user ${selection} }`);
+
+    expect(planned.logs).toHaveLength(1);
+
+    const row = await db.query.users.findFirst(planned.context.planned as never);
+    clearDrizzleLogs();
+
+    const contextValue: Context = { user: { id: 1 }, row };
+    const result = await execute({
+      schema,
+      document: gql`{ spiedUser ${selection} }`,
+      contextValue,
+    });
 
     expect(result.errors).toBeUndefined();
-    expect(logs).toHaveLength(1);
-    expect(context.promises).toBe(0);
+    expect(result.data).toEqual({ spiedUser: (planned.result.data as { user: unknown }).user });
+    expect(drizzleLogs).toHaveLength(0);
+    // The root field (planning + `drizzleField` resolve), the loaded-path count, related field
+    // and connection fields for the row, and the loaded-path relation `comments` for each of
+    // its two posts.
+    expect(contextValue.resolved).toBe(1 + 4 + 2);
+    expect(contextValue.promises).toBe(0);
   });
 });

--- a/packages/plugin-drizzle/tests/async-selections.test.ts
+++ b/packages/plugin-drizzle/tests/async-selections.test.ts
@@ -215,14 +215,28 @@ const User = builder.drizzleObject('users', {
 
 builder.queryType({
   fields: (t) => ({
-    // The query is a promise when a selection beneath the field is async (A-7).
+    // The builder is synchronous even when a selection beneath the field is async: the plan is
+    // settled before the resolver runs, and the resolver hands the query straight to drizzle.
     user: t.drizzleField({
       type: User,
-      resolve: async (query, _root, _args, ctx) => {
-        ctx.planned = await query({ where: { id: 1 } });
+      resolve: (query, _root, _args, ctx) => {
+        ctx.planned = query({ where: { id: 1 } });
 
         return db.query.users.findFirst(ctx.planned);
       },
+    }),
+    usersConnection: t.drizzleConnection({
+      type: 'users',
+      resolve: (query) => db.query.users.findMany(query({ where: { id: 1 } })),
+    }),
+    // Repeats a planned relation with other arguments: the caller's selection keeps precedence
+    // by planning again with it first, which needs every selection beneath to be synchronous.
+    userWithPosts: t.drizzleField({
+      type: User,
+      resolve: (query) =>
+        db.query.users.findFirst(
+          query({ where: { id: 1 }, with: { posts: { limit: 5, orderBy: { postId: 'asc' } } } }),
+        ),
     }),
     // A row fetched without the planned selection: every field with a `select` loads its own
     // data through the model loader.
@@ -400,6 +414,48 @@ describe('async selections', () => {
     expect(logs[0]).not.toContain('"title"');
     expect(logs[1]).toContain('"title"');
     expect(logs[1]).toContain('"d0"."id" in (?)');
+  });
+
+  it('hands a drizzleField resolver a synchronous builder once the async plan settles', async () => {
+    const { logs } = await sameAsSync(
+      gql`{ user { id titles } }`,
+      gql`{ user { id titles: asyncTitles } }`,
+    );
+
+    // The resolver passed the builder's result to drizzle without awaiting it: the query still
+    // carries its predicate and the async selection's columns.
+    expect(logs[0]).toContain('"d0"."id" = ?');
+    expect(logs[0]).toContain('"title"');
+  });
+
+  it('hands a drizzleConnection resolver a synchronous builder once the async plan settles', async () => {
+    const { logs } = await sameAsSync(
+      gql`{ usersConnection(first: 1) { edges { node { id titles } } } }`,
+      gql`{ usersConnection(first: 1) { edges { node { id titles: asyncTitles } } } }`,
+    );
+
+    expect(logs[0]).toContain('"d0"."id" = ?');
+    expect(logs[0]).toContain('"title"');
+  });
+
+  it('keeps the precedence of a builder selection that conflicts with a synchronous plan', async () => {
+    const { result, logs } = await run(gql`{ userWithPosts { posts(limit: 1) { id } } }`);
+
+    expect(result.errors).toBeUndefined();
+    // The caller's `posts` was planned first; the field's conflicting `posts` loads on its own.
+    expect(logs).toHaveLength(2);
+    expect(logs[0]).toContain('params: [5, 1, 1]');
+    expect(logs[1]).toContain('"d0"."id" in (?)');
+    expect(logs[1]).toContain('params: [1, 1]');
+  });
+
+  it('rejects a builder selection that conflicts with an async plan', async () => {
+    const { result, logs } = await run(gql`{ userWithPosts { asyncPosts(limit: 1) { id } } }`);
+
+    expect(logs).toHaveLength(0);
+    expect(result.errors?.map((error) => error.message)).toEqual([
+      'The relation "posts" passed to query() in the resolver for Query.userWithPosts conflicts with the arguments a selection beneath the field planned for it, and a selection beneath the field is async. Move the relation\'s arguments to the field that selects it.',
+    ]);
   });
 
   it('creates no promise while planning and resolving a synchronous document (A-1)', async () => {

--- a/packages/plugin-drizzle/tests/async-selections.test.ts
+++ b/packages/plugin-drizzle/tests/async-selections.test.ts
@@ -235,6 +235,15 @@ const User = builder.drizzleObject('users', {
   }),
 });
 
+// Loaded by id through `loadWithoutCache`, with the selection beneath the node field.
+builder.drizzleNode('comments', {
+  variant: 'CommentNode',
+  id: { column: (comment) => comment.id },
+  fields: (t) => ({
+    post: t.relation('post'),
+  }),
+});
+
 builder.queryType({
   fields: (t) => ({
     // The builder is synchronous even when a selection beneath the field is async: the plan is
@@ -265,6 +274,10 @@ builder.queryType({
     rawUser: t.drizzleField({
       type: User,
       resolve: () => db.query.users.findFirst({ where: { id: 1 } }),
+    }),
+    rawUsers: t.drizzleField({
+      type: [User],
+      resolve: () => db.query.users.findMany({ limit: 3, orderBy: { id: 'asc' } }),
     }),
     // Returns a row the test loaded with the planned query, so the whole resolution (planning
     // included) can run under the Promise spy without a database round trip.
@@ -490,6 +503,79 @@ describe('async selections', () => {
     expect(result.errors?.map((error) => error.message)).toEqual([
       'The relation "posts" passed to query() in the resolver for Query.userWithPosts conflicts with the arguments a selection beneath the field planned for it, and a selection beneath the field is async. Move the relation\'s arguments to the field that selects it.',
     ]);
+  });
+
+  it('loads every parent of a list through one staged batch', async () => {
+    const { result, logs } = await run(gql`{ rawUsers { posts(limit: 1) { id } } }`);
+
+    expect(result.errors).toBeUndefined();
+    expect((result.data as { rawUsers: unknown[] }).rawUsers).toHaveLength(3);
+    // One batch: every row's synchronous selection staged in the tick the rows resolved in.
+    expect(logs).toHaveLength(2);
+    expect(logs[1]).toContain('"d0"."id" in (?, ?, ?)');
+  });
+
+  it('stages an unloaded row synchronously, creating only the loader batch promises', async () => {
+    const contextValue: Context = { user: { id: 1 } };
+    const result = await execute({
+      schema,
+      document: gql`{
+        rawUser {
+          posts(limit: 2) { id }
+          publishedCount
+          commentsConnection(first: 1) { edges { node { id } } }
+        }
+      }`,
+      contextValue,
+    });
+
+    expect(result.errors).toBeUndefined();
+    // The raw row, then the one batch the relation, the count and the connection staged into.
+    expect(drizzleLogs).toHaveLength(2);
+    expect(drizzleLogs[1]).toContain('"d0"."id" in (?)');
+    expect(contextValue.resolved).toBe(3);
+    // Exactly the loader's own promises, all created before each resolver returned (planning a
+    // synchronous selection creates none): the first field creates the batch (the row's promise,
+    // the next tick's promise, and the `then` and `catch` that issue it), and every field chains
+    // the mapping step and its resolver onto the row's promise.
+    expect(contextValue.promises).toBe(4 + 2 * 3);
+  });
+
+  it('issues a node load synchronously, creating only the loader batch promises', async () => {
+    const config = builder.configStore.getTypeConfig('CommentNode', 'Object');
+    const options = config.pothosOptions as {
+      loadWithoutCache: (id: string, context: Context, info: unknown) => unknown;
+    };
+    const { loadWithoutCache } = options;
+    let promises = -1;
+
+    options.loadWithoutCache = (id, context, info) => {
+      const counted = countPromises(() => loadWithoutCache(id, context, info));
+
+      promises = counted.promises;
+
+      return counted.result;
+    };
+
+    try {
+      const { result, logs } = await run(
+        gql`{ node(id: "Q29tbWVudE5vZGU6MQ==") { ... on CommentNode { id post { id } } } }`,
+      );
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data).toEqual({
+        node: { id: 'Q29tbWVudE5vZGU6MQ==', post: { id: expect.any(String) } },
+      });
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toContain('"d0"."id" in (?)');
+      expect(logs[0]).toContain('"post"');
+      // The batch (the row's promise, the next tick's promise, and the `then` and `catch` that
+      // issue it) and the mapping step, all created before loadWithoutCache returned: planning
+      // the synchronous selection created none.
+      expect(promises).toBe(4 + 1);
+    } finally {
+      options.loadWithoutCache = loadWithoutCache;
+    }
   });
 
   it('creates no promise while planning and resolving a synchronous document (A-1)', async () => {

--- a/packages/plugin-drizzle/tests/async-selections.test.ts
+++ b/packages/plugin-drizzle/tests/async-selections.test.ts
@@ -1,0 +1,387 @@
+import SchemaBuilder, {
+  BasePlugin,
+  type PothosOutputFieldConfig,
+  type SchemaTypes,
+} from '@pothos/core';
+import RelayPlugin from '@pothos/plugin-relay';
+import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
+import { execute } from '@pothos/test-utils';
+import { eq } from 'drizzle-orm';
+import { getTableConfig } from 'drizzle-orm/sqlite-core';
+import type { DocumentNode } from 'graphql';
+import { gql } from 'graphql-tag';
+import DrizzlePlugin, { drizzleConnectionHelpers } from '../src';
+import { clearDrizzleLogs, type DrizzleRelations, db, drizzleLogs, relations } from './example/db';
+import { posts } from './example/db/schema';
+import { countPromises } from './promise-spy';
+
+// A plugin that maps a field's arguments asynchronously, as the validation plugin does.
+class AsyncArgsPlugin<Types extends SchemaTypes> extends BasePlugin<Types> {
+  override onOutputFieldConfig(fieldConfig: PothosOutputFieldConfig<Types>) {
+    const mapArgs = fieldConfig.extensions?.mapArgsAsync as
+      | ((args: Record<string, unknown>) => Promise<Record<string, unknown>>)
+      | undefined;
+
+    return mapArgs
+      ? { ...fieldConfig, argMappers: [...fieldConfig.argMappers, mapArgs] }
+      : fieldConfig;
+  }
+}
+
+declare global {
+  export namespace PothosSchemaTypes {
+    export interface Plugins<Types extends SchemaTypes> {
+      asyncArgs: AsyncArgsPlugin<Types>;
+    }
+  }
+}
+
+SchemaBuilder.registerPlugin('asyncArgs', AsyncArgsPlugin);
+
+interface Context {
+  user: { id: number };
+  promises?: number;
+}
+
+const builder = new SchemaBuilder<{
+  DrizzleRelations: DrizzleRelations;
+  Context: Context;
+}>({
+  plugins: [ScopeAuthPlugin, RelayPlugin, DrizzlePlugin, 'asyncArgs'],
+  drizzle: {
+    client: () => db,
+    getTableConfig,
+    relations,
+  },
+  scopeAuth: {
+    authScopes: () => ({}),
+  },
+});
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 1));
+
+const Comment = builder.drizzleObject('comments', {
+  name: 'Comment',
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+
+const Post = builder.drizzleObject('posts', {
+  name: 'Post',
+  fields: (t) => ({
+    id: t.exposeID('postId'),
+    comments: t.relation('comments', { query: { limit: 1, orderBy: { id: 'asc' } } }),
+    asyncComments: t.relation('comments', {
+      query: async () => {
+        await tick();
+
+        return { limit: 1, orderBy: { id: 'asc' as const } };
+      },
+    }),
+  }),
+});
+
+const postsQuery = (args: { limit?: number | null }) => ({
+  limit: args.limit ?? 2,
+  orderBy: { postId: 'asc' as const },
+});
+
+const commentHelpers = drizzleConnectionHelpers(builder, 'comments', {
+  query: () => ({ orderBy: { id: 'asc' as const } }),
+});
+
+const asyncCommentHelpers = drizzleConnectionHelpers(builder, 'comments', {
+  query: async () => {
+    await tick();
+
+    return { orderBy: { id: 'asc' as const } };
+  },
+});
+
+// Every async field has a sync twin that plans the same query.
+const User = builder.drizzleObject('users', {
+  name: 'User',
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    posts: t.relation('posts', { args: { limit: t.arg.int() }, query: postsQuery }),
+    asyncPosts: t.relation('posts', {
+      args: { limit: t.arg.int() },
+      query: async (args) => {
+        await tick();
+
+        return postsQuery(args);
+      },
+    }),
+    mappedPosts: t.relation('posts', {
+      args: { limit: t.arg.int() },
+      extensions: {
+        mapArgsAsync: async (args: { limit?: number | null }) => {
+          await tick();
+
+          return { limit: (args.limit ?? 1) * 2 };
+        },
+      },
+      query: postsQuery,
+    }),
+    titles: t.stringList({
+      select: {
+        with: { posts: { columns: { title: true }, limit: 2, orderBy: { postId: 'asc' } } },
+      },
+      resolve: (user) => user.posts.map((post) => post.title),
+    }),
+    asyncTitles: t.stringList({
+      select: async () => {
+        await tick();
+
+        return {
+          with: {
+            posts: { columns: { title: true }, limit: 2, orderBy: { postId: 'asc' as const } },
+          },
+        };
+      },
+      resolve: (user) => user.posts.map((post) => post.title),
+    }),
+    latestPosts: t.field({
+      type: [Post],
+      select: async (_args, _ctx, nestedSelection) => ({
+        with: { posts: await nestedSelection({ limit: 1, orderBy: { postId: 'asc' as const } }) },
+      }),
+      resolve: (user) => user.posts,
+    }),
+    // Forgets to await: a promise when a selection beneath the posts is async.
+    unawaitedPosts: t.field({
+      type: [Post],
+      select: async (_args, _ctx, nestedSelection) => ({
+        with: { posts: nestedSelection({ limit: 1, orderBy: { postId: 'asc' as const } }) },
+      }),
+      resolve: (user) => user.posts,
+    }),
+    publishedCount: t.relatedCount('posts', { where: eq(posts.published, 1) }),
+    asyncPublishedCount: t.relatedCount('posts', {
+      where: async () => {
+        await tick();
+
+        return eq(posts.published, 1);
+      },
+    }),
+    postsTotal: t.relatedField('posts', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { postsTotal: (parent) => db.$count(posts, buildFilter(parent)) },
+      }),
+      resolve: (user) => user.postsTotal,
+    }),
+    asyncPostsTotal: t.relatedField('posts', {
+      type: 'Int',
+      select: async (buildFilter) => {
+        await tick();
+
+        return { extras: { postsTotal: (parent) => db.$count(posts, buildFilter(parent)) } };
+      },
+      resolve: (user) => user.postsTotal,
+    }),
+    postsConnection: t.relatedConnection('posts', {
+      query: () => ({ orderBy: { postId: 'asc' } }),
+    }),
+    asyncPostsConnection: t.relatedConnection('posts', {
+      query: async () => {
+        await tick();
+
+        return { orderBy: { postId: 'asc' as const } };
+      },
+    }),
+    commentsConnection: t.connection({
+      type: Comment,
+      select: (args, ctx, nestedSelection) => ({
+        with: { comments: commentHelpers.getQuery(args, ctx, nestedSelection) },
+      }),
+      resolve: (user, args, ctx) => commentHelpers.resolve(user.comments, args, ctx),
+    }),
+    asyncCommentsConnection: t.connection({
+      type: Comment,
+      select: async (args, ctx, nestedSelection) => ({
+        with: { comments: await asyncCommentHelpers.getQuery(args, ctx, nestedSelection) },
+      }),
+      resolve: (user, args, ctx) => asyncCommentHelpers.resolve(user.comments, args, ctx),
+    }),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    // The query is a promise when a selection beneath the field is async (A-7).
+    user: t.drizzleField({
+      type: User,
+      resolve: async (query) => db.query.users.findFirst(await query({ where: { id: 1 } })),
+    }),
+    // A row fetched without the planned selection: every field with a `select` loads its own
+    // data through the model loader.
+    rawUser: t.drizzleField({
+      type: User,
+      resolve: () => db.query.users.findFirst({ where: { id: 1 } }),
+    }),
+    // Plans the document under a Promise spy and reports the count on the context.
+    spiedUser: t.drizzleField({
+      type: User,
+      resolve: (query, _root, _args, ctx) => {
+        const { result, promises } = countPromises(() => query({ where: { id: 1 } }));
+
+        ctx.promises = promises;
+
+        return db.query.users.findFirst(result);
+      },
+    }),
+  }),
+});
+
+const schema = builder.toSchema();
+
+async function run(document: DocumentNode) {
+  clearDrizzleLogs();
+
+  const contextValue: Context = { user: { id: 1 } };
+  const result = await execute({ schema, document, contextValue });
+  const logs = [...drizzleLogs];
+
+  clearDrizzleLogs();
+
+  return { result, logs, context: contextValue };
+}
+
+/** Runs the sync and async twins of one selection and expects the same query and data. */
+async function sameAsSync(sync: DocumentNode, async: DocumentNode) {
+  const expected = await run(sync);
+  const actual = await run(async);
+
+  expect(expected.result.errors).toBeUndefined();
+  expect(actual.result.errors).toBeUndefined();
+  expect(expected.logs).toHaveLength(1);
+  expect(actual.logs).toEqual(expected.logs);
+  expect(actual.result.data).toEqual(expected.result.data);
+
+  return actual;
+}
+
+describe('async selections', () => {
+  afterEach(() => {
+    clearDrizzleLogs();
+  });
+
+  it('plans an async field select like the sync one', async () => {
+    const { logs } = await sameAsSync(
+      gql`{ user { titles } }`,
+      gql`{ user { titles: asyncTitles } }`,
+    );
+
+    expect(logs[0]).toContain('"title"');
+  });
+
+  it('plans an async relation query like the sync one', async () => {
+    const { logs } = await sameAsSync(
+      gql`{ user { posts(limit: 3) { id comments { id } } } }`,
+      gql`{ user { posts: asyncPosts(limit: 3) { id comments: asyncComments { id } } } }`,
+    );
+
+    expect(logs[0]).toContain('"comments"');
+  });
+
+  it('runs the select once its async arguments are mapped', async () => {
+    const { logs } = await sameAsSync(
+      gql`{ user { posts(limit: 4) { id } } }`,
+      gql`{ user { posts: mappedPosts(limit: 2) { id } } }`,
+    );
+
+    expect(logs[0]).toContain('params: [4, 1, 1]');
+  });
+
+  it('plans an async related count like the sync one', async () => {
+    await sameAsSync(
+      gql`{ user { publishedCount } }`,
+      gql`{ user { publishedCount: asyncPublishedCount } }`,
+    );
+  });
+
+  it('plans an async related field like the sync one', async () => {
+    await sameAsSync(gql`{ user { postsTotal } }`, gql`{ user { postsTotal: asyncPostsTotal } }`);
+  });
+
+  it('plans an async connection query like the sync one', async () => {
+    await sameAsSync(
+      gql`{ user { postsConnection(first: 2) { edges { node { id comments { id } } } } } }`,
+      gql`{ user { postsConnection: asyncPostsConnection(first: 2) { edges { node { id comments: asyncComments { id } } } } } }`,
+    );
+  });
+
+  it('plans async connection helpers like the sync ones when the select awaits getQuery', async () => {
+    await sameAsSync(
+      gql`{ user { commentsConnection(first: 2) { edges { node { id } } } } }`,
+      gql`{ user { commentsConnection: asyncCommentsConnection(first: 2) { edges { node { id } } } } }`,
+    );
+  });
+
+  it('merges an awaited nested selection whose walk is async', async () => {
+    await sameAsSync(
+      gql`{ user { latestPosts { id comments { id } } } }`,
+      gql`{ user { latestPosts { id comments: asyncComments { id } } } }`,
+    );
+  });
+
+  it('rejects a nested selection that was not awaited', async () => {
+    const { result, logs } = await run(
+      gql`{ user { unawaitedPosts { id comments: asyncComments { id } } } }`,
+    );
+
+    expect(logs).toHaveLength(0);
+    expect(result.errors?.map((error) => error.message)).toEqual([
+      'Relation "posts" was given a promise. Await nestedSelection() (or a helper built on it, such as getQuery) inside an async selection function.',
+    ]);
+  });
+
+  it('merges the sync sibling first when it conflicts with an async one (D-5)', async () => {
+    for (const document of [
+      gql`{ user { posts(limit: 1) { id } asyncPosts(limit: 2) { id } } }`,
+      gql`{ user { asyncPosts(limit: 2) { id } posts(limit: 1) { id } } }`,
+    ]) {
+      const { result, logs } = await run(document);
+
+      expect(result.errors).toBeUndefined();
+      expect(logs).toHaveLength(2);
+      // The planned query pages the sync sibling's limit; the async sibling lost the conflict
+      // and loads on its own through the model loader.
+      expect(logs[0]).toContain('params: [1, 1, 1]');
+      expect(logs[1]).toContain('"d0"."id" in (?)');
+      expect(logs[1]).toContain('params: [2, 1]');
+    }
+  });
+
+  it('loads a field with an async select through the model loader in one query', async () => {
+    const planned = await run(gql`{ user { asyncTitles } }`);
+    const { result, logs } = await run(gql`{ rawUser { asyncTitles } }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ rawUser: (planned.result.data as { user: unknown }).user });
+    expect(logs).toHaveLength(2);
+    expect(logs[0]).not.toContain('"title"');
+    expect(logs[1]).toContain('"title"');
+    expect(logs[1]).toContain('"d0"."id" in (?)');
+  });
+
+  it('creates no promise while planning a synchronous document (A-1)', async () => {
+    const { result, logs, context } = await run(gql`
+      {
+        spiedUser {
+          id
+          ... on User { posts(limit: 2) { id comments { id } } }
+          publishedCount
+          postsTotal
+          commentsConnection(first: 1) { edges { node { id } } }
+        }
+      }
+    `);
+
+    expect(result.errors).toBeUndefined();
+    expect(logs).toHaveLength(1);
+    expect(context.promises).toBe(0);
+  });
+});

--- a/packages/plugin-drizzle/tests/async-types.test-d.ts
+++ b/packages/plugin-drizzle/tests/async-types.test-d.ts
@@ -1,0 +1,113 @@
+import SchemaBuilder from '@pothos/core';
+import RelayPlugin from '@pothos/plugin-relay';
+import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
+import { eq } from 'drizzle-orm';
+import { getTableConfig } from 'drizzle-orm/sqlite-core';
+import { expectTypeOf, it } from 'vitest';
+import DrizzlePlugin, { drizzleConnectionHelpers } from '../src';
+import { type DrizzleRelations, db, relations } from './example/db';
+import { posts } from './example/db/schema';
+
+// The async model widens INPUTS only (A-7): a relation `query`, a count `where`, a field or
+// related-field `select` and the connection helpers' callbacks may return promises, while what a
+// resolver is handed (the `query()` builder, `nestedSelection`, `getQuery`) keeps its synchronous
+// declared type and is awaited by the schema that opted in.
+const builder = new SchemaBuilder<{
+  DrizzleRelations: DrizzleRelations;
+  Context: { tenantId: () => Promise<number> };
+}>({
+  plugins: [ScopeAuthPlugin, RelayPlugin, DrizzlePlugin],
+  drizzle: {
+    client: () => db,
+    getTableConfig,
+    relations,
+  },
+  scopeAuth: {
+    authScopes: () => ({}),
+  },
+});
+
+const commentHelpers = drizzleConnectionHelpers(builder, 'comments', {
+  select: async (nodeSelection) => ({ with: { post: nodeSelection() } }),
+  query: async (_args, ctx) => ({ where: { authorId: await ctx.tenantId() } }),
+});
+
+const Comment = builder.drizzleObject('comments', {
+  name: 'Comment',
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+
+const Post = builder.drizzleObject('posts', {
+  name: 'Post',
+  fields: (t) => ({
+    id: t.exposeID('postId'),
+  }),
+});
+
+const User = builder.drizzleObject('users', {
+  name: 'User',
+  fields: (t) => ({
+    posts: t.relation('posts', {
+      query: async (_args, ctx) => ({ where: { authorId: await ctx.tenantId() } }),
+    }),
+    postCount: t.relatedCount('posts', {
+      where: async (_args, ctx) => eq(posts.authorId, await ctx.tenantId()),
+    }),
+    postsTotal: t.relatedField('posts', {
+      type: 'Int',
+      select: async (buildFilter) => ({
+        extras: { postsTotal: (parent) => db.$count(posts, buildFilter(parent)) },
+      }),
+      resolve: (user) => {
+        expectTypeOf(user.postsTotal).toEqualTypeOf<number>();
+
+        return user.postsTotal;
+      },
+    }),
+    postsConnection: t.relatedConnection('posts', {
+      query: async (_args, ctx) => ({ where: { authorId: await ctx.tenantId() } }),
+    }),
+    // The parent shape follows the awaited selection.
+    titles: t.stringList({
+      select: async () => ({ with: { posts: { columns: { title: true } } } }),
+      resolve: (user) => {
+        expectTypeOf(user.posts[0].title).toEqualTypeOf<string>();
+
+        return user.posts.map((post) => post.title);
+      },
+    }),
+    latestPosts: t.field({
+      type: [Post],
+      select: async (_args, _ctx, nestedSelection) => ({
+        with: { posts: await nestedSelection({ limit: 1 }) },
+      }),
+      resolve: (user) => user.posts,
+    }),
+    comments: t.connection({
+      type: Comment,
+      select: async (args, ctx, nestedSelection) => ({
+        with: { comments: await commentHelpers.getQuery(args, ctx, nestedSelection) },
+      }),
+      resolve: (user, args, ctx) => commentHelpers.resolve(user.comments, args, ctx),
+    }),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    user: t.drizzleField({
+      type: User,
+      resolve: (query) => {
+        expectTypeOf(query({ where: { id: 1 } })).not.toMatchTypeOf<PromiseLike<unknown>>();
+
+        return null as never;
+      },
+    }),
+  }),
+});
+
+it('keeps the declared return of the query builder synchronous', () => {
+  expectTypeOf(builder).not.toBeAny();
+});

--- a/packages/plugin-drizzle/tests/promise-spy.ts
+++ b/packages/plugin-drizzle/tests/promise-spy.ts
@@ -1,0 +1,32 @@
+/**
+ * Runs `fn` while every way of creating a promise is counted: construction (`new Promise`, and
+ * the statics `resolve`/`all`/... which construct through `this`) and `.then` (which derives one).
+ * `fn` must be synchronous: the spies are removed before it returns.
+ */
+export function countPromises<T>(fn: () => T): { result: T; promises: number } {
+  const NativePromise = Promise;
+  const { then } = NativePromise.prototype;
+  let promises = 0;
+
+  globalThis.Promise = new Proxy(NativePromise, {
+    construct(target, args, newTarget) {
+      promises += 1;
+
+      return Reflect.construct(target, args, newTarget);
+    },
+  });
+  // biome-ignore lint/suspicious/noThenProperty: the spy counts derived promises
+  NativePromise.prototype.then = function counted(this: Promise<unknown>, ...args: unknown[]) {
+    promises += 1;
+
+    return then.apply(this, args as never) as never;
+  } as typeof then;
+
+  try {
+    return { result: fn(), promises };
+  } finally {
+    globalThis.Promise = NativePromise;
+    // biome-ignore lint/suspicious/noThenProperty: restores the native method
+    NativePromise.prototype.then = then;
+  }
+}

--- a/packages/plugin-drizzle/tests/related-connection-path-info.test.ts
+++ b/packages/plugin-drizzle/tests/related-connection-path-info.test.ts
@@ -138,8 +138,14 @@ describe('relatedConnection pathInfo on the resolve path', () => {
     });
 
     expect(result.errors).toBeUndefined();
-    // Planned by the loader for the field alone, so the path starts at the field.
-    expect(seenPaths).toEqual([['User.postsConnection'], ['User.postsConnection']]);
+    // `rawUser` plans the document before its resolver runs (whether or not the resolver asks for
+    // the query), so the callback first sees the root path; the loader then plans the field
+    // alone, so the path starts at the field, and the resolve path agrees with that plan.
+    expect(seenPaths).toEqual([
+      ['Query.rawUser', 'User.postsConnection'],
+      ['User.postsConnection'],
+      ['User.postsConnection'],
+    ]);
     expect(result.data).toEqual({
       rawUser: {
         postsConnection: {

--- a/packages/plugin-prisma/src/connection-helpers.ts
+++ b/packages/plugin-prisma/src/connection-helpers.ts
@@ -2,6 +2,7 @@ import {
   completeValue,
   type InputFieldMap,
   type InputShapeFromFields,
+  isThenable,
   type MaybePromise,
   type ObjectRef,
   type SchemaTypes,
@@ -22,6 +23,10 @@ import { getDMMF } from './util/get-client.js';
 import { getRelationMap } from './util/relation-map.js';
 
 export const prismaModelKey = Symbol.for('Pothos.prismaModelKey');
+
+function wrapSelect(selected: unknown) {
+  return { select: selected };
+}
 
 export function prismaConnectionHelpers<
   Types extends SchemaTypes,
@@ -139,33 +144,48 @@ export function prismaConnectionHelpers<
     const nestedSelect: MaybePromise<Record<string, unknown> | true> = select
       ? completeValue(
           select((sel) => nestedSelection(sel, ['edges', 'node']), args, ctx),
-          (selected) => ({ select: selected }),
+          wrapSelect,
         )
       : nestedSelection(true, ['edges', 'node']);
     const baseQuery = typeof query === 'function' ? query(args, ctx) : (query ?? {});
 
-    return completeValue(nestedSelect, (nestedSelect) =>
-      completeValue(baseQuery, (baseQuery) => {
-        const node = createNode(fieldMap);
-
-        prismaAdapter.merge(node, { select: cursorSelection });
-
-        if (typeof nestedSelect === 'object' && nestedSelect) {
-          prismaAdapter.merge(node, nestedSelect);
-        }
-
-        return {
-          ...baseQuery,
-          ...getQueryArgs(args, ctx),
-          ...prismaAdapter.serialize(node),
-        };
-      }),
-    ) as unknown as (Model['Select'] extends Select ? {} : { select: Select }) & {
+    return (isThenable(nestedSelect) || isThenable(baseQuery)
+      ? Promise.all([nestedSelect, baseQuery]).then(([nested, base]) =>
+          buildQuery(nested, base, args, ctx),
+        )
+      : buildQuery(
+          nestedSelect,
+          baseQuery,
+          args,
+          ctx,
+        )) as unknown as (Model['Select'] extends Select ? {} : { select: Select }) & {
       where?: Model['Where'];
       orderBy?: Model['OrderBy'];
       skip?: number;
       take?: number;
       cursor?: Model['WhereUnique'];
+    };
+  }
+
+  // Built once per helper, so a synchronous `getQuery` allocates nothing beyond the query.
+  function buildQuery(
+    nestedSelect: Record<string, unknown> | true,
+    baseQuery: object,
+    args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
+    ctx: Types['Context'],
+  ) {
+    const node = createNode(fieldMap);
+
+    prismaAdapter.merge(node, { select: cursorSelection });
+
+    if (typeof nestedSelect === 'object' && nestedSelect) {
+      prismaAdapter.merge(node, nestedSelect);
+    }
+
+    return {
+      ...baseQuery,
+      ...getQueryArgs(args, ctx),
+      ...prismaAdapter.serialize(node),
     };
   }
 

--- a/packages/plugin-prisma/src/connection-helpers.ts
+++ b/packages/plugin-prisma/src/connection-helpers.ts
@@ -1,4 +1,11 @@
-import type { InputFieldMap, InputShapeFromFields, ObjectRef, SchemaTypes } from '@pothos/core';
+import {
+  completeValue,
+  type InputFieldMap,
+  type InputShapeFromFields,
+  type MaybePromise,
+  type ObjectRef,
+  type SchemaTypes,
+} from '@pothos/core';
 import { createNode } from '@pothos/selection-mapper';
 import type { PrismaRef } from './interface-ref.js';
 import { ModelLoader } from './model-loader.js';
@@ -46,15 +53,15 @@ export function prismaConnectionHelpers<
       nestedSelection: <T extends true | {}>(selection?: T) => T,
       args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
       ctx: Types['Context'],
-    ) => Select;
+    ) => MaybePromise<Select>;
     query?:
       | ((
           args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
           ctx: Types['Context'],
-        ) => {
+        ) => MaybePromise<{
           where?: Model['Where'];
           orderBy?: Model['OrderBy'];
-        })
+        }>)
       | {
           where?: Model['Where'];
           orderBy?: Model['OrderBy'];
@@ -127,25 +134,33 @@ export function prismaConnectionHelpers<
     ctx: Types['Context'],
     nestedSelection: <T extends true | {}>(selection?: T, path?: string[]) => T,
   ) {
-    const nestedSelect: Record<string, unknown> | true = select
-      ? { select: select((sel) => nestedSelection(sel, ['edges', 'node']), args, ctx) }
+    // Both callbacks start now; the query waits for whichever of them is async (A-3, A-7: the
+    // declared type stays synchronous, so an async schema awaits the result).
+    const nestedSelect: MaybePromise<Record<string, unknown> | true> = select
+      ? completeValue(
+          select((sel) => nestedSelection(sel, ['edges', 'node']), args, ctx),
+          (selected) => ({ select: selected }),
+        )
       : nestedSelection(true, ['edges', 'node']);
-
-    const node = createNode(fieldMap);
-
-    prismaAdapter.merge(node, { select: cursorSelection });
-
-    if (typeof nestedSelect === 'object' && nestedSelect) {
-      prismaAdapter.merge(node, nestedSelect);
-    }
-
     const baseQuery = typeof query === 'function' ? query(args, ctx) : (query ?? {});
 
-    return {
-      ...baseQuery,
-      ...getQueryArgs(args, ctx),
-      ...prismaAdapter.serialize(node),
-    } as unknown as (Model['Select'] extends Select ? {} : { select: Select }) & {
+    return completeValue(nestedSelect, (nestedSelect) =>
+      completeValue(baseQuery, (baseQuery) => {
+        const node = createNode(fieldMap);
+
+        prismaAdapter.merge(node, { select: cursorSelection });
+
+        if (typeof nestedSelect === 'object' && nestedSelect) {
+          prismaAdapter.merge(node, nestedSelect);
+        }
+
+        return {
+          ...baseQuery,
+          ...getQueryArgs(args, ctx),
+          ...prismaAdapter.serialize(node),
+        };
+      }),
+    ) as unknown as (Model['Select'] extends Select ? {} : { select: Select }) & {
       where?: Model['Where'];
       orderBy?: Model['OrderBy'];
       skip?: number;

--- a/packages/plugin-prisma/src/field-builder.ts
+++ b/packages/plugin-prisma/src/field-builder.ts
@@ -1,5 +1,4 @@
 import {
-  completeValue,
   type FieldKind,
   type FieldRef,
   type InputFieldMap,
@@ -46,22 +45,20 @@ fieldBuilderProto.prismaField = function prismaField({ type, resolve, ...options
   return this.field({
     ...(options as {}),
     type: typeParam,
-    resolve: (parent: never, args: unknown, context: {}, info: GraphQLResolveInfo) =>
-      completeValue(
-        queryFromInfo({
-          context,
-          info,
-          withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
-          skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
-        }),
-        (query) =>
-          checkIfQueryIsUsed(
-            this.builder,
-            query,
-            info,
-            resolve(query, parent, args as never, context, info) as never,
-          ),
-      ),
+    resolve: (parent: never, args: unknown, context: {}, info: GraphQLResolveInfo) => {
+      const query = queryFromInfo({
+        context,
+        info,
+        withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
+        skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
+      });
+
+      return isThenable(query)
+        ? query.then((resolved) =>
+            resolveWithQuery(this.builder, resolve as never, resolved, parent, args, context, info),
+          )
+        : resolveWithQuery(this.builder, resolve as never, query, parent, args, context, info);
+    },
   }) as never;
 };
 
@@ -86,24 +83,40 @@ fieldBuilderProto.prismaFieldWithInput = function prismaFieldWithInput(
   ).fieldWithInput({
     ...(options as {}),
     type: typeParam,
-    resolve: (parent: never, args: unknown, context: {}, info: GraphQLResolveInfo) =>
-      completeValue(
-        queryFromInfo({
-          context,
-          info,
-          withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
-          skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
-        }),
-        (query) =>
-          checkIfQueryIsUsed(
-            this.builder,
-            query,
-            info,
-            resolve(query, parent, args as never, context, info) as never,
-          ),
-      ),
+    resolve: (parent: never, args: unknown, context: {}, info: GraphQLResolveInfo) => {
+      const query = queryFromInfo({
+        context,
+        info,
+        withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
+        skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
+      });
+
+      return isThenable(query)
+        ? query.then((resolved) =>
+            resolveWithQuery(this.builder, resolve, resolved, parent, args, context, info),
+          )
+        : resolveWithQuery(this.builder, resolve, query, parent, args, context, info);
+    },
   }) as never;
 } as never;
+
+/** Runs a `prismaField` resolver with its planned query; built once so a sync call allocates nothing. */
+function resolveWithQuery(
+  builder: PothosSchemaTypes.SchemaBuilder<SchemaTypes>,
+  resolve: (...args: unknown[]) => unknown,
+  query: unknown,
+  parent: unknown,
+  args: unknown,
+  context: {},
+  info: GraphQLResolveInfo,
+) {
+  return checkIfQueryIsUsed(
+    builder,
+    query as object,
+    info,
+    resolve(query, parent, args, context, info) as never,
+  );
+}
 
 fieldBuilderProto.prismaConnection = function prismaConnection<
   Type extends keyof SchemaTypes['PrismaTypes'],
@@ -141,6 +154,43 @@ fieldBuilderProto.prismaConnection = function prismaConnection<
   const formatCursor = getCursorFormatter(model, this.builder, cursor);
   const parseCursor = getCursorParser(model, this.builder, cursor);
   const cursorSelection = ModelLoader.getCursorSelection(ref, model, cursor, this.builder);
+
+  // Built once per field: resolving with a synchronous plan allocates nothing beyond the
+  // callback `resolvePrismaCursorConnection` was already handed.
+  const resolveConnection = (
+    query: object,
+    parent: unknown,
+    args: PothosSchemaTypes.DefaultConnectionArguments,
+    context: {},
+    info: GraphQLResolveInfo,
+    totalCountOnly: boolean,
+  ) =>
+    resolvePrismaCursorConnection(
+      {
+        parent,
+        query,
+        ctx: context,
+        parseCursor,
+        maxSize,
+        defaultSize,
+        args,
+        totalCount: totalCount && (() => totalCount(parent, args as never, context, info)),
+      },
+      formatCursor,
+      (q) => {
+        if (totalCountOnly) {
+          return [];
+        }
+
+        return checkIfQueryIsUsed(
+          this.builder,
+          query,
+          info,
+          resolve(q as never, parent, args as never, context, info) as never,
+        );
+      },
+    );
+
   const fieldRef = (
     this as typeof fieldBuilderProto & {
       connection: (...args: unknown[]) => FieldRef<SchemaTypes, unknown>;
@@ -170,43 +220,21 @@ fieldBuilderProto.prismaConnection = function prismaConnection<
           ),
         );
 
-        return completeValue(
-          queryFromInfo({
-            context,
-            info,
-            select: cursorSelection as {},
-            paths: [['nodes'], ['edges', 'node']],
-            typeName,
-            withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
-            skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
-          }),
-          (query) =>
-            resolvePrismaCursorConnection(
-              {
-                parent,
-                query,
-                ctx: context,
-                parseCursor,
-                maxSize,
-                defaultSize,
-                args,
-                totalCount: totalCount && (() => totalCount(parent, args as never, context, info)),
-              },
-              formatCursor,
-              (q) => {
-                if (totalCountOnly) {
-                  return [];
-                }
+        const query = queryFromInfo({
+          context,
+          info,
+          select: cursorSelection as {},
+          paths: [['nodes'], ['edges', 'node']],
+          typeName,
+          withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
+          skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
+        });
 
-                return checkIfQueryIsUsed(
-                  this.builder,
-                  query,
-                  info,
-                  resolve(q as never, parent, args as never, context, info) as never,
-                );
-              },
-            ),
-        );
+        return isThenable(query)
+          ? query.then((resolved) =>
+              resolveConnection(resolved as object, parent, args, context, info, totalCountOnly),
+            )
+          : resolveConnection(query, parent, args, context, info, totalCountOnly);
       },
     },
     connectionOptions instanceof ObjectRef

--- a/packages/plugin-prisma/src/field-builder.ts
+++ b/packages/plugin-prisma/src/field-builder.ts
@@ -1,4 +1,5 @@
 import {
+  completeValue,
   type FieldKind,
   type FieldRef,
   type InputFieldMap,
@@ -45,21 +46,22 @@ fieldBuilderProto.prismaField = function prismaField({ type, resolve, ...options
   return this.field({
     ...(options as {}),
     type: typeParam,
-    resolve: (parent: never, args: unknown, context: {}, info: GraphQLResolveInfo) => {
-      const query = queryFromInfo({
-        context,
-        info,
-        withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
-        skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
-      });
-
-      return checkIfQueryIsUsed(
-        this.builder,
-        query,
-        info,
-        resolve(query, parent, args as never, context, info) as never,
-      );
-    },
+    resolve: (parent: never, args: unknown, context: {}, info: GraphQLResolveInfo) =>
+      completeValue(
+        queryFromInfo({
+          context,
+          info,
+          withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
+          skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
+        }),
+        (query) =>
+          checkIfQueryIsUsed(
+            this.builder,
+            query,
+            info,
+            resolve(query, parent, args as never, context, info) as never,
+          ),
+      ),
   }) as never;
 };
 
@@ -84,21 +86,22 @@ fieldBuilderProto.prismaFieldWithInput = function prismaFieldWithInput(
   ).fieldWithInput({
     ...(options as {}),
     type: typeParam,
-    resolve: (parent: never, args: unknown, context: {}, info: GraphQLResolveInfo) => {
-      const query = queryFromInfo({
-        context,
-        info,
-        withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
-        skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
-      });
-
-      return checkIfQueryIsUsed(
-        this.builder,
-        query,
-        info,
-        resolve(query, parent, args as never, context, info) as never,
-      );
-    },
+    resolve: (parent: never, args: unknown, context: {}, info: GraphQLResolveInfo) =>
+      completeValue(
+        queryFromInfo({
+          context,
+          info,
+          withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
+          skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
+        }),
+        (query) =>
+          checkIfQueryIsUsed(
+            this.builder,
+            query,
+            info,
+            resolve(query, parent, args as never, context, info) as never,
+          ),
+      ),
   }) as never;
 } as never;
 
@@ -152,16 +155,6 @@ fieldBuilderProto.prismaConnection = function prismaConnection<
         context: {},
         info: GraphQLResolveInfo,
       ) => {
-        const query = queryFromInfo({
-          context,
-          info,
-          select: cursorSelection as {},
-          paths: [['nodes'], ['edges', 'node']],
-          typeName,
-          withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
-          skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
-        });
-
         const returnType = getNamedType(info.returnType);
         const fields =
           isObjectType(returnType) || isInterfaceType(returnType) ? returnType.getFields() : {};
@@ -177,30 +170,42 @@ fieldBuilderProto.prismaConnection = function prismaConnection<
           ),
         );
 
-        return resolvePrismaCursorConnection(
-          {
-            parent,
-            query,
-            ctx: context,
-            parseCursor,
-            maxSize,
-            defaultSize,
-            args,
-            totalCount: totalCount && (() => totalCount(parent, args as never, context, info)),
-          },
-          formatCursor,
-          (q) => {
-            if (totalCountOnly) {
-              return [];
-            }
+        return completeValue(
+          queryFromInfo({
+            context,
+            info,
+            select: cursorSelection as {},
+            paths: [['nodes'], ['edges', 'node']],
+            typeName,
+            withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
+            skipDeferredFragments: this.builder.options.prisma?.skipDeferredFragments,
+          }),
+          (query) =>
+            resolvePrismaCursorConnection(
+              {
+                parent,
+                query,
+                ctx: context,
+                parseCursor,
+                maxSize,
+                defaultSize,
+                args,
+                totalCount: totalCount && (() => totalCount(parent, args as never, context, info)),
+              },
+              formatCursor,
+              (q) => {
+                if (totalCountOnly) {
+                  return [];
+                }
 
-            return checkIfQueryIsUsed(
-              this.builder,
-              query,
-              info,
-              resolve(q as never, parent, args as never, context, info) as never,
-            );
-          },
+                return checkIfQueryIsUsed(
+                  this.builder,
+                  query,
+                  info,
+                  resolve(q as never, parent, args as never, context, info) as never,
+                );
+              },
+            ),
         );
       },
     },

--- a/packages/plugin-prisma/src/index.ts
+++ b/packages/plugin-prisma/src/index.ts
@@ -4,6 +4,7 @@ import './field-builder.js';
 import SchemaBuilder, {
   BasePlugin,
   type BuildCache,
+  completeValue,
   type PothosOutputFieldConfig,
   PothosSchemaError,
   type PothosTypeConfig,
@@ -110,14 +111,15 @@ export class PothosPrismaPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
                   args: {},
                   ctx: Types['Context'],
                   nestedQuery: (query: unknown, path?: string[], type?: string) => never,
-                ) => {
-                  const selected = (
-                    select as (args: unknown, ctx: unknown, nestedQuery: unknown) => {} | null
-                  )(args, ctx, nestedQuery);
-
-                  // A falsy selection means the field selects nothing from the parent row.
-                  return selected ? { select: selected } : null;
-                }
+                ) =>
+                  completeValue(
+                    (select as (args: unknown, ctx: unknown, nestedQuery: unknown) => {} | null)(
+                      args,
+                      ctx,
+                      nestedQuery,
+                    ),
+                    wrapSelect,
+                  )
               : select,
         },
       };
@@ -176,16 +178,13 @@ export class PothosPrismaPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
       }
 
       if (fallback) {
-        return fallback(
+        return completeValue(
           queryFromInfo({
             context,
             info,
             skipDeferredFragments: this.builder.options.prisma.skipDeferredFragments,
           }),
-          parent,
-          args,
-          context,
-          info,
+          (query) => fallback(query, parent, args, context, info),
         );
       }
 
@@ -194,6 +193,11 @@ export class PothosPrismaPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
         .then((result) => resolver(result, args, context, info));
     };
   }
+}
+
+/** A falsy selection means the field selects nothing from the parent row. */
+function wrapSelect(selected: {} | null) {
+  return selected ? { select: selected } : null;
 }
 
 SchemaBuilder.registerPlugin(pluginName, PothosPrismaPlugin, {

--- a/packages/plugin-prisma/src/index.ts
+++ b/packages/plugin-prisma/src/index.ts
@@ -5,6 +5,7 @@ import SchemaBuilder, {
   BasePlugin,
   type BuildCache,
   completeValue,
+  isThenable,
   type PothosOutputFieldConfig,
   PothosSchemaError,
   type PothosTypeConfig,
@@ -178,14 +179,15 @@ export class PothosPrismaPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
       }
 
       if (fallback) {
-        return completeValue(
-          queryFromInfo({
-            context,
-            info,
-            skipDeferredFragments: this.builder.options.prisma.skipDeferredFragments,
-          }),
-          (query) => fallback(query, parent, args, context, info),
-        );
+        const query = queryFromInfo({
+          context,
+          info,
+          skipDeferredFragments: this.builder.options.prisma.skipDeferredFragments,
+        });
+
+        return isThenable(query)
+          ? query.then((resolved) => fallback(resolved as {}, parent, args, context, info))
+          : fallback(query, parent, args, context, info);
       }
 
       return loaderCache(context)

--- a/packages/plugin-prisma/src/model-loader.ts
+++ b/packages/plugin-prisma/src/model-loader.ts
@@ -2,6 +2,7 @@ import {
   completeValue,
   createContextCache,
   type InterfaceRef,
+  isThenable,
   type MaybePromise,
   type ObjectRef,
   PothosSchemaError,
@@ -20,6 +21,13 @@ interface ResolvablePromise<T> {
   resolve: (value: T) => void;
   reject: (err: unknown) => void;
 }
+
+/** A field's loader walk and the query it serializes to. */
+interface Selection {
+  walk: PrismaWalk;
+  query: SelectionMap;
+}
+
 export class ModelLoader {
   context: object;
 
@@ -30,7 +38,7 @@ export class ModelLoader {
   modelName: string;
 
   // L-4: one selection per `Type@path`, a promise while a select beneath the field is async.
-  queryCache = new Map<string, MaybePromise<{ walk: PrismaWalk; query: SelectionMap }>>();
+  queryCache = new Map<string, MaybePromise<Selection>>();
 
   staged = new Set<{
     walk: PrismaWalk;
@@ -250,23 +258,34 @@ export class ModelLoader {
     return this.queryCache.get(key)!;
   }
 
-  async loadSelection(info: GraphQLResolveInfo, model: object) {
-    const { walk, query } = await this.getSelection(info);
+  /**
+   * L-3: `model` reloaded with the selection of the field `info` resolves. A synchronous
+   * selection stages synchronously, so every row resolved in a tick joins the same batch; only a
+   * selection with an async select beneath the field waits for it.
+   */
+  loadSelection(info: GraphQLResolveInfo, model: object): Promise<Record<string, unknown> | null> {
+    const selection = this.getSelection(info);
 
-    const result = await this.stageQuery(walk, query, model);
-
-    if (result) {
-      const mapping = walk.mappings[`${info.parentType.name}@${info.path.key}`];
-
-      if (mapping) {
-        setLoaderMappings(this.context, info, mapping.nested);
-      }
-    }
-
-    return result;
+    return isThenable(selection)
+      ? selection.then((settled) => this.loadWith(settled as Selection, info, model))
+      : this.loadWith(selection, info, model);
   }
 
-  async stageQuery(walk: PrismaWalk, query: SelectionMap, model: object) {
+  private loadWith({ walk, query }: Selection, info: GraphQLResolveInfo, model: object) {
+    return this.stageQuery(walk, query, model).then((result) => {
+      if (result) {
+        const mapping = walk.mappings[`${info.parentType.name}@${info.path.key}`];
+
+        if (mapping) {
+          setLoaderMappings(this.context, info, mapping.nested);
+        }
+      }
+
+      return result;
+    });
+  }
+
+  stageQuery(walk: PrismaWalk, query: SelectionMap, model: object) {
     for (const entry of this.staged) {
       if (prismaAdapter.compatible(entry.walk.root, query, false)) {
         prismaAdapter.merge(entry.walk.root, query);
@@ -275,7 +294,7 @@ export class ModelLoader {
           entry.models.set(model, createResolvablePromise<Record<string, unknown> | null>());
         }
 
-        return await entry.models.get(model)!.promise;
+        return entry.models.get(model)!.promise;
       }
     }
 

--- a/packages/plugin-prisma/src/model-loader.ts
+++ b/packages/plugin-prisma/src/model-loader.ts
@@ -1,6 +1,8 @@
 import {
+  completeValue,
   createContextCache,
   type InterfaceRef,
+  type MaybePromise,
   type ObjectRef,
   PothosSchemaError,
   type SchemaTypes,
@@ -27,7 +29,8 @@ export class ModelLoader {
 
   modelName: string;
 
-  queryCache = new Map<string, { walk: PrismaWalk; query: SelectionMap }>();
+  // L-4: one selection per `Type@path`, a promise while a select beneath the field is async.
+  queryCache = new Map<string, MaybePromise<{ walk: PrismaWalk; query: SelectionMap }>>();
 
   staged = new Set<{
     walk: PrismaWalk;
@@ -231,22 +234,24 @@ export class ModelLoader {
   getSelection(info: GraphQLResolveInfo) {
     const key = cacheKey(info.parentType.name, info.path);
     if (!this.queryCache.has(key)) {
-      const walk = selectionStateFromInfo(
-        this.context,
-        info,
-        this.builder.options.prisma.skipDeferredFragments ?? true,
+      this.queryCache.set(
+        key,
+        completeValue(
+          selectionStateFromInfo(
+            this.context,
+            info,
+            this.builder.options.prisma.skipDeferredFragments ?? true,
+          ),
+          selectionOf,
+        ),
       );
-      this.queryCache.set(key, {
-        walk,
-        query: prismaAdapter.serialize(walk.root),
-      });
     }
 
     return this.queryCache.get(key)!;
   }
 
   async loadSelection(info: GraphQLResolveInfo, model: object) {
-    const { walk, query } = this.getSelection(info);
+    const { walk, query } = await this.getSelection(info);
 
     const result = await this.stageQuery(walk, query, model);
 
@@ -323,6 +328,10 @@ export class ModelLoader {
 
     return promise.promise;
   }
+}
+
+function selectionOf(walk: PrismaWalk) {
+  return { walk, query: prismaAdapter.serialize(walk.root) };
 }
 
 function createResolvablePromise<T = unknown>(): ResolvablePromise<T> {

--- a/packages/plugin-prisma/src/prisma-field-builder.ts
+++ b/packages/plugin-prisma/src/prisma-field-builder.ts
@@ -1,5 +1,6 @@
 import {
   type CompatibleTypes,
+  completeValue,
   type ExposeNullability,
   type FieldKind,
   type FieldRef,
@@ -208,6 +209,7 @@ export class PrismaObjectFieldBuilder<
     const formatCursor = getCursorFormatter(relationField.type, this.builder, cursorValue);
     const parseCursor = getCursorParser(relationField.type, this.builder, cursorValue);
 
+    // The field's `query` may be async, so the result is a promise when it is (A-5).
     const getQuery = (args: PothosSchemaTypes.DefaultConnectionArguments, ctx: {}) => {
       const connectionQuery = prismaCursorConnectionQuery({
         parseCursor,
@@ -217,21 +219,28 @@ export class PrismaObjectFieldBuilder<
         args,
       });
 
-      const {
-        take = connectionQuery.take,
-        skip = connectionQuery.skip,
-        cursor = connectionQuery.cursor,
-        ...fieldQuery
-      } = ((typeof query === 'function' ? query(args, ctx) : query) ??
-        {}) as typeof connectionQuery;
+      return completeValue(
+        (typeof query === 'function' ? query(args, ctx) : query) as
+          | MaybePromise<typeof connectionQuery>
+          | null
+          | undefined,
+        (userQuery) => {
+          const {
+            take = connectionQuery.take,
+            skip = connectionQuery.skip,
+            cursor = connectionQuery.cursor,
+            ...fieldQuery
+          } = userQuery ?? ({} as typeof connectionQuery);
 
-      return {
-        ...fieldQuery,
-        ...connectionQuery,
-        take,
-        skip,
-        ...(cursor ? { cursor } : {}),
-      };
+          return {
+            ...fieldQuery,
+            ...connectionQuery,
+            take,
+            skip,
+            ...(cursor ? { cursor } : {}),
+          };
+        },
+      );
     };
 
     const cursorSelection = ModelLoader.getCursorSelection(
@@ -259,10 +268,11 @@ export class PrismaObjectFieldBuilder<
       getSelection: (path: string[]) => FieldNode | null,
     ) => {
       typeName ??= this.builder.configStore.getTypeConfig(ref).name;
+      // A maybe-promise query starts the nested walk now; its merge waits for the query.
       const nested = nestedQuery(getQuery(args, context), {
         getType: () => typeName!,
         paths: [[{ name: 'nodes' }], [{ name: 'edges' }, { name: 'node' }]],
-      }) as SelectionMap;
+      }) as MaybePromise<SelectionMap>;
 
       // Each lookup searches every node selecting the connection (fragments on a wrapper's
       // success type may split totalCount and edges across two of them), so the plan agrees with
@@ -272,29 +282,31 @@ export class PrismaObjectFieldBuilder<
         !!getSelection(['edges']) || !!getSelection(['nodes']) || !!getSelection(['pageInfo']);
       const totalCountOnly = hasTotalCount && !hasRows;
 
-      const countSelect =
-        this.builder.options.prisma.filterConnectionTotalCount !== false
-          ? nested.where
-            ? { where: nested.where }
-            : true
-          : true;
+      return completeValue(nested, (nested) => {
+        const countSelect =
+          this.builder.options.prisma.filterConnectionTotalCount !== false
+            ? nested.where
+              ? { where: nested.where }
+              : true
+            : true;
 
-      return {
-        select: {
-          ...(hasTotalCount ? { _count: { select: { [name]: countSelect } } } : {}),
-          [name]: totalCountOnly
-            ? undefined
-            : nested?.select
-              ? {
-                  ...nested,
-                  select: {
-                    ...cursorSelection,
-                    ...nested.select,
-                  },
-                }
-              : nested,
-        },
-      };
+        return {
+          select: {
+            ...(hasTotalCount ? { _count: { select: { [name]: countSelect } } } : {}),
+            [name]: totalCountOnly
+              ? undefined
+              : nested?.select
+                ? {
+                    ...nested,
+                    select: {
+                      ...cursorSelection,
+                      ...nested.select,
+                    },
+                  }
+                : nested,
+          },
+        };
+      });
     };
 
     const fieldRef = (
@@ -331,18 +343,22 @@ export class PrismaObjectFieldBuilder<
               context: {},
               info: GraphQLResolveInfo,
             ) =>
-              Promise.resolve(
-                resolve(
-                  {
-                    ...q,
-                    ...getQuery(args, context),
-                  } as never,
-                  parent,
-                  args,
-                  context,
-                  info,
+              completeValue(getQuery(args, context), (connectionQuery) =>
+                Promise.resolve(
+                  resolve(
+                    {
+                      ...q,
+                      ...connectionQuery,
+                    } as never,
+                    parent,
+                    args,
+                    context,
+                    info,
+                  ),
+                ).then((result) =>
+                  wrapConnectionResult(parent, result, args, q.take, formatCursor),
                 ),
-              ).then((result) => wrapConnectionResult(parent, result, args, q.take, formatCursor))),
+              )),
         },
         type: ref,
         resolve: (
@@ -352,15 +368,16 @@ export class PrismaObjectFieldBuilder<
           info: GraphQLResolveInfo,
         ) => {
           const { totalCountOnly } = connectionSelection(context, info);
-          const connectionQuery = getQuery(args, context);
 
-          return wrapConnectionResult(
-            parent,
-            totalCountOnly ? [] : ((parent as Record<string, never>)[name] ?? []),
-            args,
-            connectionQuery.take,
-            formatCursor,
-            (parent as { _count?: Record<string, number> })._count?.[name],
+          return completeValue(getQuery(args, context), (connectionQuery) =>
+            wrapConnectionResult(
+              parent,
+              totalCountOnly ? [] : ((parent as Record<string, never>)[name] ?? []),
+              args,
+              connectionQuery.take,
+              formatCursor,
+              (parent as { _count?: Record<string, number> })._count?.[name],
+            ),
           );
         },
       },
@@ -423,11 +440,13 @@ export class PrismaObjectFieldBuilder<
 
     const { query = {}, resolve, extensions, onNull, ...rest } = options;
 
+    // Built once per field: the select allocates nothing when the nested selection is sync.
+    const selectRelation = (nested: unknown) => ({ select: { [name]: nested } });
     const relationSelect = (
       _args: object,
       _context: object,
       nestedQuery: (query: unknown) => unknown,
-    ) => ({ select: { [name]: nestedQuery(query) } });
+    ) => completeValue(nestedQuery(query), selectRelation);
 
     return this.field({
       ...(rest as {}),
@@ -441,12 +460,8 @@ export class PrismaObjectFieldBuilder<
         pothosPrismaFallback:
           resolve &&
           ((q: {}, parent: Shape, args: {}, context: {}, info: GraphQLResolveInfo) =>
-            resolve(
-              { ...q, ...(typeof query === 'function' ? query(args, context) : query) } as never,
-              parent,
-              args as never,
-              context,
-              info,
+            completeValue(typeof query === 'function' ? query(args, context) : query, (userQuery) =>
+              resolve({ ...q, ...userQuery } as never, parent, args as never, context, info),
             )),
       },
       resolve: (parent, args, context, info) => {
@@ -476,15 +491,14 @@ export class PrismaObjectFieldBuilder<
   ): FieldRef<Types, number, 'Object'> {
     const [{ where, ...options } = {} as never] = allArgs;
 
+    const selectCount = (where: {}) => ({ _count: { select: { [name]: { where } } } });
     const countSelect =
       typeof where === 'function'
-        ? (args: {}, context: {}) => ({
-            _count: {
-              select: {
-                [name]: { where: (where as (args: unknown, ctx: unknown) => {})(args, context) },
-              },
-            },
-          })
+        ? (args: {}, context: {}) =>
+            completeValue(
+              (where as (args: unknown, ctx: unknown) => MaybePromise<{}>)(args, context),
+              selectCount,
+            )
         : {
             _count: {
               select: { [name]: where ? { where } : true },

--- a/packages/plugin-prisma/src/prisma-field-builder.ts
+++ b/packages/plugin-prisma/src/prisma-field-builder.ts
@@ -219,28 +219,16 @@ export class PrismaObjectFieldBuilder<
         args,
       });
 
-      return completeValue(
-        (typeof query === 'function' ? query(args, ctx) : query) as
-          | MaybePromise<typeof connectionQuery>
-          | null
-          | undefined,
-        (userQuery) => {
-          const {
-            take = connectionQuery.take,
-            skip = connectionQuery.skip,
-            cursor = connectionQuery.cursor,
-            ...fieldQuery
-          } = userQuery ?? ({} as typeof connectionQuery);
+      const userQuery = (typeof query === 'function' ? query(args, ctx) : query) as
+        | MaybePromise<typeof connectionQuery>
+        | null
+        | undefined;
 
-          return {
-            ...fieldQuery,
-            ...connectionQuery,
-            take,
-            skip,
-            ...(cursor ? { cursor } : {}),
-          };
-        },
-      );
+      return isThenable(userQuery)
+        ? (userQuery as PromiseLike<typeof connectionQuery | null | undefined>).then((resolved) =>
+            mergeConnectionQuery(resolved, connectionQuery),
+          )
+        : mergeConnectionQuery(userQuery, connectionQuery);
     };
 
     const cursorSelection = ModelLoader.getCursorSelection(
@@ -259,6 +247,37 @@ export class PrismaObjectFieldBuilder<
       const hasRows = selected.has('edges') || selected.has('nodes') || selected.has('pageInfo');
 
       return { hasTotalCount, totalCountOnly: hasTotalCount && !hasRows };
+    };
+
+    // Built once per field, so a synchronous plan allocates nothing beyond the map itself.
+    const selectConnection = (
+      nested: SelectionMap,
+      hasTotalCount: boolean,
+      totalCountOnly: boolean,
+    ) => {
+      const countSelect =
+        this.builder.options.prisma.filterConnectionTotalCount !== false
+          ? nested.where
+            ? { where: nested.where }
+            : true
+          : true;
+
+      return {
+        select: {
+          ...(hasTotalCount ? { _count: { select: { [name]: countSelect } } } : {}),
+          [name]: totalCountOnly
+            ? undefined
+            : nested?.select
+              ? {
+                  ...nested,
+                  select: {
+                    ...cursorSelection,
+                    ...nested.select,
+                  },
+                }
+              : nested,
+        },
+      };
     };
 
     const relationSelect = (
@@ -282,32 +301,40 @@ export class PrismaObjectFieldBuilder<
         !!getSelection(['edges']) || !!getSelection(['nodes']) || !!getSelection(['pageInfo']);
       const totalCountOnly = hasTotalCount && !hasRows;
 
-      return completeValue(nested, (nested) => {
-        const countSelect =
-          this.builder.options.prisma.filterConnectionTotalCount !== false
-            ? nested.where
-              ? { where: nested.where }
-              : true
-            : true;
-
-        return {
-          select: {
-            ...(hasTotalCount ? { _count: { select: { [name]: countSelect } } } : {}),
-            [name]: totalCountOnly
-              ? undefined
-              : nested?.select
-                ? {
-                    ...nested,
-                    select: {
-                      ...cursorSelection,
-                      ...nested.select,
-                    },
-                  }
-                : nested,
-          },
-        };
-      });
+      return isThenable(nested)
+        ? nested.then((resolved) => selectConnection(resolved, hasTotalCount, totalCountOnly))
+        : selectConnection(nested, hasTotalCount, totalCountOnly);
     };
+
+    // The loaded path, per parent row: the rows are on the parent, only the page size is needed.
+    const resolveLoaded = (
+      connectionQuery: { take: number },
+      parent: unknown,
+      args: PothosSchemaTypes.DefaultConnectionArguments,
+      totalCountOnly: boolean,
+    ) =>
+      wrapConnectionResult(
+        parent,
+        totalCountOnly ? [] : ((parent as Record<string, never>)[name] ?? []),
+        args,
+        connectionQuery.take,
+        formatCursor,
+        (parent as { _count?: Record<string, number> })._count?.[name],
+      );
+
+    const resolveFallback =
+      resolve &&
+      ((
+        connectionQuery: {},
+        q: { take: number },
+        parent: unknown,
+        args: PothosSchemaTypes.DefaultConnectionArguments,
+        context: {},
+        info: GraphQLResolveInfo,
+      ) =>
+        Promise.resolve(
+          resolve({ ...q, ...connectionQuery } as never, parent, args, context, info),
+        ).then((result) => wrapConnectionResult(parent, result, args, q.take, formatCursor)));
 
     const fieldRef = (
       this as unknown as {
@@ -335,30 +362,22 @@ export class PrismaObjectFieldBuilder<
             );
           },
           pothosPrismaFallback:
-            resolve &&
+            resolveFallback &&
             ((
               q: { take: number },
               parent: unknown,
               args: PothosSchemaTypes.DefaultConnectionArguments,
               context: {},
               info: GraphQLResolveInfo,
-            ) =>
-              completeValue(getQuery(args, context), (connectionQuery) =>
-                Promise.resolve(
-                  resolve(
-                    {
-                      ...q,
-                      ...connectionQuery,
-                    } as never,
-                    parent,
-                    args,
-                    context,
-                    info,
-                  ),
-                ).then((result) =>
-                  wrapConnectionResult(parent, result, args, q.take, formatCursor),
-                ),
-              )),
+            ) => {
+              const connectionQuery = getQuery(args, context);
+
+              return isThenable(connectionQuery)
+                ? connectionQuery.then((resolved) =>
+                    resolveFallback(resolved as {}, q, parent, args, context, info),
+                  )
+                : resolveFallback(connectionQuery, q, parent, args, context, info);
+            }),
         },
         type: ref,
         resolve: (
@@ -368,17 +387,13 @@ export class PrismaObjectFieldBuilder<
           info: GraphQLResolveInfo,
         ) => {
           const { totalCountOnly } = connectionSelection(context, info);
+          const connectionQuery = getQuery(args, context);
 
-          return completeValue(getQuery(args, context), (connectionQuery) =>
-            wrapConnectionResult(
-              parent,
-              totalCountOnly ? [] : ((parent as Record<string, never>)[name] ?? []),
-              args,
-              connectionQuery.take,
-              formatCursor,
-              (parent as { _count?: Record<string, number> })._count?.[name],
-            ),
-          );
+          return isThenable(connectionQuery)
+            ? connectionQuery.then((resolved) =>
+                resolveLoaded(resolved as { take: number }, parent, args, totalCountOnly),
+              )
+            : resolveLoaded(connectionQuery, parent, args, totalCountOnly);
         },
       },
       connectionOptions instanceof ObjectRef
@@ -448,6 +463,11 @@ export class PrismaObjectFieldBuilder<
       nestedQuery: (query: unknown) => unknown,
     ) => completeValue(nestedQuery(query), selectRelation);
 
+    const resolveWithQuery =
+      resolve &&
+      ((userQuery: {}, q: {}, parent: Shape, args: {}, context: {}, info: GraphQLResolveInfo) =>
+        resolve({ ...q, ...userQuery } as never, parent, args as never, context, info));
+
     return this.field({
       ...(rest as {}),
       type: relationField.isList ? [ref] : ref,
@@ -458,11 +478,16 @@ export class PrismaObjectFieldBuilder<
         pothosPrismaSelect: relationSelect as never,
         pothosPrismaLoaded: (value: Record<string, unknown>) => value[name] !== undefined,
         pothosPrismaFallback:
-          resolve &&
-          ((q: {}, parent: Shape, args: {}, context: {}, info: GraphQLResolveInfo) =>
-            completeValue(typeof query === 'function' ? query(args, context) : query, (userQuery) =>
-              resolve({ ...q, ...userQuery } as never, parent, args as never, context, info),
-            )),
+          resolveWithQuery &&
+          ((q: {}, parent: Shape, args: {}, context: {}, info: GraphQLResolveInfo) => {
+            const userQuery = typeof query === 'function' ? query(args, context) : query;
+
+            return isThenable(userQuery)
+              ? userQuery.then((resolved) =>
+                  resolveWithQuery(resolved as {}, q, parent, args, context, info),
+                )
+              : resolveWithQuery(userQuery, q, parent, args, context, info);
+          }),
       },
       resolve: (parent, args, context, info) => {
         const result = (parent as Record<string, never>)[name];
@@ -660,6 +685,27 @@ export class PrismaObjectFieldBuilder<
       );
     };
   }
+}
+
+/** The field's `query` under the cursor arguments; its own `take`/`skip`/`cursor` win. */
+function mergeConnectionQuery<Q extends { take: number; skip: number; cursor?: unknown }>(
+  userQuery: Q | null | undefined,
+  connectionQuery: Q,
+): Q {
+  const {
+    take = connectionQuery.take,
+    skip = connectionQuery.skip,
+    cursor = connectionQuery.cursor,
+    ...fieldQuery
+  } = userQuery ?? ({} as Q);
+
+  return {
+    ...fieldQuery,
+    ...connectionQuery,
+    take,
+    skip,
+    ...(cursor ? { cursor } : {}),
+  } as Q;
 }
 
 function addScopes(

--- a/packages/plugin-prisma/src/schema-builder.ts
+++ b/packages/plugin-prisma/src/schema-builder.ts
@@ -2,6 +2,7 @@ import './global-types.js';
 import SchemaBuilder, {
   brandWithType,
   type InterfaceRef,
+  isThenable,
   type OutputType,
   type SchemaTypes,
 } from '@pothos/core';
@@ -140,33 +141,39 @@ schemaBuilderProto.prismaNode = function prismaNode(
 
   const ref = this.prismaObject(type, extendedOptions as never);
 
+  // Built once per node type: loading with a synchronous plan issues the query in the same tick,
+  // without a promise or closure of its own.
+  const loadNode = (query: object, id: string, context: SchemaTypes['Context']) => {
+    const delegate = getDelegateFromModel(getClient(this, context), type);
+    const where = rawFindUnique ? rawFindUnique(id, context) : { [fieldName]: idParser!(id) };
+
+    return (
+      delegate.findUniqueOrThrow && !nullable
+        ? delegate.findUniqueOrThrow({ ...query, where } as never)
+        : delegate.findUnique({
+            ...query,
+            ...(nullable ? {} : { rejectOnNotFound: true }),
+            where,
+          } as never)
+    ).then((record: unknown) => {
+      brandWithType(record, typeName as OutputType<SchemaTypes>);
+
+      return record;
+    });
+  };
+
   (this as typeof this & { nodeRef: (ref: unknown, options: unknown) => unknown }).nodeRef(ref, {
     id: {
       ...idOptions,
       resolve: (parent: never, _args: object, context: object) => resolve(parent, context),
     },
-    loadWithoutCache: async (
-      id: string,
-      context: SchemaTypes['Context'],
-      info: GraphQLResolveInfo,
-    ) => {
-      const query = await queryFromInfo({ context, info, typeName });
-      const delegate = getDelegateFromModel(getClient(this, context), type);
+    loadWithoutCache: (id: string, context: SchemaTypes['Context'], info: GraphQLResolveInfo) => {
+      // A promise while a select beneath the node is async (A-7); the query waits only then.
+      const query = queryFromInfo({ context, info, typeName });
 
-      const record = await (delegate.findUniqueOrThrow && !nullable
-        ? delegate.findUniqueOrThrow({
-            ...query,
-            where: rawFindUnique ? rawFindUnique(id, context) : { [fieldName]: idParser!(id) },
-          } as never)
-        : delegate.findUnique({
-            ...query,
-            ...(nullable ? {} : { rejectOnNotFound: true }),
-            where: rawFindUnique ? rawFindUnique(id, context) : { [fieldName]: idParser!(id) },
-          } as never));
-
-      brandWithType(record, typeName as OutputType<SchemaTypes>);
-
-      return record;
+      return isThenable(query)
+        ? query.then((settled) => loadNode(settled as object, id, context))
+        : loadNode(query, id, context);
     },
   });
 

--- a/packages/plugin-prisma/src/schema-builder.ts
+++ b/packages/plugin-prisma/src/schema-builder.ts
@@ -150,7 +150,7 @@ schemaBuilderProto.prismaNode = function prismaNode(
       context: SchemaTypes['Context'],
       info: GraphQLResolveInfo,
     ) => {
-      const query = queryFromInfo({ context, info, typeName });
+      const query = await queryFromInfo({ context, info, typeName });
       const delegate = getDelegateFromModel(getClient(this, context), type);
 
       const record = await (delegate.findUniqueOrThrow && !nullable

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -89,7 +89,7 @@ export type PrismaObjectFieldOptions<
           Types,
           ExtractModel<Types, ParentShape>,
           // biome-ignore lint/suspicious/noExplicitAny: this is fine
-          { select: Select extends (...args: any[]) => infer S ? S : Select }
+          { select: Select extends (...args: any[]) => infer S ? Awaited<S> : Select }
         >,
 > = PothosSchemaTypes.ObjectFieldOptions<Types, Shape, Type, Nullable, Args, ResolveReturnShape> &
   InferredFieldOptionsByKind<
@@ -101,6 +101,10 @@ export type PrismaObjectFieldOptions<
     Args,
     ResolveReturnShape
   > & {
+    /**
+     * What the field needs from its parent row. A function may be async; `nestedSelection` is
+     * then a promise when a selection beneath it is async, and must be awaited.
+     */
     select?: Select &
       (
         | ExtractModel<Types, ParentShape>['Select']
@@ -112,7 +116,7 @@ export type PrismaObjectFieldOptions<
               path?: string[],
               type?: string,
             ) => Selection,
-          ) => ExtractModel<Types, ParentShape>['Select'])
+          ) => MaybePromise<ExtractModel<Types, ParentShape>['Select']>)
       );
   };
 
@@ -373,7 +377,7 @@ type QueryForField<
       | ((
           args: InputShapeFromFields<Args>,
           ctx: Types['Context'],
-        ) => Omit<Include, 'include' | 'select'>)
+        ) => MaybePromise<Omit<Include, 'include' | 'select'>>)
   : never;
 
 type QueryFromRelation<
@@ -500,7 +504,9 @@ export type RelationCountOptions<
     context: Types['Context'],
     info: GraphQLResolveInfo,
   ) => MaybePromise<number>;
-  where?: Where | ((args: InputShapeFromFields<Args>, context: Types['Context']) => Where);
+  where?:
+    | Where
+    | ((args: InputShapeFromFields<Args>, context: Types['Context']) => MaybePromise<Where>);
 };
 
 export type PrismaFieldOptions<

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -778,18 +778,26 @@ export interface SelectionMap {
   where?: object;
 }
 
+/**
+ * A field's selection: a static map, or a function that may be async and whose nested-query
+ * callback may be too. What the function is handed (`mergeNestedSelection`) keeps its
+ * synchronous declared type: it is a promise only when a callback beneath it returned one.
+ */
 export type FieldSelection =
   | Record<string, SelectionMap | boolean>
   | ((
       args: object,
       context: object,
       mergeNestedSelection: (
-        selection: SelectionMap | boolean | ((args: object, context: object) => SelectionMap),
+        selection:
+          | SelectionMap
+          | boolean
+          | ((args: object, context: object) => MaybePromise<SelectionMap>),
         path?: IndirectInclude | string[],
         type?: string,
       ) => SelectionMap | boolean,
       resolveSelection: (path: string[]) => FieldNode | null,
-    ) => SelectionMap | false | null | undefined);
+    ) => MaybePromise<SelectionMap | false | null | undefined>);
 
 /**
  * @deprecated kept for compatibility. The loader mapping record is internal to the plugin and

--- a/packages/plugin-prisma/tests/async-selections.test.ts
+++ b/packages/plugin-prisma/tests/async-selections.test.ts
@@ -30,8 +30,8 @@ class AsyncArgsPlugin<Types extends SchemaTypes> extends BasePlugin<Types> {
 }
 
 declare global {
-  export namespace PothosSchemaTypes {
-    export interface Plugins<Types extends SchemaTypes> {
+  namespace PothosSchemaTypes {
+    interface Plugins<Types extends SchemaTypes> {
       asyncArgs: AsyncArgsPlugin<Types>;
     }
   }

--- a/packages/plugin-prisma/tests/async-selections.test.ts
+++ b/packages/plugin-prisma/tests/async-selections.test.ts
@@ -5,13 +5,9 @@ import SchemaBuilder, {
 } from '@pothos/core';
 import RelayPlugin from '@pothos/plugin-relay';
 import { execute } from '@pothos/test-utils';
-import type { DocumentNode } from 'graphql';
+import type { DocumentNode, GraphQLObjectType } from 'graphql';
 import { gql } from 'graphql-tag';
-import PrismaPlugin, {
-  type PrismaTypesFromClient,
-  prismaConnectionHelpers,
-  queryFromInfo,
-} from '../src';
+import PrismaPlugin, { type PrismaTypesFromClient, prismaConnectionHelpers } from '../src';
 import { prisma, queries } from './example/builder';
 import { getDatamodel } from './generated.js';
 import { countPromises } from './promise-spy';
@@ -41,7 +37,11 @@ SchemaBuilder.registerPlugin('asyncArgs', AsyncArgsPlugin);
 
 interface Context {
   user: { id: number };
+  /** A row already loaded with the planned selection, returned by `spiedUser` as is. */
+  row?: object;
+  /** Promise count and call count of the resolvers wrapped by `spyResolvers`. */
   promises?: number;
+  resolved?: number;
 }
 
 const builder = new SchemaBuilder<{
@@ -196,21 +196,42 @@ builder.queryType({
       type: User,
       resolve: () => prisma.user.findUniqueOrThrow({ where: { id: 1 } }),
     }),
-    // Plans the document under a Promise spy and reports the count on the context.
-    spiedUser: t.field({
+    // Returns a row the test loaded with the planned query, so the whole resolution (planning
+    // included) can run under the Promise spy without a database round trip.
+    spiedUser: t.prismaField({
       type: User,
-      resolve: (_root, _args, ctx, info) => {
-        const { result, promises } = countPromises(() => queryFromInfo({ context: ctx, info }));
-
-        ctx.promises = promises;
-
-        return prisma.user.findUniqueOrThrow({ ...result, where: { id: 1 } });
-      },
+      resolve: (_query, _root, _args, ctx) => ctx.row as never,
     }),
   }),
 });
 
 const schema = builder.toSchema();
+
+/** Wraps the built resolvers of `fields` so every call is counted under the Promise spy. */
+function spyResolvers(fields: [string, string][]) {
+  for (const [typeName, fieldName] of fields) {
+    const field = (schema.getType(typeName) as GraphQLObjectType).getFields()[fieldName];
+    const { resolve } = field;
+
+    field.resolve = (parent, args, ctx: Context, info) => {
+      const { result, promises } = countPromises(() => resolve!(parent, args, ctx, info));
+
+      ctx.promises = (ctx.promises ?? 0) + promises;
+      ctx.resolved = (ctx.resolved ?? 0) + 1;
+
+      return result;
+    };
+  }
+}
+
+spyResolvers([
+  ['Query', 'spiedUser'],
+  ['User', 'posts'],
+  ['User', 'publishedCount'],
+  ['User', 'postsConnection'],
+  ['User', 'commentsConnection'],
+  ['Post', 'comments'],
+]);
 
 async function run(document: DocumentNode) {
   const contextValue: Context = { user: { id: 1 } };
@@ -370,20 +391,36 @@ describe('async selections', () => {
     ]);
   });
 
-  it('creates no promise while planning a synchronous document (A-1)', async () => {
-    const { result, queries, context } = await run(gql`
-      {
-        spiedUser {
-          id
-          ... on User { posts(limit: 2) { id comments { id } } }
-          publishedCount
-          commentsConnection(first: 1) { edges { node { id } } }
-        }
-      }
-    `);
+  it('creates no promise while planning and resolving a synchronous document (A-1)', async () => {
+    const selection = /* GraphQL */ `{
+      id
+      ... on User { publishedCount }
+      postsConnection(first: 2) { edges { node { id comments { id } } } }
+      commentsConnection(first: 1) { edges { node { id } } }
+    }`;
+    // The row `spiedUser` hands back: loaded with the query the same document plans.
+    const planned = await run(gql`{ user ${selection} }`);
+
+    expect(planned.queries).toHaveLength(1);
+
+    const row = await prisma.user.findUniqueOrThrow(
+      (planned.queries[0] as { args: { where: { id: number } } }).args,
+    );
+    queries.length = 0;
+
+    const contextValue: Context = { user: { id: 1 }, row };
+    const result = await execute({
+      schema,
+      document: gql`{ spiedUser ${selection} }`,
+      contextValue,
+    });
 
     expect(result.errors).toBeUndefined();
-    expect(queries).toHaveLength(1);
-    expect(context.promises).toBe(0);
+    expect(result.data).toEqual({ spiedUser: (planned.result.data as { user: unknown }).user });
+    expect(queries).toHaveLength(0);
+    // The root field (planning + `prismaField` resolve), the loaded-path count and connection
+    // fields for the row, and the loaded-path relation `comments` for each of its two posts.
+    expect(contextValue.resolved).toBe(1 + 3 + 2);
+    expect(contextValue.promises).toBe(0);
   });
 });

--- a/packages/plugin-prisma/tests/async-selections.test.ts
+++ b/packages/plugin-prisma/tests/async-selections.test.ts
@@ -4,6 +4,7 @@ import SchemaBuilder, {
   type SchemaTypes,
 } from '@pothos/core';
 import RelayPlugin from '@pothos/plugin-relay';
+import { getLoaderMapping } from '@pothos/selection-mapper';
 import { execute } from '@pothos/test-utils';
 import type { DocumentNode, GraphQLObjectType } from 'graphql';
 import { gql } from 'graphql-tag';
@@ -56,6 +57,16 @@ const builder = new SchemaBuilder<{
 });
 
 const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 1));
+
+function pathOf(...keys: (string | number)[]) {
+  let path: { prev: unknown; key: string | number; typename: undefined } | undefined;
+
+  for (const key of keys) {
+    path = { prev: path, key, typename: undefined };
+  }
+
+  return path as never;
+}
 
 const Comment = builder.prismaObject('Comment', {
   fields: (t) => ({
@@ -145,6 +156,17 @@ const User = builder.prismaObject('User', {
       select: async (_args, _ctx, nestedSelection) => ({
         posts: nestedSelection({ take: 1, orderBy: { id: 'asc' as const } }),
       }),
+      resolve: (user) => user.posts,
+    }),
+    // Starts a nested selection and returns without it: its walk is async when a selection
+    // beneath the posts is, and would otherwise record mappings for data this never loads.
+    discardedPosts: t.field({
+      type: [Post],
+      select: async (_args, _ctx, nestedSelection) => {
+        nestedSelection({ take: 1, orderBy: { id: 'asc' as const } });
+
+        return { posts: { take: 1, orderBy: { id: 'asc' as const } } };
+      },
       resolve: (user) => user.posts,
     }),
     publishedCount: t.relationCount('posts', { where: { published: true } }),
@@ -350,6 +372,18 @@ describe('async selections', () => {
     expect(result.errors?.map((error) => error.message)).toEqual([
       'Relation "posts" was given a promise. Await nestedSelection() (or a helper built on it, such as getQuery) inside an async selection function.',
     ]);
+  });
+
+  it('rejects a nested selection that was discarded, recording no mapping for it', async () => {
+    const { result, queries, context } = await run(
+      gql`{ user { discardedPosts { id asyncComments { id } } } }`,
+    );
+
+    expect(queries).toHaveLength(0);
+    expect(result.errors?.map((error) => error.message)).toEqual([
+      'The selection function of User.discardedPosts returned while a nested selection it started was still pending. Await nestedSelection() (or a helper built on it, such as getQuery) inside an async selection function.',
+    ]);
+    expect(getLoaderMapping(context, pathOf('user', 'discardedPosts'), 'User')).toBe(null);
   });
 
   it('merges the sync sibling first when it conflicts with an async one (D-5)', async () => {

--- a/packages/plugin-prisma/tests/async-selections.test.ts
+++ b/packages/plugin-prisma/tests/async-selections.test.ts
@@ -1,0 +1,389 @@
+import SchemaBuilder, {
+  BasePlugin,
+  type PothosOutputFieldConfig,
+  type SchemaTypes,
+} from '@pothos/core';
+import RelayPlugin from '@pothos/plugin-relay';
+import { execute } from '@pothos/test-utils';
+import type { DocumentNode } from 'graphql';
+import { gql } from 'graphql-tag';
+import PrismaPlugin, {
+  type PrismaTypesFromClient,
+  prismaConnectionHelpers,
+  queryFromInfo,
+} from '../src';
+import { prisma, queries } from './example/builder';
+import { getDatamodel } from './generated.js';
+import { countPromises } from './promise-spy';
+
+// A plugin that maps a field's arguments asynchronously, as the validation plugin does.
+class AsyncArgsPlugin<Types extends SchemaTypes> extends BasePlugin<Types> {
+  override onOutputFieldConfig(fieldConfig: PothosOutputFieldConfig<Types>) {
+    const mapArgs = fieldConfig.extensions?.mapArgsAsync as
+      | ((args: Record<string, unknown>) => Promise<Record<string, unknown>>)
+      | undefined;
+
+    return mapArgs
+      ? { ...fieldConfig, argMappers: [...fieldConfig.argMappers, mapArgs] }
+      : fieldConfig;
+  }
+}
+
+declare global {
+  export namespace PothosSchemaTypes {
+    export interface Plugins<Types extends SchemaTypes> {
+      asyncArgs: AsyncArgsPlugin<Types>;
+    }
+  }
+}
+
+SchemaBuilder.registerPlugin('asyncArgs', AsyncArgsPlugin);
+
+interface Context {
+  user: { id: number };
+  promises?: number;
+}
+
+const builder = new SchemaBuilder<{
+  PrismaTypes: PrismaTypesFromClient<typeof prisma>;
+  Context: Context;
+}>({
+  plugins: [PrismaPlugin, RelayPlugin, 'asyncArgs'],
+  prisma: {
+    client: () => prisma,
+    dmmf: getDatamodel(),
+  },
+});
+
+const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 1));
+
+const Comment = builder.prismaObject('Comment', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+
+const Post = builder.prismaObject('Post', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    comments: t.relation('comments', { query: { take: 1, orderBy: { id: 'asc' } } }),
+    asyncComments: t.relation('comments', {
+      query: async () => {
+        await tick();
+
+        return { take: 1, orderBy: { id: 'asc' } };
+      },
+    }),
+  }),
+});
+
+const postsQuery = (args: { limit?: number | null }) => ({
+  take: args.limit ?? 2,
+  orderBy: { id: 'asc' as const },
+});
+
+const commentHelpers = prismaConnectionHelpers(builder, 'Comment', {
+  cursor: 'id',
+  query: () => ({ orderBy: { id: 'asc' as const } }),
+});
+
+const asyncCommentHelpers = prismaConnectionHelpers(builder, 'Comment', {
+  cursor: 'id',
+  query: async () => {
+    await tick();
+
+    return { orderBy: { id: 'asc' as const } };
+  },
+});
+
+// Every async field has a sync twin that plans the same query.
+const User = builder.prismaObject('User', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    posts: t.relation('posts', { args: { limit: t.arg.int() }, query: postsQuery }),
+    asyncPosts: t.relation('posts', {
+      args: { limit: t.arg.int() },
+      query: async (args) => {
+        await tick();
+
+        return postsQuery(args);
+      },
+    }),
+    mappedPosts: t.relation('posts', {
+      args: { limit: t.arg.int() },
+      extensions: {
+        mapArgsAsync: async (args: { limit?: number | null }) => {
+          await tick();
+
+          return { limit: (args.limit ?? 1) * 2 };
+        },
+      },
+      query: postsQuery,
+    }),
+    titles: t.stringList({
+      select: { posts: { select: { title: true }, take: 2, orderBy: { id: 'asc' } } },
+      resolve: (user) => user.posts.map((post) => post.title),
+    }),
+    asyncTitles: t.stringList({
+      select: async () => {
+        await tick();
+
+        return { posts: { select: { title: true }, take: 2, orderBy: { id: 'asc' as const } } };
+      },
+      resolve: (user) => user.posts.map((post) => post.title),
+    }),
+    latestPosts: t.field({
+      type: [Post],
+      select: async (_args, _ctx, nestedSelection) => ({
+        posts: await nestedSelection({ take: 1, orderBy: { id: 'asc' as const } }),
+      }),
+      resolve: (user) => user.posts,
+    }),
+    // Forgets to await: a promise when a selection beneath the posts is async.
+    unawaitedPosts: t.field({
+      type: [Post],
+      select: async (_args, _ctx, nestedSelection) => ({
+        posts: nestedSelection({ take: 1, orderBy: { id: 'asc' as const } }),
+      }),
+      resolve: (user) => user.posts,
+    }),
+    publishedCount: t.relationCount('posts', { where: { published: true } }),
+    asyncPublishedCount: t.relationCount('posts', {
+      where: async () => {
+        await tick();
+
+        return { published: true };
+      },
+    }),
+    postsConnection: t.relatedConnection('posts', {
+      cursor: 'id',
+      query: () => ({ orderBy: { id: 'asc' } }),
+    }),
+    asyncPostsConnection: t.relatedConnection('posts', {
+      cursor: 'id',
+      query: async () => {
+        await tick();
+
+        return { orderBy: { id: 'asc' } };
+      },
+    }),
+    commentsConnection: t.connection({
+      type: Comment,
+      select: (args, ctx, nestedSelection) => ({
+        comments: commentHelpers.getQuery(args, ctx, nestedSelection),
+      }),
+      resolve: (user, args, ctx) => commentHelpers.resolve(user.comments, args, ctx),
+    }),
+    asyncCommentsConnection: t.connection({
+      type: Comment,
+      select: async (args, ctx, nestedSelection) => ({
+        comments: await asyncCommentHelpers.getQuery(args, ctx, nestedSelection),
+      }),
+      resolve: (user, args, ctx) => asyncCommentHelpers.resolve(user.comments, args, ctx),
+    }),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    user: t.prismaField({
+      type: User,
+      resolve: (query) => prisma.user.findUniqueOrThrow({ ...query, where: { id: 1 } }),
+    }),
+    // A row fetched without the planned selection: every field with a `select` loads its own
+    // data through the model loader.
+    rawUser: t.field({
+      type: User,
+      resolve: () => prisma.user.findUniqueOrThrow({ where: { id: 1 } }),
+    }),
+    // Plans the document under a Promise spy and reports the count on the context.
+    spiedUser: t.field({
+      type: User,
+      resolve: (_root, _args, ctx, info) => {
+        const { result, promises } = countPromises(() => queryFromInfo({ context: ctx, info }));
+
+        ctx.promises = promises;
+
+        return prisma.user.findUniqueOrThrow({ ...result, where: { id: 1 } });
+      },
+    }),
+  }),
+});
+
+const schema = builder.toSchema();
+
+async function run(document: DocumentNode) {
+  const contextValue: Context = { user: { id: 1 } };
+  const result = await execute({ schema, document, contextValue });
+  const issued = [...queries];
+
+  queries.length = 0;
+
+  return { result, queries: issued, context: contextValue };
+}
+
+/** Runs the sync and async twins of one selection and expects the same query and data. */
+async function sameAsSync(sync: DocumentNode, async: DocumentNode) {
+  const expected = await run(sync);
+  const actual = await run(async);
+
+  expect(expected.result.errors).toBeUndefined();
+  expect(actual.result.errors).toBeUndefined();
+  expect(expected.queries).toHaveLength(1);
+  expect(actual.queries).toEqual(expected.queries);
+  expect(actual.result.data).toEqual(expected.result.data);
+
+  return actual;
+}
+
+describe('async selections', () => {
+  afterEach(() => {
+    queries.length = 0;
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('plans an async field select like the sync one', async () => {
+    const { queries } = await sameAsSync(
+      gql`{ user { titles } }`,
+      gql`{ user { titles: asyncTitles } }`,
+    );
+
+    expect(queries[0]).toMatchObject({
+      args: { include: { posts: { select: { title: true }, take: 2 } } },
+    });
+  });
+
+  it('plans an async relation query like the sync one', async () => {
+    const { queries } = await sameAsSync(
+      gql`{ user { posts(limit: 3) { id comments { id } } } }`,
+      gql`{ user { posts: asyncPosts(limit: 3) { id comments: asyncComments { id } } } }`,
+    );
+
+    expect(queries[0]).toMatchObject({
+      args: { include: { posts: { take: 3, include: { comments: { take: 1 } } } } },
+    });
+  });
+
+  it('runs the select once its async arguments are mapped', async () => {
+    const { queries } = await sameAsSync(
+      gql`{ user { posts(limit: 4) { id } } }`,
+      gql`{ user { posts: mappedPosts(limit: 2) { id } } }`,
+    );
+
+    expect(queries[0]).toMatchObject({ args: { include: { posts: { take: 4 } } } });
+  });
+
+  it('plans an async relation count like the sync one', async () => {
+    const { queries } = await sameAsSync(
+      gql`{ user { publishedCount } }`,
+      gql`{ user { publishedCount: asyncPublishedCount } }`,
+    );
+
+    expect(queries[0]).toMatchObject({
+      args: { include: { _count: { select: { posts: { where: { published: true } } } } } },
+    });
+  });
+
+  it('plans an async connection query like the sync one', async () => {
+    const { queries } = await sameAsSync(
+      gql`{ user { postsConnection(first: 2) { edges { node { id comments { id } } } } } }`,
+      gql`{ user { postsConnection: asyncPostsConnection(first: 2) { edges { node { id comments: asyncComments { id } } } } } }`,
+    );
+
+    expect(queries[0]).toMatchObject({
+      args: { include: { posts: { take: 3, include: { comments: { take: 1 } } } } },
+    });
+  });
+
+  it('plans async connection helpers like the sync ones when the select awaits getQuery', async () => {
+    const { queries } = await sameAsSync(
+      gql`{ user { commentsConnection(first: 2) { edges { node { id } } } } }`,
+      gql`{ user { commentsConnection: asyncCommentsConnection(first: 2) { edges { node { id } } } } }`,
+    );
+
+    expect(queries[0]).toMatchObject({
+      args: { include: { comments: { take: 3, orderBy: { id: 'asc' } } } },
+    });
+  });
+
+  it('merges an awaited nested selection whose walk is async', async () => {
+    const { queries } = await sameAsSync(
+      gql`{ user { latestPosts { id comments { id } } } }`,
+      gql`{ user { latestPosts { id comments: asyncComments { id } } } }`,
+    );
+
+    expect(queries[0]).toMatchObject({
+      args: { include: { posts: { take: 1, include: { comments: { take: 1 } } } } },
+    });
+  });
+
+  it('rejects a nested selection that was not awaited', async () => {
+    const { result, queries } = await run(
+      gql`{ user { unawaitedPosts { id asyncComments { id } } } }`,
+    );
+
+    expect(queries).toHaveLength(0);
+    expect(result.errors?.map((error) => error.message)).toEqual([
+      'Relation "posts" was given a promise. Await nestedSelection() (or a helper built on it, such as getQuery) inside an async selection function.',
+    ]);
+  });
+
+  it('merges the sync sibling first when it conflicts with an async one (D-5)', async () => {
+    for (const document of [
+      gql`{ user { posts(limit: 1) { id } asyncPosts(limit: 2) { id } } }`,
+      gql`{ user { asyncPosts(limit: 2) { id } posts(limit: 1) { id } } }`,
+    ]) {
+      const { result, queries } = await run(document);
+
+      expect(result.errors).toBeUndefined();
+      expect(queries).toHaveLength(2);
+      expect(queries[0]).toMatchObject({ args: { include: { posts: { take: 1 } } } });
+      // The async sibling lost the conflict and loads on its own.
+      expect(queries[1]).toMatchObject({
+        action: 'findUniqueOrThrow',
+        args: { include: { posts: { take: 2 } }, where: { id: 1 } },
+      });
+    }
+  });
+
+  it('loads a field with an async select through the model loader in one query', async () => {
+    const planned = await run(gql`{ user { asyncTitles } }`);
+    const { result, queries } = await run(gql`{ rawUser { asyncTitles } }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      rawUser: (planned.result.data as { user: unknown }).user,
+    });
+    expect(queries).toEqual([
+      { action: 'findUniqueOrThrow', model: 'User', args: { where: { id: 1 } } },
+      {
+        action: 'findUniqueOrThrow',
+        model: 'User',
+        args: {
+          include: { posts: { select: { title: true }, take: 2, orderBy: { id: 'asc' } } },
+          where: { id: 1 },
+        },
+      },
+    ]);
+  });
+
+  it('creates no promise while planning a synchronous document (A-1)', async () => {
+    const { result, queries, context } = await run(gql`
+      {
+        spiedUser {
+          id
+          ... on User { posts(limit: 2) { id comments { id } } }
+          publishedCount
+          commentsConnection(first: 1) { edges { node { id } } }
+        }
+      }
+    `);
+
+    expect(result.errors).toBeUndefined();
+    expect(queries).toHaveLength(1);
+    expect(context.promises).toBe(0);
+  });
+});

--- a/packages/plugin-prisma/tests/async-selections.test.ts
+++ b/packages/plugin-prisma/tests/async-selections.test.ts
@@ -8,7 +8,9 @@ import { getLoaderMapping } from '@pothos/selection-mapper';
 import { execute } from '@pothos/test-utils';
 import type { DocumentNode, GraphQLObjectType } from 'graphql';
 import { gql } from 'graphql-tag';
+import { vi } from 'vitest';
 import PrismaPlugin, { type PrismaTypesFromClient, prismaConnectionHelpers } from '../src';
+import { ModelLoader } from '../src/model-loader';
 import { prisma, queries } from './example/builder';
 import { getDatamodel } from './generated.js';
 import { countPromises } from './promise-spy';
@@ -206,6 +208,15 @@ const User = builder.prismaObject('User', {
   }),
 });
 
+// Loaded by id through `loadWithoutCache`, with the selection beneath the node field.
+builder.prismaNode('Profile', {
+  id: { field: 'id' },
+  fields: (t) => ({
+    bio: t.exposeString('bio', { nullable: true }),
+    user: t.relation('user'),
+  }),
+});
+
 builder.queryType({
   fields: (t) => ({
     user: t.prismaField({
@@ -217,6 +228,10 @@ builder.queryType({
     rawUser: t.field({
       type: User,
       resolve: () => prisma.user.findUniqueOrThrow({ where: { id: 1 } }),
+    }),
+    rawUsers: t.field({
+      type: [User],
+      resolve: () => prisma.user.findMany({ take: 3, orderBy: { id: 'asc' } }),
     }),
     // Returns a row the test loaded with the planned query, so the whole resolution (planning
     // included) can run under the Promise spy without a database round trip.
@@ -282,6 +297,8 @@ async function sameAsSync(sync: DocumentNode, async: DocumentNode) {
 describe('async selections', () => {
   afterEach(() => {
     queries.length = 0;
+    // A spied method chains onto the promise it returns, which the Promise spy would count.
+    vi.restoreAllMocks();
   });
 
   afterAll(async () => {
@@ -423,6 +440,99 @@ describe('async selections', () => {
         },
       },
     ]);
+  });
+
+  it('loads every parent of a list through one staged batch', async () => {
+    const initLoad = vi.spyOn(ModelLoader.prototype, 'initLoad');
+    const { result, queries } = await run(gql`{ rawUsers { posts(limit: 1) { id } } }`);
+
+    expect(result.errors).toBeUndefined();
+    expect((result.data as { rawUsers: unknown[] }).rawUsers).toHaveLength(3);
+    // One batch: every row's synchronous selection staged in the tick the rows resolved in.
+    expect(initLoad).toHaveBeenCalledTimes(1);
+    expect(queries.map((query) => (query as { action: string }).action)).toEqual([
+      'findMany',
+      'findUniqueOrThrow',
+      'findUniqueOrThrow',
+      'findUniqueOrThrow',
+    ]);
+    expect(
+      new Set(
+        queries
+          .slice(1)
+          .map((query) => JSON.stringify((query as { args: { include: unknown } }).args.include)),
+      ).size,
+    ).toBe(1);
+  });
+
+  it('stages an unloaded row synchronously, creating only the loader batch promises', async () => {
+    const contextValue: Context = { user: { id: 1 } };
+    const result = await execute({
+      schema,
+      document: gql`{
+        rawUser {
+          posts(limit: 2) { id }
+          publishedCount
+          commentsConnection(first: 1) { edges { node { id } } }
+        }
+      }`,
+      contextValue,
+    });
+
+    expect(result.errors).toBeUndefined();
+    // The raw row, then the one batch the relation, the count and the connection staged into.
+    expect(queries.map((query) => (query as { action: string }).action)).toEqual([
+      'findUniqueOrThrow',
+      'findUniqueOrThrow',
+    ]);
+    expect(contextValue.resolved).toBe(3);
+    // Exactly the loader's own promises, all created before each resolver returned (planning a
+    // synchronous selection creates none): the first field creates the loader (its `tick`) and
+    // the batch (the row's promise, the next tick's promise, and the `tick.then` that issues the
+    // batch), and every field chains the mapping step and its resolver onto the row's promise.
+    expect(contextValue.promises).toBe(1 + 3 + 2 * 3);
+    queries.length = 0;
+  });
+
+  it('issues a node load synchronously, creating no promise beyond the query itself', async () => {
+    const config = builder.configStore.getTypeConfig('Profile', 'Object');
+    const options = config.pothosOptions as {
+      loadWithoutCache: (id: string, context: Context, info: unknown) => unknown;
+    };
+    const { loadWithoutCache } = options;
+    let promises = -1;
+
+    options.loadWithoutCache = (id, context, info) => {
+      const counted = countPromises(() => loadWithoutCache(id, context, info));
+
+      promises = counted.promises;
+
+      return counted.result;
+    };
+
+    try {
+      const { result, queries: issuedQueries } = await run(
+        gql`{ node(id: "UHJvZmlsZTox") { ... on Profile { bio user { id } } } }`,
+      );
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data).toEqual({ node: { bio: expect.any(String), user: { id: '1' } } });
+      expect(issuedQueries).toMatchObject([
+        { action: 'findUniqueOrThrow', model: 'Profile', args: { include: { user: true } } },
+      ]);
+      // The query was issued, and its result chained, before loadWithoutCache returned: the
+      // synchronous window holds exactly the promises issuing the query itself creates, and
+      // planning added none.
+      const baseline = countPromises(() =>
+        prisma.profile.findUniqueOrThrow({ where: { id: 1 } }).then((record) => record),
+      );
+
+      await baseline.result;
+      expect(baseline.promises).toBeGreaterThan(0);
+      expect(promises).toBe(baseline.promises);
+    } finally {
+      options.loadWithoutCache = loadWithoutCache;
+    }
   });
 
   it('creates no promise while planning and resolving a synchronous document (A-1)', async () => {

--- a/packages/plugin-prisma/tests/async-types.test-d.ts
+++ b/packages/plugin-prisma/tests/async-types.test-d.ts
@@ -1,0 +1,95 @@
+import SchemaBuilder from '@pothos/core';
+import RelayPlugin from '@pothos/plugin-relay';
+import { expectTypeOf, it } from 'vitest';
+import PrismaPlugin, {
+  type PrismaTypesFromClient,
+  prismaConnectionHelpers,
+  queryFromInfo,
+} from '../src';
+import type { prisma } from './example/builder';
+import { getDatamodel } from './generated.js';
+
+// The async model widens INPUTS only (A-7): a relation `query`, a count `where`, a field `select`
+// and the connection helpers' callbacks may return promises, while what a resolver is handed
+// (`queryFromInfo`, `nestedSelection`, `getQuery`) keeps its synchronous declared type and is
+// awaited by the schema that opted in.
+const builder = new SchemaBuilder<{
+  PrismaTypes: PrismaTypesFromClient<typeof prisma>;
+  Context: { tenantId: () => Promise<number> };
+}>({
+  plugins: [PrismaPlugin, RelayPlugin],
+  prisma: {
+    client: () => null as never,
+    dmmf: getDatamodel(),
+  },
+});
+
+const commentHelpers = prismaConnectionHelpers(builder, 'Comment', {
+  cursor: 'id',
+  select: async (nodeSelection) => ({ id: true, post: nodeSelection({}) }),
+  query: async (_args, ctx) => ({ where: { authorId: await ctx.tenantId() } }),
+  resolveNode: (comment) => comment.post,
+});
+
+builder.prismaObject('Comment', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+
+const Post = builder.prismaObject('Post', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+
+const User = builder.prismaObject('User', {
+  select: { id: true },
+  fields: (t) => ({
+    posts: t.relation('posts', {
+      query: async (_args, ctx) => ({ where: { authorId: await ctx.tenantId() } }),
+    }),
+    postCount: t.relationCount('posts', {
+      where: async (_args, ctx) => ({ authorId: await ctx.tenantId() }),
+    }),
+    postsConnection: t.relatedConnection('posts', {
+      cursor: 'id',
+      query: async (_args, ctx) => ({ where: { authorId: await ctx.tenantId() } }),
+    }),
+    // The parent shape follows the awaited selection.
+    titles: t.stringList({
+      select: async (_args, _ctx, nestedSelection) => ({
+        posts: await nestedSelection({ select: { title: true } }),
+      }),
+      resolve: (user) => {
+        expectTypeOf(user.posts[0].title).toEqualTypeOf<string>();
+
+        return user.posts.map((post) => post.title);
+      },
+    }),
+    comments: t.connection({
+      type: Post,
+      select: async (args, ctx, nestedSelection) => ({
+        comments: await commentHelpers.getQuery(args, ctx, nestedSelection),
+      }),
+      resolve: (user, args, ctx) => commentHelpers.resolve(user.comments, args, ctx),
+    }),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    user: t.prismaField({
+      type: User,
+      resolve: (query) => {
+        expectTypeOf(query).not.toMatchTypeOf<PromiseLike<unknown>>();
+
+        return null as never;
+      },
+    }),
+  }),
+});
+
+it('keeps the declared return of queryFromInfo synchronous', () => {
+  expectTypeOf(queryFromInfo).returns.not.toMatchTypeOf<PromiseLike<unknown>>();
+});

--- a/packages/plugin-prisma/tests/promise-spy.ts
+++ b/packages/plugin-prisma/tests/promise-spy.ts
@@ -1,0 +1,32 @@
+/**
+ * Runs `fn` while every way of creating a promise is counted: construction (`new Promise`, and
+ * the statics `resolve`/`all`/... which construct through `this`) and `.then` (which derives one).
+ * `fn` must be synchronous: the spies are removed before it returns.
+ */
+export function countPromises<T>(fn: () => T): { result: T; promises: number } {
+  const NativePromise = Promise;
+  const { then } = NativePromise.prototype;
+  let promises = 0;
+
+  globalThis.Promise = new Proxy(NativePromise, {
+    construct(target, args, newTarget) {
+      promises += 1;
+
+      return Reflect.construct(target, args, newTarget);
+    },
+  });
+  // biome-ignore lint/suspicious/noThenProperty: the spy counts derived promises
+  NativePromise.prototype.then = function counted(this: Promise<unknown>, ...args: unknown[]) {
+    promises += 1;
+
+    return then.apply(this, args as never) as never;
+  } as typeof then;
+
+  try {
+    return { result: fn(), promises };
+  } finally {
+    globalThis.Promise = NativePromise;
+    // biome-ignore lint/suspicious/noThenProperty: restores the native method
+    NativePromise.prototype.then = then;
+  }
+}

--- a/packages/selection-mapper/src/index.ts
+++ b/packages/selection-mapper/src/index.ts
@@ -27,6 +27,7 @@ export {
   type Env,
   type NestedSelection,
   queryFromInfo,
+  queryFromWalk,
   type SelectFn,
   selectionStateFromInfo,
   type TypeLevelConflict,

--- a/packages/selection-mapper/src/walk.ts
+++ b/packages/selection-mapper/src/walk.ts
@@ -1,4 +1,9 @@
-import { getMappedArgumentValues, PothosValidationError } from '@pothos/core';
+import {
+  getMappedArgumentValues,
+  isThenable,
+  type MaybePromise,
+  PothosValidationError,
+} from '@pothos/core';
 import {
   type FieldNode,
   type FragmentDefinitionNode,
@@ -32,14 +37,20 @@ import { wrapWithUsageCheck } from './usage.js';
 
 type WalkedType = GraphQLInterfaceType | GraphQLObjectType;
 
+/** A relation query: a map, or a callback building one from the field's arguments. */
+export type NestedQuery<Map, X = undefined> =
+  | MaybePromise<Map | null | undefined>
+  | ((args: object, ctx: object, extra: X) => MaybePromise<Map | null | undefined>);
+
 /**
  * The callback handed to a field's select function to plan the selection beneath the field:
  * `query` is merged first (a function is called with the field's args, `true` means no query),
  * then the selection found under `path` (an explicit include, or a string path from the field's
- * return type) is walked as `type` (or the field's return type).
+ * return type) is walked as `type` (or the field's return type). Declared synchronous (A-7): the
+ * result is a promise only when a callback beneath it returned one, and must then be awaited.
  */
 export type NestedSelection<Map, X = undefined> = (
-  query?: Map | true | ((args: object, ctx: object, extra: X) => Map | null | undefined),
+  query?: NestedQuery<Map, X> | true,
   path?: string[] | IndirectInclude,
   type?: string,
 ) => Map;
@@ -51,7 +62,7 @@ export type SelectFn<Map, X = undefined> = (
   nested: NestedSelection<Map, X>,
   getSelectedNode: (path: string[]) => FieldNode | null,
   extra: X,
-) => Map | false | null | undefined;
+) => MaybePromise<Map | false | null | undefined>;
 
 export interface EntryOptions<Map> {
   context: object;
@@ -153,12 +164,20 @@ export interface Walk<M, Map, X = undefined> {
   mappings: Mappings;
   /** D-7: the extra of the field this walk hangs beneath. */
   extra?: X;
+  /**
+   * The merges waiting on a user callback that returned a promise, in the order they were
+   * appended (A-2, A-4). Absent until the first one: a synchronous walk never creates a promise.
+   */
+  pending?: Promise<void>;
 }
 
 /** The mapping of a static selection: nothing can ever be recorded beneath one. */
 const NONE: Mapping = Object.freeze({ nested: Object.freeze({}) as Mappings });
 
-/** E-1: the query for the field `info` resolves, with its loader mappings recorded (L-2). */
+/**
+ * E-1: the query for the field `info` resolves, with its loader mappings recorded (L-2).
+ * Declared synchronous (A-7): a promise is returned only when a callback returned one.
+ */
 export function queryFromInfo<M, Map extends object, X = undefined>(
   adapter: Adapter<M, Map, X>,
   options: EntryOptions<Map>,
@@ -204,13 +223,19 @@ export function selectionStateFromInfo<M, Map extends object, X = undefined>(
     applyField(walk, walk.root, type, fieldNode, []);
   }
 
+  return finish(walk, enterLoaded, type);
+}
+
+/** E-2: the parent type's selection, minus what conflicts with the field, once it is merged. */
+function enterLoaded<M, Map, X>(walk: Walk<M, Map, X>, type: GraphQLNamedType) {
+  const { adapter } = walk.env;
   const selection = adapter.typeSelection(type);
 
   if (selection) {
     adapter.merge(walk.root, adapter.withoutConflicts(walk.root, selection));
   }
 
-  return finish(walk, identity);
+  return walk;
 }
 
 /**
@@ -244,13 +269,31 @@ export function defaultFragmentType<M>(
   return undefined;
 }
 
-/** The single exit of every entry point: the async seam, where awaiting the walk will land. */
+/**
+ * A-2: appends the merge of `value` to the walk's pending chain. Only merges are chained, never
+ * user code, so a link can never append another and the chain needs no loop. Each link waits on
+ * the previous one, so async merges run in the order they were appended (A-4). Both promises get
+ * a handler at once, so a callback that rejects early is never an unhandled rejection.
+ */
+function chain<M, Map, X, T>(walk: Walk<M, Map, X>, value: PromiseLike<T>, merge: (v: T) => void) {
+  const prev = walk.pending;
+
+  walk.pending = prev
+    ? Promise.all([prev, value]).then(([, v]) => merge(v))
+    : Promise.resolve(value).then(merge);
+}
+
+/**
+ * The single exit of every entry point (A-3): `done` runs now when nothing is pending, else
+ * after every pending merge. The result is then a promise behind the declared synchronous type
+ * (A-7): a schema without async callbacks never sees one, and one with them must await it.
+ */
 function finish<M, Map, X, A extends unknown[], R>(
   walk: Walk<M, Map, X>,
   done: (walk: Walk<M, Map, X>, ...args: A) => R,
   ...args: A
 ): R {
-  return done(walk, ...args);
+  return walk.pending ? (walk.pending.then(() => done(walk, ...args)) as R) : done(walk, ...args);
 }
 
 function identity<M, Map, X>(walk: Walk<M, Map, X>) {
@@ -747,17 +790,39 @@ function applyField<M, Map, X>(
   // stays invisible to the walk until the invocation's map is accepted.
   const extra = adapter.callbackExtra?.(walk.extra, type, field, fieldNode);
   const mapping: Mapping = { nested: {}, extra };
-  const args = getMappedArgumentValues(field, fieldNode, context, info) as Record<string, unknown>;
+  const args = getMappedArgumentValues(field, fieldNode, context, info);
+  const select = selection as SelectFn<Map, X>;
 
-  const map = (selection as SelectFn<Map, X>)(
+  // S-6: the select runs as soon as its own arguments are known; only its merge waits (A-3).
+  const map = isThenable(args)
+    ? args.then((mapped) => runSelect(walk, field, fieldNode, select, mapped, extra, mapping))
+    : runSelect(walk, field, fieldNode, select, args, extra, mapping);
+
+  if (isThenable(map)) {
+    chain(walk, map as PromiseLike<Map | false | null | undefined>, (resolved) =>
+      mergeField(walk, node, key, resolved, mapping),
+    );
+  } else {
+    mergeField(walk, node, key, map, mapping);
+  }
+}
+
+function runSelect<M, Map, X>(
+  walk: Walk<M, Map, X>,
+  field: GraphQLField<unknown, unknown>,
+  fieldNode: FieldNode,
+  select: SelectFn<Map, X>,
+  args: object,
+  extra: X | undefined,
+  mapping: Mapping,
+) {
+  return select(
     args,
-    context,
+    walk.env.context,
     nestedSelectionFor(walk, field, fieldNode, args, extra, mapping),
     getNodeFor(walk, field, fieldNode),
     extra as X,
   );
-
-  mergeField(walk, node, key, map, mapping);
 }
 
 /**
@@ -801,7 +866,7 @@ function nestedSelectionFor<M, Map, X>(
   mapping: Mapping,
 ): NestedSelection<Map, X> {
   const { env } = walk;
-  const { info, adapter } = env;
+  const { info } = env;
 
   return (rawQuery, pathOrInclude, typeName) => {
     const returnType = getNamedType(field.type);
@@ -815,19 +880,25 @@ function nestedSelectionFor<M, Map, X>(
     const target = include ? info.schema.getType(include.getType())! : returnType;
     const child = createWalk(env, target, mapping.nested, extra);
     // `true` is the public "no query"; it never reaches an adapter.
-    const query =
+    const query: MaybePromise<Map | null | undefined> =
       rawQuery === true
         ? undefined
         : typeof rawQuery === 'function'
-          ? (rawQuery as (args: object, ctx: object, extra: X) => Map | null | undefined)(
-              args,
-              env.context,
-              extra as X,
-            )
+          ? (
+              rawQuery as (
+                args: object,
+                ctx: object,
+                extra: X,
+              ) => MaybePromise<Map | null | undefined>
+            )(args, env.context, extra as X)
           : rawQuery;
 
-    if (query && hasKeys(query)) {
-      adapter.merge(child.root, { ...adapter.empty, ...query });
+    if (isThenable(query)) {
+      chain(child, query as PromiseLike<Map | null | undefined>, (resolved) =>
+        mergeQuery(child, resolved),
+      );
+    } else {
+      mergeQuery(child, query);
     }
 
     const paths = include?.paths?.length
@@ -872,6 +943,13 @@ function nestedSelectionFor<M, Map, X>(
 
     return finish(child, serializeRoot);
   };
+}
+
+/** E-3: a relation query merges over `empty`, so a query without columns adds none. */
+function mergeQuery<M, Map, X>(child: Walk<M, Map, X>, query: Map | null | undefined) {
+  if (query && hasKeys(query)) {
+    child.env.adapter.merge(child.root, { ...child.env.adapter.empty, ...query });
+  }
 }
 
 /**

--- a/packages/selection-mapper/src/walk.ts
+++ b/packages/selection-mapper/src/walk.ts
@@ -193,12 +193,48 @@ export function queryFromInfo<M, Map extends object, X = undefined>(
   return finish(walk, emitQuery, options.withUsageCheck);
 }
 
-/** E-1 without paths: the walk itself, nothing recorded. Always produces a walk. */
+/**
+ * E-1 without emitting: the walk itself, nothing recorded, or undefined when paths are given and
+ * nothing is selected under them. Declared synchronous like `queryFromInfo` (A-7). A plugin that
+ * must hand a resolver a synchronous query builder settles this first, then emits the query with
+ * `queryFromWalk` once the resolver asks for it.
+ */
 export function walkFromInfo<M, Map extends object, X = undefined>(
   adapter: Adapter<M, Map, X>,
   options: EntryOptions<Map>,
-): Walk<M, Map, X> {
-  return finish(buildWalk(makeEnv(adapter, options), options)!, identity);
+): Walk<M, Map, X> | undefined {
+  const walk = buildWalk(makeEnv(adapter, options), options);
+
+  return walk && finish(walk, identity);
+}
+
+/**
+ * E-1 from a settled walk: the loader mappings recorded (L-2) and the query serialized (M-6,
+ * L-5). Synchronous: the walk must be one `walkFromInfo` returned, and when that was a promise,
+ * the walk it resolved to. `select` takes the place of `initial`: the query is built from it first
+ * and the walked plan merged over it, so a compatible `select` yields what `queryFromInfo` yields
+ * with it as `initial`. The caller checks compatibility (`typeLevelConflict`) first: a relation or
+ * extra the plan already holds with other arguments cannot be merged after the fact.
+ */
+export function queryFromWalk<M, Map extends object, X = undefined>(
+  walk: Walk<M, Map, X>,
+  select?: Map,
+  withUsageCheck?: boolean,
+): Map {
+  const { adapter, context, info } = walk.env;
+
+  setLoaderMappings(context, info, walk.mappings);
+
+  if (!select) {
+    return wrap(adapter.serialize(walk.root), withUsageCheck);
+  }
+
+  const root = createNode(walk.root.model);
+
+  adapter.merge(root, select);
+  adapter.merge(root, adapter.serialize(walk.root));
+
+  return wrap(adapter.serialize(root), withUsageCheck);
 }
 
 /**

--- a/packages/selection-mapper/src/walk.ts
+++ b/packages/selection-mapper/src/walk.ts
@@ -287,13 +287,20 @@ function chain<M, Map, X, T>(walk: Walk<M, Map, X>, value: PromiseLike<T>, merge
  * The single exit of every entry point (A-3): `done` runs now when nothing is pending, else
  * after every pending merge. The result is then a promise behind the declared synchronous type
  * (A-7): a schema without async callbacks never sees one, and one with them must await it.
+ * Fixed arity, so the synchronous call allocates nothing.
  */
-function finish<M, Map, X, A extends unknown[], R>(
+function finish<M, Map, X, R>(walk: Walk<M, Map, X>, done: (walk: Walk<M, Map, X>) => R): R;
+function finish<M, Map, X, A, R>(
   walk: Walk<M, Map, X>,
-  done: (walk: Walk<M, Map, X>, ...args: A) => R,
-  ...args: A
+  done: (walk: Walk<M, Map, X>, arg: A) => R,
+  arg: A,
+): R;
+function finish<M, Map, X, A, R>(
+  walk: Walk<M, Map, X>,
+  done: (walk: Walk<M, Map, X>, arg?: A) => R,
+  arg?: A,
 ): R {
-  return walk.pending ? (walk.pending.then(() => done(walk, ...args)) as R) : done(walk, ...args);
+  return walk.pending ? (walk.pending.then(() => done(walk, arg)) as R) : done(walk, arg);
 }
 
 function identity<M, Map, X>(walk: Walk<M, Map, X>) {

--- a/packages/selection-mapper/src/walk.ts
+++ b/packages/selection-mapper/src/walk.ts
@@ -187,6 +187,14 @@ interface Invocation extends Mapping {
 function noop() {}
 
 /**
+ * A-3, M-2: a walk that threw synchronously never reaches `finish`, so the merges it had already
+ * chained would reject unobserved once their callbacks settle. The throw is what the caller sees.
+ */
+function abandon<M, Map, X>(walk: Walk<M, Map, X>) {
+  walk.pending?.catch(noop);
+}
+
+/**
  * E-1: the query for the field `info` resolves, with its loader mappings recorded (L-2).
  * Declared synchronous (A-7): a promise is returned only when a callback returned one.
  */
@@ -265,10 +273,15 @@ export function selectionStateFromInfo<M, Map extends object, X = undefined>(
   const type = info.parentType;
   const walk = createWalk(env, type, {});
 
-  // Every node selecting the field (one per fragment it appears under) plans into the same row,
-  // so the loaded row satisfies each of them.
-  for (const fieldNode of info.fieldNodes) {
-    applyField(walk, walk.root, type, fieldNode, []);
+  try {
+    // Every node selecting the field (one per fragment it appears under) plans into the same
+    // row, so the loaded row satisfies each of them.
+    for (const fieldNode of info.fieldNodes) {
+      applyField(walk, walk.root, type, fieldNode, []);
+    }
+  } catch (error) {
+    abandon(walk);
+    throw error;
   }
 
   return finish(walk, enterLoaded, type);
@@ -418,28 +431,38 @@ function buildWalk<M, Map, X>(
 
     const walk = createWalk(env, typeName ? target : matches[0].type, {}, extra, initial);
 
-    // Every match is planned into the one root, entered under its own type first (W-11).
-    walkFieldWalks(
-      walk,
-      walk.root,
-      matches.map((match) => ({
-        // A matched type with its own model (including variants of the target model) is walked
-        // with its own model. Types without a model (interfaces, wrappers) are walked as the
-        // requested type so its fields can be found.
-        type: typeName && !env.modelOf(match.type) ? target : match.type,
-        declared: match.type,
-        fieldNodes: [match.field],
-        indirectPath: match.path,
-        deferred: match.deferred,
-      })),
-    );
+    try {
+      // Every match is planned into the one root, entered under its own type first (W-11).
+      walkFieldWalks(
+        walk,
+        walk.root,
+        matches.map((match) => ({
+          // A matched type with its own model (including variants of the target model) is walked
+          // with its own model. Types without a model (interfaces, wrappers) are walked as the
+          // requested type so its fields can be found.
+          type: typeName && !env.modelOf(match.type) ? target : match.type,
+          declared: match.type,
+          fieldNodes: [match.field],
+          indirectPath: match.path,
+          deferred: match.deferred,
+        })),
+      );
+    } catch (error) {
+      abandon(walk);
+      throw error;
+    }
 
     return walk;
   }
 
   const walk = createWalk(env, target, {}, extra, initial);
 
-  walkFields(walk, walk.root, target, returnType, info.fieldNodes, [], false);
+  try {
+    walkFields(walk, walk.root, target, returnType, info.fieldNodes, [], false);
+  } catch (error) {
+    abandon(walk);
+    throw error;
+  }
 
   return walk;
 }
@@ -949,66 +972,72 @@ function nestedSelectionFor<M, Map, X>(
       : pathOrInclude;
     const target = include ? info.schema.getType(include.getType())! : returnType;
     const child = createWalk(env, target, mapping.nested, extra);
-    // `true` is the public "no query"; it never reaches an adapter.
-    const query: MaybePromise<Map | null | undefined> =
-      rawQuery === true
-        ? undefined
-        : typeof rawQuery === 'function'
-          ? (
-              rawQuery as (
-                args: object,
-                ctx: object,
-                extra: X,
-              ) => MaybePromise<Map | null | undefined>
-            )(args, env.context, extra as X)
-          : rawQuery;
 
-    if (isThenable(query)) {
-      chain(child, query as PromiseLike<Map | null | undefined>, (resolved) =>
-        mergeQuery(child, resolved),
-      );
-    } else {
-      mergeQuery(child, query);
-    }
+    try {
+      // `true` is the public "no query"; it never reaches an adapter.
+      const query: MaybePromise<Map | null | undefined> =
+        rawQuery === true
+          ? undefined
+          : typeof rawQuery === 'function'
+            ? (
+                rawQuery as (
+                  args: object,
+                  ctx: object,
+                  extra: X,
+                ) => MaybePromise<Map | null | undefined>
+              )(args, env.context, extra as X)
+            : rawQuery;
 
-    const paths = include?.paths?.length
-      ? include.paths
-      : include?.path?.length
-        ? [include.path]
-        : undefined;
+      if (isThenable(query)) {
+        chain(child, query as PromiseLike<Map | null | undefined>, (resolved) =>
+          mergeQuery(child, resolved),
+        );
+      } else {
+        mergeQuery(child, query);
+      }
 
-    if (paths) {
-      // Each match is walked as its own type (W-11); the wrapper's selection set is not walked.
-      const matches = findMatches(info, returnType, fieldNode, paths, {
-        prefix: includeOf(returnType)?.path,
-        targetType: target,
-        modelOf: env.modelOf,
-      });
+      const paths = include?.paths?.length
+        ? include.paths
+        : include?.path?.length
+          ? [include.path]
+          : undefined;
 
-      walkFieldWalks(
-        child,
-        child.root,
-        matches.map((match) => ({
-          type: match.type,
-          declared: match.type,
-          fieldNodes: [match.field],
-          indirectPath: match.path,
-          deferred: match.deferred,
-        })),
-      );
-    } else {
-      const asType = (type: GraphQLNamedType): FieldWalk => ({
-        type,
-        declared: returnType,
-        fieldNodes: [fieldNode],
-        indirectPath: [],
-        deferred: false,
-      });
+      if (paths) {
+        // Each match is walked as its own type (W-11); the wrapper's selection set is not walked.
+        const matches = findMatches(info, returnType, fieldNode, paths, {
+          prefix: includeOf(returnType)?.path,
+          targetType: target,
+          modelOf: env.modelOf,
+        });
 
-      walkFieldWalks(child, child.root, [
-        ...(target === returnType ? [] : [asType(target)]),
-        asType(returnType),
-      ]);
+        walkFieldWalks(
+          child,
+          child.root,
+          matches.map((match) => ({
+            type: match.type,
+            declared: match.type,
+            fieldNodes: [match.field],
+            indirectPath: match.path,
+            deferred: match.deferred,
+          })),
+        );
+      } else {
+        const asType = (type: GraphQLNamedType): FieldWalk => ({
+          type,
+          declared: returnType,
+          fieldNodes: [fieldNode],
+          indirectPath: [],
+          deferred: false,
+        });
+
+        walkFieldWalks(child, child.root, [
+          ...(target === returnType ? [] : [asType(target)]),
+          asType(returnType),
+        ]);
+      }
+    } catch (error) {
+      abandon(child);
+      throw error;
     }
 
     // A promise behind the declared synchronous type, as `finish` returns one (A-7).

--- a/packages/selection-mapper/src/walk.ts
+++ b/packages/selection-mapper/src/walk.ts
@@ -175,6 +175,18 @@ export interface Walk<M, Map, X = undefined> {
 const NONE: Mapping = Object.freeze({ nested: Object.freeze({}) as Mappings });
 
 /**
+ * One select invocation's mapping record while the invocation runs: `pending` counts the nested
+ * selections it started whose walk is async and which have not resolved (A-8). Set only when a
+ * nested walk is async, and removed once every one has resolved, so a recorded `Mapping` never
+ * carries it and a synchronous invocation never touches it.
+ */
+interface Invocation extends Mapping {
+  pending?: number;
+}
+
+function noop() {}
+
+/**
  * E-1: the query for the field `info` resolves, with its loader mappings recorded (L-2).
  * Declared synchronous (A-7): a promise is returned only when a callback returned one.
  */
@@ -832,7 +844,7 @@ function applyField<M, Map, X>(
   // This invocation's mapping; every nested walk it makes records into `mapping.nested`, which
   // stays invisible to the walk until the invocation's map is accepted.
   const extra = adapter.callbackExtra?.(walk.extra, type, field, fieldNode);
-  const mapping: Mapping = { nested: {}, extra };
+  const mapping: Invocation = { nested: {}, extra };
   const args = getMappedArgumentValues(field, fieldNode, context, info);
   const select = selection as SelectFn<Map, X>;
 
@@ -872,18 +884,33 @@ function runSelect<M, Map, X>(
  * S-5, M-3, M-4, L-2: merges an accepted map and records its mapping, or does neither. A
  * rejected or falsy map records nothing, so the resolver loads its own data (L-3). This is the
  * only place a mapping is recorded.
+ *
+ * A-8: an invocation whose nested selection is still pending returned without awaiting it. Its
+ * map cannot hold what the nested walk will select, so recording its mapping would claim data
+ * the query never loads: the invocation is refused instead, and the pending walks (already
+ * handled, see `awaitNested`) are left to settle unobserved. Checked after the merge, so a map
+ * that embeds the pending promise is reported as that by the adapter.
  */
 function mergeField<M, Map, X>(
   walk: Walk<M, Map, X>,
   node: Node<M>,
   key: string,
   map: Map | false | null | undefined,
-  mapping: Mapping,
+  mapping: Invocation,
 ) {
-  if (map && walk.env.adapter.compatible(node, map, true)) {
-    walk.env.adapter.merge(node, map);
-    walk.mappings[key] = unionMappings(walk.mappings[key], mapping);
+  if (!(map && walk.env.adapter.compatible(node, map, true))) {
+    return;
   }
+
+  walk.env.adapter.merge(node, map);
+
+  if (mapping.pending) {
+    throw new PothosValidationError(
+      `The selection function of ${key.replace('@', '.')} returned while a nested selection it started was still pending. Await nestedSelection() (or a helper built on it, such as getQuery) inside an async selection function.`,
+    );
+  }
+
+  walk.mappings[key] = unionMappings(walk.mappings[key], mapping);
 }
 
 /** Adopts the first mapping accepted for a key; later accepted walks of the key deep-union. */
@@ -906,7 +933,7 @@ function nestedSelectionFor<M, Map, X>(
   fieldNode: FieldNode,
   args: object,
   extra: X | undefined,
-  mapping: Mapping,
+  mapping: Invocation,
 ): NestedSelection<Map, X> {
   const { env } = walk;
   const { info } = env;
@@ -984,8 +1011,32 @@ function nestedSelectionFor<M, Map, X>(
       ]);
     }
 
-    return finish(child, serializeRoot);
+    // A promise behind the declared synchronous type, as `finish` returns one (A-7).
+    return child.pending ? (awaitNested(child, mapping) as Map) : serializeRoot(child);
   };
+}
+
+/**
+ * A-8: the promise of a nested selection whose walk is async, counted against its invocation
+ * until it resolves. It is handled here, so a nested selection the invocation discards is never
+ * an unhandled rejection: `mergeField` refuses the invocation instead. A rejection keeps the
+ * count, since the invocation did not wait for it either; one that was awaited surfaces through
+ * the invocation's own promise.
+ */
+function awaitNested<M, Map, X>(child: Walk<M, Map, X>, mapping: Invocation) {
+  mapping.pending = (mapping.pending ?? 0) + 1;
+
+  const result = child.pending!.then(() => serializeRoot(child));
+
+  result.then(() => {
+    if (mapping.pending === 1) {
+      delete mapping.pending;
+    } else {
+      mapping.pending! -= 1;
+    }
+  }, noop);
+
+  return result;
 }
 
 /** E-3: a relation query merges over `empty`, so a query without columns adds none. */

--- a/packages/selection-mapper/tests/async.test.ts
+++ b/packages/selection-mapper/tests/async.test.ts
@@ -2,7 +2,13 @@ import { completeValue, isThenable } from '@pothos/core';
 import type { GraphQLObjectType } from 'graphql';
 import { describe, expect, it } from 'vitest';
 import type { Adapter, SelectFn } from '../src';
-import { getLoaderMapping, queryFromInfo, selectionStateFromInfo, walkFromInfo } from '../src';
+import {
+  getLoaderMapping,
+  queryFromInfo,
+  queryFromWalk,
+  selectionStateFromInfo,
+  walkFromInfo,
+} from '../src';
 import { type FakeMap, type FakeModel, type FakePath, resolveInfo } from './fake-adapter';
 import { countPromises } from './promise-spy';
 import { createTestAdapter, createTestSchema } from './schema';
@@ -306,6 +312,30 @@ describe('async callbacks', () => {
     );
   });
 
+  it('settles walkFromInfo, then queryFromWalk emits synchronously', async () => {
+    const source = '{ user { posts(take: 2) { id author(x: 1) { name } } } }';
+    const info = await resolveInfo(schema, source);
+    const syncContext = {};
+    const expected = queryFromInfo(adapter, { context: syncContext, info, initial: { take: 1 } });
+    const context = {};
+    const pending = walkFromInfo(
+      withWraps({ posts: pluginRelation(takeQuery), author: asyncRelation(whereXQuery, 1) }),
+      { context, info },
+    );
+
+    expect(isThenable(pending)).toBe(true);
+
+    const walk = (await pending)!;
+    // A resolver handed the settled plan emits without creating a promise.
+    const { result, promises } = countPromises(() => queryFromWalk(walk, { take: 1 }));
+
+    expect(promises).toBe(0);
+    expect(result).toEqual(expected);
+    expect(getLoaderMapping(context, pathOf('user', 'posts'), 'User')).toEqual(
+      getLoaderMapping(syncContext, pathOf('user', 'posts'), 'User'),
+    );
+  });
+
   it('returns the loader walk after its async select, then enters the parent type (E-2)', async () => {
     const info = await resolveInfo(schema, '{ viewer { posts(take: 2) { id } } }', {
       at: ['Viewer', 'posts'],
@@ -316,11 +346,11 @@ describe('async callbacks', () => {
     expect(adapter.serialize(walk.root)).toEqual({ select: { posts: { take: 2 }, id: true } });
     expect(walk.mappings).toEqual({ 'Viewer@posts': { nested: {} } });
 
-    const direct = await walkFromInfo(withSelects(['posts'], deferred), {
+    const direct = (await walkFromInfo(withSelects(['posts'], deferred), {
       context: {},
       info: await resolveInfo(schema, '{ user { posts { id } } }'),
       typeName: 'User',
-    });
+    }))!;
 
     expect(adapter.serialize(direct.root)).toEqual({ select: { posts: true } });
   });
@@ -371,6 +401,17 @@ describe('the synchronous path (A-1)', () => {
         }),
       ).promises,
     ).toBe(0);
+  });
+
+  it('creates no promise for a plan settled before its resolver runs', async () => {
+    const context = {};
+    const info = await resolveInfo(schema, source);
+    const { result, promises } = countPromises(() =>
+      queryFromWalk(walkFromInfo(adapter, { context, info })!, { take: 1 }),
+    );
+
+    expect(promises).toBe(0);
+    expect(result).toEqual(queryFromInfo(adapter, { context: {}, info, initial: { take: 1 } }));
   });
 
   it('counts the promises the spy is meant to see', () => {

--- a/packages/selection-mapper/tests/async.test.ts
+++ b/packages/selection-mapper/tests/async.test.ts
@@ -1,0 +1,382 @@
+import { completeValue, isThenable } from '@pothos/core';
+import type { GraphQLObjectType } from 'graphql';
+import { describe, expect, it } from 'vitest';
+import type { Adapter, SelectFn } from '../src';
+import { getLoaderMapping, queryFromInfo, selectionStateFromInfo, walkFromInfo } from '../src';
+import { type FakeMap, type FakeModel, type FakePath, resolveInfo } from './fake-adapter';
+import { countPromises } from './promise-spy';
+import { createTestAdapter, createTestSchema } from './schema';
+
+const schema = createTestSchema();
+const adapter = createTestAdapter();
+
+type Select = SelectFn<FakeMap, FakePath>;
+type Args = Record<string, unknown>;
+type Wrap = (select: Select, field: string) => Select;
+
+function pathOf(...keys: (string | number)[]) {
+  let path: { prev: unknown; key: string | number; typename: undefined } | undefined;
+
+  for (const key of keys) {
+    path = { prev: path, key, typename: undefined };
+  }
+
+  return path as never;
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** The test adapter with the select functions of `fields` wrapped by `wrap`. */
+function withSelects(fields: string[], wrap: Wrap): Adapter<FakeModel, FakeMap, FakePath> {
+  const wrapped = createTestAdapter();
+  const { fieldSelection } = wrapped;
+
+  wrapped.fieldSelection = (field) => {
+    const selection = fieldSelection(field);
+
+    return typeof selection === 'function' && fields.includes(field.name)
+      ? wrap(selection, field.name)
+      : selection;
+  };
+
+  return wrapped;
+}
+
+const takeQuery = (args: Args): FakeMap => (args.take === undefined ? {} : { take: args.take });
+const whereXQuery = (args: Args): FakeMap => (args.x === undefined ? {} : { where: { x: args.x } });
+
+/** An async `t.relation`-style select: it awaits its nested selection (A-6). */
+const asyncRelation =
+  (query?: (args: Args) => FakeMap, delay = 0): Wrap =>
+  (_select, name) =>
+  async (args, _ctx, nested) => {
+    if (delay) {
+      await sleep(delay);
+    }
+
+    return { select: { [name]: await nested(query?.(args as Args) ?? {}) } };
+  };
+
+/** A plugin-owned relation select: sync unless the nested selection is a promise. */
+const pluginRelation =
+  (query?: (args: Args) => FakeMap): Wrap =>
+  (_select, name) =>
+  (args, _ctx, nested) =>
+    completeValue(nested(query?.(args as Args) ?? {}), (map) => ({ select: { [name]: map } }));
+
+/** The field's own select, made async. */
+const deferred: Wrap = (select) => async (args, ctx, nested, getNode, extra) => {
+  await sleep(1);
+
+  return select(args, ctx, nested, getNode, extra);
+};
+
+function withWraps(wraps: Record<string, Wrap>) {
+  return withSelects(Object.keys(wraps), (select, name) => wraps[name](select, name));
+}
+
+async function sameAs(
+  source: string,
+  async: Adapter<FakeModel, FakeMap, FakePath>,
+  keys: [string, (string | number)[]][],
+) {
+  const info = await resolveInfo(schema, source);
+  const syncContext = {};
+  const expected = queryFromInfo(adapter, { context: syncContext, info });
+  const context = {};
+  const result = queryFromInfo(async, { context, info });
+
+  expect(isThenable(result)).toBe(true);
+
+  // L-2: nothing is recorded until every pending merge has run.
+  for (const [type, path] of keys) {
+    expect(getLoaderMapping(context, pathOf(...path), type)).toBe(null);
+  }
+
+  expect(await result).toEqual(expected);
+
+  for (const [type, path] of keys) {
+    expect(getLoaderMapping(context, pathOf(...path), type)).toEqual(
+      getLoaderMapping(syncContext, pathOf(...path), type),
+    );
+  }
+}
+
+describe('async callbacks', () => {
+  it('awaits an async select and builds the query the sync select builds', async () => {
+    await sameAs(
+      '{ user { id posts(take: 2) { id author(x: 1) { name } } profile { bio } } }',
+      withWraps({
+        posts: asyncRelation(takeQuery, 1),
+        author: asyncRelation(whereXQuery, 1),
+        profile: deferred,
+      }),
+      [
+        ['User', ['user', 'posts']],
+        ['User', ['user', 'profile']],
+      ],
+    );
+  });
+
+  it('propagates a nested async walk through a plugin-owned select (A-6)', async () => {
+    await sameAs(
+      '{ user { posts(take: 2) { id author(x: 1) { name } } } }',
+      withWraps({ posts: pluginRelation(takeQuery), author: asyncRelation(whereXQuery, 1) }),
+      [['User', ['user', 'posts']]],
+    );
+  });
+
+  it('awaits an async relation query', async () => {
+    const async = withSelects(['posts'], (_select, name) => (_args, _ctx, nested) => ({
+      select: { [name]: nested(async (args) => takeQuery(args as Args)) },
+    }));
+
+    // A relation query that returns a promise makes the nested selection a promise, which a
+    // synchronous select cannot embed (A-6)...
+    const info = await resolveInfo(schema, '{ user { posts(take: 2) { id } } }');
+
+    expect(() => queryFromInfo(async, { context: {}, info })).toThrow(
+      'Relation "posts" was given a promise',
+    );
+
+    // ...so the select awaits it.
+    await sameAs(
+      '{ user { posts(take: 2) { id author { name } } } }',
+      withSelects(['posts'], (_select, name) => async (_args, _ctx, nested) => ({
+        select: { [name]: await nested(async (args) => takeQuery(args as Args)) },
+      })),
+      [['User', ['user', 'posts']]],
+    );
+  });
+
+  it('rejects an async select that embeds a nested selection without awaiting it', async () => {
+    const async = withSelects(['posts'], (_select, name) => async (_args, _ctx, nested) => ({
+      select: { [name]: nested(async () => ({ take: 1 })) },
+    }));
+    const info = await resolveInfo(schema, '{ user { posts { id } } }');
+
+    await expect(queryFromInfo(async, { context: {}, info })).rejects.toThrow(
+      'Relation "posts" was given a promise',
+    );
+  });
+
+  it('runs a select as soon as its async arguments resolve (S-6)', async () => {
+    const info = await resolveInfo(schema, '{ user { posts(take: 2) { id } } }');
+    const field = (schema.getType('User') as GraphQLObjectType).getFields().posts;
+    const seen: string[] = [];
+    const spied = withSelects(['posts'], (select) => (args, ...rest) => {
+      seen.push(`select:${JSON.stringify(args)}`);
+
+      return select(args, ...rest);
+    });
+
+    field.extensions = {
+      ...field.extensions,
+      pothosArgMappers: [
+        async (args: { take: number }) => {
+          seen.push('mapper');
+          await new Promise((resolve) => setTimeout(resolve, 1));
+
+          return { take: args.take * 10 };
+        },
+      ],
+    };
+
+    try {
+      const context = {};
+      const result = queryFromInfo(spied, { context, info });
+
+      expect(seen).toEqual(['mapper']);
+      expect(await result).toEqual({ select: { posts: { take: 20 } } });
+      expect(seen).toEqual(['mapper', 'select:{"take":20}']);
+      expect(getLoaderMapping(context, pathOf('user', 'posts'), 'User')).toEqual({ nested: {} });
+    } finally {
+      field.extensions = { ...field.extensions, pothosArgMappers: undefined };
+    }
+  });
+
+  it('starts every callback of a walk in the same tick (A-3)', async () => {
+    const started: string[] = [];
+    const async = withSelects(['posts', 'profile'], (select, name) => async (...args) => {
+      started.push(name);
+      await new Promise((resolve) => setTimeout(resolve, 1));
+
+      return select(...args);
+    });
+    const info = await resolveInfo(schema, '{ user { posts { id } profile { bio } } }');
+
+    const result = queryFromInfo(async, { context: {}, info });
+
+    expect(started).toEqual(['posts', 'profile']);
+    expect(await result).toEqual({ select: { posts: true, profile: true } });
+  });
+
+  it('merges sync selections first, then async ones in document order (A-4, D-5)', async () => {
+    // `first` takes 1 and is async; `second` takes 2 and is sync. They conflict on `take`.
+    const syncWins = withSelects(['posts'], (select) => (args, ...rest) => {
+      const map = select(args, ...rest);
+
+      return (args as { take: number }).take === 1 ? Promise.resolve(map) : map;
+    });
+    const info = await resolveInfo(
+      schema,
+      '{ user { first: posts(take: 1) { id } second: posts(take: 2) { id } } }',
+    );
+    const context = {};
+
+    expect(await queryFromInfo(syncWins, { context, info })).toEqual({
+      select: { posts: { take: 2 } },
+    });
+    expect(getLoaderMapping(context, pathOf('user', 'second'), 'User')).toEqual({ nested: {} });
+    expect(getLoaderMapping(context, pathOf('user', 'first'), 'User')).toBe(null);
+
+    // Both async: `first` resolves last but was appended first, so it wins.
+    const appendOrder = withSelects(['posts'], (select) => (args, ...rest) => {
+      const map = select(args, ...rest);
+
+      return (args as { take: number }).take === 1
+        ? new Promise((resolve) => setTimeout(() => resolve(map), 5))
+        : Promise.resolve(map);
+    });
+    const ordered = {};
+
+    expect(await queryFromInfo(appendOrder, { context: ordered, info })).toEqual({
+      select: { posts: { take: 1 } },
+    });
+    expect(getLoaderMapping(ordered, pathOf('user', 'first'), 'User')).toEqual({ nested: {} });
+    expect(getLoaderMapping(ordered, pathOf('user', 'second'), 'User')).toBe(null);
+  });
+
+  it('unions the mappings of a key accepted from an async and a sync walk', async () => {
+    const source = /* GraphQL */ `{
+      user {
+        ... on User { posts { author { name } } }
+        ... on User { posts { comments { id } } }
+      }
+    }`;
+    // The first `posts` walk is async (its `author` is), the second is sync.
+    const mixed = withWraps({ posts: pluginRelation(), author: asyncRelation(undefined, 1) });
+
+    await sameAs(source, mixed, [['User', ['user', 'posts']]]);
+
+    const context = {};
+
+    await queryFromInfo(mixed, { context, info: await resolveInfo(schema, source) });
+
+    // The sync walk was merged first (D-5); the async one unioned into its mapping.
+    expect(Object.keys(getLoaderMapping(context, pathOf('user', 'posts'), 'User')!.nested)).toEqual(
+      ['Post@comments', 'Post@author'],
+    );
+  });
+
+  it('rejects the walk when a callback rejects', async () => {
+    const failing = withWraps({
+      posts: pluginRelation(),
+      author: () => () => Promise.reject(new Error('no author')),
+    });
+    const info = await resolveInfo(schema, '{ user { posts { author { name } } } }');
+
+    await expect(queryFromInfo(failing, { context: {}, info })).rejects.toThrow('no author');
+  });
+
+  it('plans a connection through an async relation query', async () => {
+    const async = withSelects(['postsConnection'], (select) => (args, ctx, nested, ...rest) => {
+      const nestedAsync: typeof nested = (query, path, type) =>
+        nested(
+          async () =>
+            typeof query === 'function' ? query(args, ctx, []) : query === true ? undefined : query,
+          path,
+          type,
+        );
+
+      return select(args, ctx, nestedAsync, ...rest);
+    });
+
+    // The connection select embeds the nested promise synchronously, as `getQuery` helpers do
+    // when not awaited.
+    const info = await resolveInfo(
+      schema,
+      '{ user { postsConnection(first: 2) { totalCount nodes { id } } } }',
+    );
+
+    expect(() => queryFromInfo(async, { context: {}, info })).toThrow(
+      'Relation "posts" was given a promise',
+    );
+  });
+
+  it('returns the loader walk after its async select, then enters the parent type (E-2)', async () => {
+    const info = await resolveInfo(schema, '{ viewer { posts(take: 2) { id } } }', {
+      at: ['Viewer', 'posts'],
+    });
+    const walk = await selectionStateFromInfo(withSelects(['posts'], deferred), {}, info);
+
+    // The type-level `posts: { take: 5 }` conflicts with the field's `take: 2`, merged first.
+    expect(adapter.serialize(walk.root)).toEqual({ select: { posts: { take: 2 }, id: true } });
+    expect(walk.mappings).toEqual({ 'Viewer@posts': { nested: {} } });
+
+    const direct = await walkFromInfo(withSelects(['posts'], deferred), {
+      context: {},
+      info: await resolveInfo(schema, '{ user { posts { id } } }'),
+      typeName: 'User',
+    });
+
+    expect(adapter.serialize(direct.root)).toEqual({ select: { posts: true } });
+  });
+});
+
+describe('the synchronous path (A-1)', () => {
+  const source = /* GraphQL */ `{
+    user {
+      id
+      posts(take: 2) { id author(x: 1) { name } ... on Post { comments { author { id } } } }
+      profile { bio }
+      postsConnection(first: 2) { totalCount nodes { id } edges { node { title } } }
+    }
+  }`;
+
+  it('creates no promise', async () => {
+    const context = {};
+    const info = await resolveInfo(schema, source);
+    const { result, promises } = countPromises(() => queryFromInfo(adapter, { context, info }));
+
+    expect(promises).toBe(0);
+    expect(isThenable(result)).toBe(false);
+    expect(result).toEqual({
+      extras: { postsCount: true },
+      select: {
+        posts: {
+          take: 2,
+          select: { author: { where: { x: 1 } }, comments: { select: { author: true } } },
+        },
+        profile: true,
+      },
+    });
+    expect(getLoaderMapping(context, pathOf('user', 'posts'), 'User')).not.toBe(null);
+  });
+
+  it('creates no promise for the loader entry points', async () => {
+    const info = await resolveInfo(schema, '{ viewer { posts(take: 2) { id } } }', {
+      at: ['Viewer', 'posts'],
+    });
+
+    expect(countPromises(() => selectionStateFromInfo(adapter, {}, info)).promises).toBe(0);
+    expect(
+      countPromises(() =>
+        walkFromInfo(adapter, {
+          context: {},
+          info,
+          typeName: 'Post',
+        }),
+      ).promises,
+    ).toBe(0);
+  });
+
+  it('counts the promises the spy is meant to see', () => {
+    expect(countPromises(() => Promise.resolve(1)).promises).toBe(1);
+    expect(countPromises(() => Promise.resolve(1).then(() => 2)).promises).toBe(2);
+    expect(countPromises(() => Promise.all([])).promises).toBe(1);
+    expect(countPromises(() => new Promise(() => {})).promises).toBe(1);
+  });
+});

--- a/packages/selection-mapper/tests/async.test.ts
+++ b/packages/selection-mapper/tests/async.test.ts
@@ -455,6 +455,73 @@ describe('a nested selection that was not awaited (A-8)', () => {
   });
 });
 
+describe('a walk that throws after a callback started (M-2)', () => {
+  const rejecting: Wrap = () => () => Promise.reject(new Error('late'));
+  const throwing: Wrap = () => () => {
+    throw new Error('sync');
+  };
+
+  it('handles the pending merges of every entry point before rethrowing', async () => {
+    await withoutUnhandledRejection(async () => {
+      const failing = withWraps({ posts: rejecting, profile: throwing });
+      const info = await resolveInfo(schema, '{ user { posts { id } profile { bio } } }');
+
+      expect(() => queryFromInfo(failing, { context: {}, info })).toThrow('sync');
+      expect(() => walkFromInfo(failing, { context: {}, info, typeName: 'User' })).toThrow('sync');
+
+      const paths = await resolveInfo(
+        schema,
+        '{ entries { ... on AppointmentEntry { appointment { posts { id } profile { bio } } } } }',
+      );
+
+      expect(() =>
+        queryFromInfo(failing, {
+          context: {},
+          info: paths,
+          typeName: 'User',
+          path: ['appointment'],
+        }),
+      ).toThrow('sync');
+    });
+  });
+
+  it('handles the pending merge of a loader walk whose second field node throws', async () => {
+    await withoutUnhandledRejection(async () => {
+      let calls = 0;
+      const failing = withSelects(['posts'], () => () => {
+        calls += 1;
+
+        if (calls === 1) {
+          return Promise.reject(new Error('late'));
+        }
+
+        throw new Error('sync');
+      });
+      // Two nodes select the field, so the loader walk applies two selects to the one row.
+      const info = await resolveInfo(
+        schema,
+        '{ viewer { ... on Viewer { posts { id } } ... on Viewer { posts { title } } } }',
+        { at: ['Viewer', 'posts'] },
+      );
+
+      expect(() => selectionStateFromInfo(failing, {}, info)).toThrow('sync');
+      expect(calls).toBe(2);
+    });
+  });
+
+  it('handles the pending merge of a nested walk that throws', async () => {
+    await withoutUnhandledRejection(async () => {
+      const failing = withWraps({ author: rejecting, comments: throwing });
+      const info = await resolveInfo(
+        schema,
+        '{ user { posts { author { name } comments { id } } } }',
+      );
+
+      expect(() => queryFromInfo(failing, { context: {}, info })).toThrow('sync');
+    });
+  });
+});
+
 describe('the synchronous path (A-1)', () => {
   const source = /* GraphQL */ `{
     user {

--- a/packages/selection-mapper/tests/async.test.ts
+++ b/packages/selection-mapper/tests/async.test.ts
@@ -356,6 +356,105 @@ describe('async callbacks', () => {
   });
 });
 
+/**
+ * Runs `run`, then gives anything it left pending time to settle, and expects no unhandled
+ * rejection in the meantime.
+ */
+async function withoutUnhandledRejection(run: () => Promise<void>) {
+  const unhandled: unknown[] = [];
+  const onUnhandled = (reason: unknown) => {
+    unhandled.push(reason);
+  };
+
+  process.on('unhandledRejection', onUnhandled);
+
+  try {
+    await run();
+    await sleep(30);
+
+    expect(unhandled).toEqual([]);
+  } finally {
+    process.off('unhandledRejection', onUnhandled);
+  }
+}
+
+describe('a nested selection that was not awaited (A-8)', () => {
+  const message =
+    'The selection function of User.posts returned while a nested selection it started was still pending. Await nestedSelection() (or a helper built on it, such as getQuery) inside an async selection function.';
+  const rejecting: Wrap = () => () => Promise.reject(new Error('no author'));
+
+  /** A sync select that starts the nested selection and returns without it. */
+  const discarding: Wrap = (_select, name) => (_args, _ctx, nested) => {
+    nested({});
+
+    return { select: { [name]: true } };
+  };
+
+  /** An async select that does the same, returning after `delay`. */
+  const discardingAsync =
+    (delay: number): Wrap =>
+    (_select, name) =>
+    async (_args, _ctx, nested) => {
+      nested({});
+      await sleep(delay);
+
+      return { select: { [name]: true } };
+    };
+
+  const source = '{ user { posts { author { name } } } }';
+
+  it('refuses a sync select whose discarded nested walk rejects, without an unhandled rejection', async () => {
+    await withoutUnhandledRejection(async () => {
+      const context = {};
+      const info = await resolveInfo(schema, source);
+
+      expect(() =>
+        queryFromInfo(withWraps({ posts: discarding, author: rejecting }), { context, info }),
+      ).toThrow(message);
+      expect(getLoaderMapping(context, pathOf('user', 'posts'), 'User')).toBe(null);
+    });
+  });
+
+  it('refuses an async select whose discarded nested walk rejected before it returned', async () => {
+    await withoutUnhandledRejection(async () => {
+      const context = {};
+      const info = await resolveInfo(schema, source);
+
+      await expect(
+        queryFromInfo(withWraps({ posts: discardingAsync(5), author: rejecting }), {
+          context,
+          info,
+        }),
+      ).rejects.toThrow(message);
+      expect(getLoaderMapping(context, pathOf('user', 'posts'), 'User')).toBe(null);
+    });
+  });
+
+  it('refuses an async select whose discarded nested walk resolves late, recording nothing', async () => {
+    await withoutUnhandledRejection(async () => {
+      const context = {};
+      const info = await resolveInfo(schema, source);
+      const late = withWraps({ posts: discardingAsync(1), author: asyncRelation(undefined, 20) });
+
+      await expect(queryFromInfo(late, { context, info })).rejects.toThrow(message);
+      expect(getLoaderMapping(context, pathOf('user', 'posts'), 'User')).toBe(null);
+
+      // The discarded walk completes after the invocation was refused: still nothing recorded.
+      await sleep(25);
+
+      expect(getLoaderMapping(context, pathOf('user', 'posts'), 'User')).toBe(null);
+    });
+  });
+
+  it('accepts a nested selection that was awaited, and records the same mapping as the sync walk', async () => {
+    await sameAs(
+      source,
+      withWraps({ posts: asyncRelation(), author: asyncRelation(undefined, 1) }),
+      [['User', ['user', 'posts']]],
+    );
+  });
+});
+
 describe('the synchronous path (A-1)', () => {
   const source = /* GraphQL */ `{
     user {

--- a/packages/selection-mapper/tests/index.test.ts
+++ b/packages/selection-mapper/tests/index.test.ts
@@ -14,6 +14,7 @@ it('exports only what the plugins use', () => {
     'getLoaderMapping',
     'isUsed',
     'queryFromInfo',
+    'queryFromWalk',
     'relation',
     'selectedFieldNames',
     'selectionStateFromInfo',

--- a/packages/selection-mapper/tests/promise-spy.ts
+++ b/packages/selection-mapper/tests/promise-spy.ts
@@ -1,0 +1,32 @@
+/**
+ * Runs `fn` while every way of creating a promise is counted: construction (`new Promise`, and
+ * the statics `resolve`/`all`/... which construct through `this`) and `.then` (which derives one).
+ * `fn` must be synchronous: the spies are removed before it returns.
+ */
+export function countPromises<T>(fn: () => T): { result: T; promises: number } {
+  const NativePromise = Promise;
+  const { then } = NativePromise.prototype;
+  let promises = 0;
+
+  globalThis.Promise = new Proxy(NativePromise, {
+    construct(target, args, newTarget) {
+      promises += 1;
+
+      return Reflect.construct(target, args, newTarget);
+    },
+  });
+  // biome-ignore lint/suspicious/noThenProperty: the spy counts derived promises
+  NativePromise.prototype.then = function counted(this: Promise<unknown>, ...args: unknown[]) {
+    promises += 1;
+
+    return then.apply(this, args as never) as never;
+  } as typeof then;
+
+  try {
+    return { result: fn(), promises };
+  } finally {
+    globalThis.Promise = NativePromise;
+    // biome-ignore lint/suspicious/noThenProperty: restores the native method
+    NativePromise.prototype.then = then;
+  }
+}

--- a/packages/selection-mapper/tests/walk.test.ts
+++ b/packages/selection-mapper/tests/walk.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { getLoaderMapping, queryFromInfo, selectionStateFromInfo, walkFromInfo } from '../src';
+import {
+  getLoaderMapping,
+  queryFromInfo,
+  queryFromWalk,
+  selectionStateFromInfo,
+  walkFromInfo,
+} from '../src';
 import { resolveInfo } from './fake-adapter';
 import { createTestAdapter, createTestSchema } from './schema';
 
@@ -659,10 +665,67 @@ describe('walkFromInfo', () => {
     const context = {};
     const info = await resolveInfo(schema, '{ user { posts { id } } }');
 
-    const walk = walkFromInfo(adapter, { context, info, typeName: 'User' });
+    const walk = walkFromInfo(adapter, { context, info, typeName: 'User' })!;
 
     expect(adapter.serialize(walk.root)).toEqual({ select: { posts: true } });
     expect(walk.mappings).toEqual({ 'User@posts': { nested: {} } });
     expect(getLoaderMapping(context, pathOf('user', 'posts'), 'User')).toBe(null);
+  });
+
+  it('returns undefined when paths are given and nothing is selected under them', async () => {
+    const paths = [['nodes'], ['edges', 'node']];
+    const at: [string, string] = ['User', 'postsConnection'];
+    const options = { context: {}, typeName: 'Post', paths };
+
+    const empty = await resolveInfo(schema, '{ user { postsConnection { totalCount } } }', { at });
+
+    expect(walkFromInfo(adapter, { ...options, info: empty })).toBeUndefined();
+
+    const nodes = await resolveInfo(
+      schema,
+      '{ user { postsConnection { nodes { author { id } } } } }',
+      {
+        at,
+      },
+    );
+    const walk = walkFromInfo(adapter, { ...options, info: nodes })!;
+
+    expect(adapter.serialize(walk.root)).toEqual({ select: { author: true } });
+  });
+});
+
+describe('queryFromWalk', () => {
+  it('emits what queryFromInfo emits with the selection as initial, and records the mappings', async () => {
+    const info = await resolveInfo(
+      schema,
+      '{ user { id posts(take: 2) { id author(x: 1) { name } } } }',
+    );
+    const select = { select: { profile: true }, take: 1 };
+    const expectedContext = {};
+    const expected = queryFromInfo(adapter, { context: expectedContext, info, initial: select });
+    const context = {};
+    const walk = walkFromInfo(adapter, { context, info })!;
+
+    expect(getLoaderMapping(context, pathOf('user', 'posts'), 'User')).toBe(null);
+
+    const query = queryFromWalk(walk, select);
+
+    expect(query).toEqual(expected);
+    // The caller's selection comes first, as `initial` does (E-1), so the query is the same
+    // object key for key.
+    expect(Object.keys(query.select!)).toEqual(Object.keys(expected.select!));
+    expect(getLoaderMapping(context, pathOf('user', 'posts'), 'User')).toEqual(
+      getLoaderMapping(expectedContext, pathOf('user', 'posts'), 'User'),
+    );
+  });
+
+  it('emits the walked plan alone without a selection', async () => {
+    const context = {};
+    const info = await resolveInfo(schema, '{ user { posts(take: 2) { id } } }');
+
+    expect(queryFromWalk(walkFromInfo(adapter, { context, info })!)).toEqual(
+      queryFromInfo(adapter, { context: {}, info }),
+    );
+    expect(getLoaderMapping(context, pathOf('user', 'posts'), 'User')).toEqual({ nested: {} });
   });
 });

--- a/website/content/docs/plugins/drizzle.mdx
+++ b/website/content/docs/plugins/drizzle.mdx
@@ -277,6 +277,46 @@ describes where in the GraphQL query the relation is being loaded:
 You can read more about the relation query builder api
 [here](https://orm.drizzle.team/docs/rqb#querying)
 
+## Async selections
+
+`select` functions, relation `query` callbacks, and `relatedCount` `where` callbacks may be async.
+The plugin still builds one query: it waits for the callbacks and merges what they return after
+every synchronous selection, in document order. Schemas without async callbacks are unaffected: no
+promise is created until a callback returns one.
+
+```ts
+builder.drizzleObject('users', {
+  name: 'User',
+  fields: (t) => ({
+    posts: t.relation('posts', {
+      query: async (args, ctx) => ({ where: { authorId: await ctx.currentUserId() } }),
+    }),
+    latestPosts: t.field({
+      type: [Post],
+      select: async (args, ctx, nestedSelection) => ({
+        // A promise when a selection beneath it is async, so it must be awaited
+        with: { posts: await nestedSelection({ limit: await ctx.previewSize() }) },
+      }),
+      resolve: (user) => user.posts,
+    }),
+  }),
+});
+
+builder.queryField('me', (t) =>
+  t.drizzleField({
+    type: 'users',
+    // `query()` returns a promise when a selection beneath the field is async
+    resolve: async (query, root, args, ctx) =>
+      db.query.users.findFirst(await query({ where: { id: ctx.userId } })),
+  }),
+);
+```
+
+Inside an async `select`, `await` the result of `nestedSelection` (and of helpers built on it, such
+as `getQuery` from `drizzleConnectionHelpers`) before adding it to the selection; a selection that
+contains the promise itself throws. Calling `nestedSelection` and discarding its result is not
+detected: the nested selection is then not loaded with the parent.
+
 ## Drizzle Fields
 
 Drizzle objects and relations allow you to define parts of your schema backed by your drizzle

--- a/website/content/docs/plugins/drizzle.mdx
+++ b/website/content/docs/plugins/drizzle.mdx
@@ -279,10 +279,11 @@ You can read more about the relation query builder api
 
 ## Async selections
 
-`select` functions, relation `query` callbacks, and `relatedCount` `where` callbacks may be async.
-The plugin still builds one query: it waits for the callbacks and merges what they return after
-every synchronous selection, in document order. Schemas without async callbacks are unaffected: no
-promise is created until a callback returns one.
+`select` functions, relation `query` callbacks, `relatedCount` `where` callbacks, and the `select`
+and `query` callbacks of `drizzleConnectionHelpers` may be async. The plugin still builds one query:
+it waits for the callbacks and merges what they return after every synchronous selection, in
+document order. Schemas without async callbacks are unaffected: no promise is created until a
+callback returns one.
 
 ```ts
 builder.drizzleObject('users', {
@@ -314,7 +315,8 @@ builder.queryField('me', (t) =>
 
 Inside an async `select`, `await` the result of `nestedSelection` (and of helpers built on it, such
 as `getQuery` from `drizzleConnectionHelpers`) before adding it to the selection; a selection that
-contains the promise itself throws. Calling `nestedSelection` and discarding its result is not
+contains the promise itself throws, and so does a `select` that returns while a nested selection it
+started is still pending. Calling `nestedSelection` and discarding a synchronous result is not
 detected: the nested selection is then not loaded with the parent.
 
 ## Drizzle Fields

--- a/website/content/docs/plugins/drizzle.mdx
+++ b/website/content/docs/plugins/drizzle.mdx
@@ -305,9 +305,9 @@ builder.drizzleObject('users', {
 builder.queryField('me', (t) =>
   t.drizzleField({
     type: 'users',
-    // `query()` returns a promise when a selection beneath the field is async
-    resolve: async (query, root, args, ctx) =>
-      db.query.users.findFirst(await query({ where: { id: ctx.userId } })),
+    // The plan is settled before the resolver runs, so `query()` never returns a promise
+    resolve: (query, root, args, ctx) =>
+      db.query.users.findFirst(query({ where: { id: ctx.userId } })),
   }),
 );
 ```

--- a/website/content/docs/plugins/prisma/selections.mdx
+++ b/website/content/docs/plugins/prisma/selections.mdx
@@ -111,10 +111,11 @@ const PostDraft = builder.prismaObject('Post', {
 
 ## Async selections
 
-`select` functions, relation `query` callbacks, and `relationCount` `where` callbacks may be async.
-The plugin still builds one query: it waits for the callbacks and merges what they return after
-every synchronous selection, in document order. Schemas without async callbacks are unaffected: no
-promise is created until a callback returns one.
+`select` functions, relation `query` callbacks, `relationCount` `where` callbacks, and the `select`
+and `query` callbacks of `prismaConnectionHelpers` may be async. The plugin still builds one query:
+it waits for the callbacks and merges what they return after every synchronous selection, in
+document order. Schemas without async callbacks are unaffected: no promise is created until a
+callback returns one.
 
 ```typescript
 builder.prismaObject('Post', {
@@ -136,7 +137,8 @@ builder.prismaObject('Post', {
 
 Inside an async `select`, `await` the result of `nestedSelection` (and of helpers built on it, such
 as `getQuery` from `prismaConnectionHelpers`) before adding it to the selection; a selection that
-contains the promise itself throws. Calling `nestedSelection` and discarding its result is not
+contains the promise itself throws, and so does a `select` that returns while a nested selection it
+started is still pending. Calling `nestedSelection` and discarding a synchronous result is not
 detected: the nested selection is then not loaded with the parent, and the field falls back to its
 own query. `queryFromInfo` returns a promise when a callback beneath the field is async, so `await`
 it in resolvers that call it directly.
@@ -184,7 +186,8 @@ builder.mutationField(
       }
 
       const post = prisma.city.create({
-        ...queryFromInfo({
+        // A promise when a callback beneath the field is async, so it is awaited
+        ...(await queryFromInfo({
           context,
           info,
           // nested path where the selections for this type can be found
@@ -194,7 +197,7 @@ builder.mutationField(
           select: {
             comments: true,
           },
-        }),
+        })),
         data: {
           title: args.input.title,
           ...

--- a/website/content/docs/plugins/prisma/selections.mdx
+++ b/website/content/docs/plugins/prisma/selections.mdx
@@ -109,6 +109,38 @@ const PostDraft = builder.prismaObject('Post', {
 });
 ```
 
+## Async selections
+
+`select` functions, relation `query` callbacks, and `relationCount` `where` callbacks may be async.
+The plugin still builds one query: it waits for the callbacks and merges what they return after
+every synchronous selection, in document order. Schemas without async callbacks are unaffected: no
+promise is created until a callback returns one.
+
+```typescript
+builder.prismaObject('Post', {
+  fields: (t) => ({
+    comments: t.relation('comments', {
+      query: async (args, ctx) => ({ where: { authorId: await ctx.currentUserId() } }),
+    }),
+    latestComments: t.field({
+      type: [Comment],
+      select: async (args, ctx, nestedSelection) => ({
+        // A promise when a selection beneath it is async, so it must be awaited
+        comments: await nestedSelection({ take: await ctx.previewSize() }),
+      }),
+      resolve: (post) => post.comments,
+    }),
+  }),
+});
+```
+
+Inside an async `select`, `await` the result of `nestedSelection` (and of helpers built on it, such
+as `getQuery` from `prismaConnectionHelpers`) before adding it to the selection; a selection that
+contains the promise itself throws. Calling `nestedSelection` and discarding its result is not
+detected: the nested selection is then not loaded with the parent, and the field falls back to its
+own query. `queryFromInfo` returns a promise when a callback beneath the field is async, so `await`
+it in resolvers that call it directly.
+
 ## Optimized queries without `t.prismaField`
 
 In some cases, it may be useful to get an optimized query for fields where you can't use


### PR DESCRIPTION
Stacked on #1672. Fifth PR in the selection-mapper stack.

The three user callbacks the walker runs, argument mappers, a field's `select`, and a relation `query`, may now return promises. The mechanism is the one from the approved design (§5): one optional `pending` promise on a walk, only merges are chained onto it (never user code), and `finish` returns synchronously when nothing is pending. A prisma `select: async () => ...`, which compiled and was silently dropped, now works.

## What changed

- **Package.** `Walk.pending`, `chain`, `finish`; two chain sites (`applyField` for async args or an async select result, `nestedSelectionFor` for an async relation `query`). Callbacks run as soon as their own inputs resolve; async merges land after every synchronous merge, in append order. `relation()` still throws when a relation value is a thenable, telling the user to `await nestedSelection(...)`.
- **Every consumer** goes through a maybe-promise: prisma `t.relation`, `relatedConnection` (`getQuery`, select, loaded-path `resolve`, fallback), `relationCount` `where`, `prismaConnectionHelpers.getQuery`, the `prismaField`/`prismaConnection` resolvers, the `wrapResolve` fallback, node loading, and the model loader (caches the maybe-promise walk per `Type@path`); drizzle `t.relation`, `relatedConnection`, `relatedField`, `relatedCount`, `drizzleConnectionHelpers`, cursor connection resolution, and the model loader.
- **Types.** Inputs widened to `MaybePromise` (relation `query`, count `where`, connection-helper `select`/`query`, field `select`). Declared returns of `queryFromInfo`, `nestedSelection`, the drizzle resolver-side `query()` and the connection helpers' `getQuery` stay synchronous (A-7): in an async schema they hand back a promise the user awaits. Type tests pin both.
- **Docs.** One "Async selections" section per plugin page, including the one hole the design accepts: a `nestedSelection` whose promise is discarded leaves its selection unloaded and is not detected.

## Synchronous path

Zero promises and zero closures beyond the base, asserted by spies: over the package's fake adapter for every entry point, and over a real prisma and drizzle document through the built schema's resolvers (root field plus the loaded-path relation, count, related-field and connection resolvers for every row), with zero queries issued. Per-call sites use a split form (`isThenable(v) ? v.then(fn) : fn(v, ...)` with `fn` hoisted) rather than a closure-capturing `completeValue`. `finish` has a fixed arity, which also removes the rest-array allocation the base carried.

## Deviations from the design, deliberate

- Connection-helper `getQuery` keeps its synchronous declared return, like `nestedSelection`; widening it would break every synchronous `select` that embeds it.
- Prisma `relatedConnection`'s loaded-path `resolve` keeps reading the user `query` for `take`, since a user query can override it and the loaded path must use the same value the plan used.
- `chain` joins links with `Promise.all` from the second link on, so a callback rejecting before an earlier link settles is never an unhandled rejection.

## Verification

selection-mapper 75 tests, prisma 155, drizzle 188; `pnpm type` and biome clean in all three. Root turbo `build generate test type` 108/108 excluding `plugin-prisma-utils` (needs its Postgres container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf25mwTTUmeM2ogHxq3idp

## Review round 1 fixes (last seven commits)

- **drizzle: the plan is settled before a `drizzleField`/`drizzleConnection` resolver runs**, so the `query()` builder the resolver receives never returns a promise. Before, an async selection anywhere beneath made `query({ where })` return a promise that user code handed straight to drizzle, which ran the query without the predicate. The package exports `queryFromWalk` for this; `walkFromInfo` returns `undefined` on no match. Tests assert the issued SQL keeps the predicate and equals the synchronous twin.
- **A select that discarded a pending `nestedSelection`** is refused with a validation error naming the field, and its rejection is handled, so no mapping can claim data the parent never loaded and nothing escapes as an unhandled rejection. Pending children are counted on the invocation record only while async work is outstanding.
- **A synchronous throw after an async sibling** no longer orphans that sibling's rejection; every entry point handles pending merges before rethrowing.
- **Model loaders stage a synchronous selection without awaiting it** (prisma and drizzle, plus prisma node loading), so the per-tick batch is intact and the resolver's synchronous window contains only the loader's own batch promises. Spy tests now cover the unloaded-row paths (relation, count, connection, node load) and batching of several raw parents.
- Prisma's exported `FieldSelection` type widened; drizzle `selectionOf` hoisted to module level; docs example awaits `queryFromInfo`; helper callbacks listed among the async-capable ones.

One non-snapshot expectation changed: planning now runs before a `drizzleField` resolver whether or not it calls `query()`, as `prismaField` already did, so a `relatedConnection` `query` callback observes the root path once more when the row later loads through the loader (data and query count unchanged).

selection-mapper 87 tests, prisma 159, drizzle 196; `pnpm type` and biome clean in all three.