### PR TITLE
feat(prisma, drizzle): honest selection types, helper types, and docs

### DIFF
--- a/.changeset/selection-mapper-types.md
+++ b/.changeset/selection-mapper-types.md
@@ -1,0 +1,40 @@
+---
+'@pothos/selection-mapper': patch
+'@pothos/plugin-prisma': patch
+'@pothos/plugin-drizzle': patch
+---
+
+Type the selection API by what it does, and document what was undocumented.
+
+- `queryFromInfo` (prisma) is typed by what it was given: `{ select }` or `{ include }` when one
+  was passed, and otherwise `{ select?, include? }`, whichever the type's mode produced. It used
+  to claim `{ select: Select }` for every call without `include`.
+- `nestedSelection` returns the relation query for the field's model or table (prisma:
+  `PrismaRelationQuery<Model>`; drizzle: the table's `DBQueryConfig`, a `many` config for a list
+  field), keeping the keys it was given as given, so a `select`/`columns` in them still narrows
+  the parent shape. Its argument is typed by that query when the field's type names a model, so
+  literals such as `select: { title: true }` are kept. It used to return its argument's type.
+- One `PathSegment` type (`string | { name: string; type?: string }`) for `queryFromInfo` paths,
+  `nestedSelection` paths, and `IndirectInclude`, exported from `@pothos/selection-mapper` and
+  re-exported by both plugins. A `{ name, type }` segment given to `nestedSelection` now pins the
+  implementation the field is found under at runtime, as it already did for `queryFromInfo`.
+- The `query` a `t.relation` fallback `resolve` receives (prisma) carries the relation's own
+  arguments (`where`, `orderBy`, `take`, ...) alongside the planned `select`/`include`, so it
+  spreads into a prisma call without a cast. Exported as `QueryFromRelation`.
+- `t.relationCount` (prisma) and `t.relatedCount` (drizzle) accept only list relations.
+- `t.relatedField` (drizzle) accepts the ordinary field options (`deprecationReason`,
+  `extensions`, `authScopes`, ...); its `resolve` may be async and receives the resolve `info`.
+  Exported as `RelatedSelectionFieldOptions`.
+- New `PrismaQueriedShape<Types, Model, Query>` and `DrizzleQueriedShape<Types, Table, Query>`
+  name the row shape a query loads, for resolvers that load rows themselves.
+- The drizzle plugin's unused `withUsageCheck` option on its internal `queryFromInfo`, and the
+  commented-out call sites for it, are removed: a drizzle resolver is handed a query builder
+  function, so the prisma-style check that observes reads on a query object cannot see the
+  realistic mistake (never calling `query()`), and a check that could would be a new mechanism.
+- Docs: how selections are planned (a field is either planned into an ancestor's query or loaded
+  on its own, never both; selections share a query node only with matching arguments; a
+  field-level `select` merges with its siblings), prisma `findUnique: null`, `onNull`, `select`
+  on `t.prismaField`, `nestedSelection`'s typed segments and third argument,
+  `skipDeferredFragments`, `prismaFieldWithInput`/`drizzleFieldWithInput`, drizzle
+  `drizzleInterface`/`drizzleInterfaceField(s)`, `t.variant(Ref, { select })`, connection size
+  options, the drizzle fallback loader, and the error for conflicting type-level selections.

--- a/.changeset/selection-mapper-types.md
+++ b/.changeset/selection-mapper-types.md
@@ -21,7 +21,9 @@ Type the selection API by what it does, and document what was undocumented.
 - The `query` a `t.relation` fallback `resolve` receives (prisma) carries the relation's own
   arguments (`where`, `orderBy`, `take`, ...) alongside the planned `select`/`include`, so it
   spreads into a prisma call without a cast. Exported as `QueryFromRelation`.
-- `t.relationCount` (prisma) and `t.relatedCount` (drizzle) accept only list relations.
+- `t.relationCount` (prisma) and `t.relatedCount` (drizzle) accept only list relations. Code that
+  called either on a to-one relation (which built a count query prisma or drizzle rejected at
+  runtime) compiled before and now fails to compile.
 - `t.relatedField` (drizzle) accepts the ordinary field options (`deprecationReason`,
   `extensions`, `authScopes`, ...); its `resolve` may be async and receives the resolve `info`.
   Exported as `RelatedSelectionFieldOptions`.

--- a/.changeset/selection-mapper-types.md
+++ b/.changeset/selection-mapper-types.md
@@ -14,10 +14,12 @@ Type the selection API by what it does, and document what was undocumented.
   field), keeping the keys it was given as given, so a `select`/`columns` in them still narrows
   the parent shape. Its argument is typed by that query when the field's type names a model, so
   literals such as `select: { title: true }` are kept. It used to return its argument's type.
-- One `PathSegment` type (`string | { name: string; type?: string }`) for `queryFromInfo` paths,
-  `nestedSelection` paths, and `IndirectInclude`, exported from `@pothos/selection-mapper` and
-  re-exported by both plugins. A `{ name, type }` segment given to `nestedSelection` now pins the
-  implementation the field is found under at runtime, as it already did for `queryFromInfo`.
+- One `PathSegment` type (`string | { name: string; type?: string }`) for `queryFromInfo` paths
+  and `nestedSelection` paths, exported from `@pothos/selection-mapper` and re-exported by both
+  plugins, together with `IndirectPathSegment` (its `{ name, type? }` form) and `IndirectInclude`,
+  whose `path`/`paths` still take only `IndirectPathSegment` objects. A `{ name, type }` segment
+  given to `nestedSelection` now pins the implementation the field is found under at runtime, as
+  it already did for `queryFromInfo`.
 - The `query` a `t.relation` fallback `resolve` receives (prisma) carries the relation's own
   arguments (`where`, `orderBy`, `take`, ...) alongside the planned `select`/`include`, so it
   spreads into a prisma call without a cast. Exported as `QueryFromRelation`.

--- a/packages/plugin-drizzle/src/connection-helpers.ts
+++ b/packages/plugin-drizzle/src/connection-helpers.ts
@@ -65,6 +65,7 @@ export function drizzleConnectionHelpers<
   }: {
     args?: (t: PothosSchemaTypes.InputFieldBuilder<Types, 'Arg'>) => ExtraArgs;
     select?: (
+      // The node's selection: its table is the connection field's, which the helper does not know.
       nestedSelection: <T extends true | {}>(selection?: T) => T,
       args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
       ctx: Types['Context'],
@@ -196,7 +197,8 @@ export function drizzleConnectionHelpers<
     };
   };
 
-  type NestedSelection = <T extends true | {}>(selection?: T, path?: string[]) => T;
+  // The `nestedSelection` of the field's `select`, whatever table its type names.
+  type NestedSelection = (selection?: SelectionMap | true, path?: string[]) => unknown;
 
   function getQuery(
     args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
@@ -211,14 +213,14 @@ export function drizzleConnectionHelpers<
               info: nestedSelectionOrInfo,
               context: ctx,
               config,
-              select,
+              select: select as SelectionMap,
               path,
             });
     // Both callbacks start now; the query waits for whichever of them is async (A-3, A-7: the
     // declared type stays synchronous, so an async schema awaits the result).
     const nestedSelect: MaybePromise<Record<string, unknown> | true> = select
-      ? select((sel) => nestedSelection(sel, ['edges', 'node']), args, ctx)
-      : nestedSelection(true, ['edges', 'node']);
+      ? select((sel) => nestedSelection(sel as SelectionMap, ['edges', 'node']) as never, args, ctx)
+      : (nestedSelection(true, ['edges', 'node']) as never);
     const baseQuery = baseQueryFor(args, ctx);
 
     return (isThenable(nestedSelect) || isThenable(baseQuery)

--- a/packages/plugin-drizzle/src/connection-helpers.ts
+++ b/packages/plugin-drizzle/src/connection-helpers.ts
@@ -6,7 +6,7 @@ import {
   type MaybePromise,
   type SchemaTypes,
 } from '@pothos/core';
-import { createNode } from '@pothos/selection-mapper';
+import { createNode, type PathSegment } from '@pothos/selection-mapper';
 import type {
   BuildQueryResult,
   DBQueryConfig,
@@ -198,7 +198,7 @@ export function drizzleConnectionHelpers<
   };
 
   // The `nestedSelection` of the field's `select`, whatever table its type names.
-  type NestedSelection = (selection?: SelectionMap | true, path?: string[]) => unknown;
+  type NestedSelection = (selection?: SelectionMap | true, path?: PathSegment[]) => unknown;
 
   function getQuery(
     args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,

--- a/packages/plugin-drizzle/src/drizzle-field-builder.ts
+++ b/packages/plugin-drizzle/src/drizzle-field-builder.ts
@@ -42,6 +42,7 @@ import type {
   RelatedConnectionOptions,
   RelatedCountOptions,
   RelatedFieldOptions,
+  RelatedSelectionFieldOptions,
   ShapeFromConnection,
   TypesForRelation,
   VariantFieldOptions,
@@ -637,27 +638,15 @@ export class DrizzleObjectFieldBuilder<
       BuildQueryResult<Types['DrizzleRelations'], TableConfig, Select & { columns: {} }>,
   >(
     relationName: Field,
-    options: {
-      type: Type;
-      nullable?: Nullable;
-      args?: Args;
-      description?: string;
-      select: (
-        buildFilter: (parentTable: TableConfig['table']) => SQL,
-        args: Args extends InputFieldMap ? InputShapeFromFields<Args> : {},
-        ctx: Types['Context'],
-        nestedQuery: (
-          query: DBQueryConfig<'many', Types['DrizzleRelations'], TableConfig>,
-        ) => DBQueryConfig<'many', Types['DrizzleRelations'], TableConfig>,
-      ) => MaybePromise<Select>;
-      resolve: (
-        parent: ShapeWithSelection,
-        args: Args extends InputFieldMap ? InputShapeFromFields<Args> : {},
-        ctx: Types['Context'],
-        info: unknown,
-      ) => ShapeFromTypeParam<Types, Type, Nullable>;
-      extensions?: Record<string, unknown>;
-    },
+    options: RelatedSelectionFieldOptions<
+      Types,
+      TableConfig,
+      Type,
+      Nullable,
+      Args,
+      Select,
+      ShapeWithSelection
+    >,
   ): FieldRef<Types, ShapeFromTypeParam<Types, Type, Nullable>, 'DrizzleObject'> {
     const schemaConfig = getSchemaConfig(this.builder);
     const relationField = schemaConfig.relations?.[this.table].relations[relationName as string];

--- a/packages/plugin-drizzle/src/drizzle-field-builder.ts
+++ b/packages/plugin-drizzle/src/drizzle-field-builder.ts
@@ -703,7 +703,7 @@ export class DrizzleObjectFieldBuilder<
   }
 
   relatedCount<
-    Field extends keyof TableConfig['relations'],
+    Field extends ListRelation<TableConfig>,
     Args extends InputFieldMap,
     Where extends SQL | undefined,
   >(

--- a/packages/plugin-drizzle/src/drizzle-field-builder.ts
+++ b/packages/plugin-drizzle/src/drizzle-field-builder.ts
@@ -6,7 +6,6 @@ import {
   type FieldRef,
   type InferredFieldOptionKeys,
   type InputFieldMap,
-  type InputShapeFromFields,
   type InterfaceParam,
   isThenable,
   type MaybePromise,

--- a/packages/plugin-drizzle/src/field-builder.ts
+++ b/packages/plugin-drizzle/src/field-builder.ts
@@ -122,7 +122,6 @@ function resolveWithWalk(
         context,
         select,
         info,
-        // withUsageCheck: !!this.builder.options.drizzle?.onUnusedQuery,
       }),
     parent,
     args,

--- a/packages/plugin-drizzle/src/schema-builder.ts
+++ b/packages/plugin-drizzle/src/schema-builder.ts
@@ -186,7 +186,8 @@ schemaBuilderProto.drizzleObjectField = function drizzleObjectField(type, fieldN
 };
 
 schemaBuilderProto.drizzleInterfaceField = function drizzleInterfaceField(type, fieldName, field) {
-  const ref = typeof type === 'string' ? getRefFromModel(type, this) : (type as never);
+  // A table name names the interface registered under it, as `drizzleInterface` registers one.
+  const ref = typeof type === 'string' ? getRefFromModel(type, this, 'interface') : (type as never);
   this.configStore.onTypeConfig(ref, ({ name }) => {
     this.configStore.addFields(ref, () => ({
       [fieldName]: field(new DrizzleObjectFieldBuilder(name, this, ref.tableName, 'Interface')),
@@ -204,7 +205,7 @@ schemaBuilderProto.drizzleObjectFields = function drizzleObjectFields(type, fiel
 };
 
 schemaBuilderProto.drizzleInterfaceFields = function drizzleInterfaceFields(type, fields) {
-  const ref = typeof type === 'string' ? getRefFromModel(type, this) : (type as never);
+  const ref = typeof type === 'string' ? getRefFromModel(type, this, 'interface') : (type as never);
   this.configStore.onTypeConfig(ref, ({ name }) => {
     this.configStore.addFields(ref, () =>
       fields(new DrizzleObjectFieldBuilder(name, this, ref.tableName, 'Interface')),

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -351,7 +351,7 @@ export type DrizzleObjectFieldOptions<
         | ((
             args: InputShapeFromFields<Args>,
             ctx: Types['Context'],
-            nestedSelection: NestedSelectionFn<Types, Type>,
+            nestedSelection: NestedSelectionFn<Types, Type, Args>,
           ) => MaybePromise<
             DBQueryConfig<'one', Types['DrizzleRelations'], ExtractTable<Types, ParentShape>>
           >)
@@ -401,18 +401,34 @@ export type NestedSelectionResult<Types extends SchemaTypes, Selection, Type> = 
  * It also carries the `PathInfo` of the field being planned. The selection is typed by the
  * field's table when it has one, so `columns: { title: true }` keeps its literal `true`.
  */
-export type NestedSelectionFn<Types extends SchemaTypes, Type> = (<
+export type NestedSelectionFn<Types extends SchemaTypes, Type, Args extends InputFieldMap = {}> = (<
   Selection extends
     | boolean
     | ([QueryForTypeParam<Types, Type>] extends [never]
         ? {}
         : QueryForTypeParam<Types, Type>) = true,
 >(
-  selection?: Selection,
+  selection?: NestedSelectionArg<Types, Selection, Args>,
   path?: PathSegment[],
   type?: string,
 ) => NestedSelectionResult<Types, Selection, Type>) &
   PathInfo;
+
+/**
+ * The selection given to `nestedSelection`: the query config itself, a promise of it, or a
+ * callback building it from the field's arguments, the context, and the field's `PathInfo`
+ * (which may be async). The result is typed by the query either way; it is a promise at runtime
+ * only when a promise or an async callback was given, or a selection beneath it is async, and
+ * must then be awaited.
+ */
+export type NestedSelectionArg<Types extends SchemaTypes, Selection, Args extends InputFieldMap> =
+  | Selection
+  | PromiseLike<Selection>
+  | ((
+      args: InputShapeFromFields<Args>,
+      ctx: Types['Context'],
+      pathInfo: PathInfo,
+    ) => MaybePromise<Selection>);
 
 export type DrizzleFieldSelection =
   | DBQueryConfig<'one'>

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -26,6 +26,7 @@ import {
   type TypeParam,
   typeBrandKey,
 } from '@pothos/core';
+import type { IndirectInclude, IndirectPathSegment, PathSegment } from '@pothos/selection-mapper';
 import type {
   AnyRelations,
   BuildQueryResult,
@@ -41,8 +42,13 @@ import type {
 import type { FieldNode, GraphQLResolveInfo } from 'graphql';
 import type { DrizzleObjectFieldBuilder } from './drizzle-field-builder.js';
 import type { DrizzleRef } from './interface-ref.js';
-import type { IndirectInclude } from './utils/map-query.js';
 import type { SelectionMap } from './utils/selections.js';
+
+/**
+ * A segment of a `path` given to `queryFromInfo` or `nestedSelection`: a field name, or
+ * `{ name, type }` to pin the type the field must be selected under (a fragment on it).
+ */
+export type { IndirectInclude, IndirectPathSegment, PathSegment };
 
 export interface FieldPathInfo {
   field: string;
@@ -403,7 +409,7 @@ export type NestedSelectionFn<Types extends SchemaTypes, Type> = (<
         : QueryForTypeParam<Types, Type>) = true,
 >(
   selection?: Selection,
-  path?: string[],
+  path?: PathSegment[],
   type?: string,
 ) => NestedSelectionResult<Types, Selection, Type>) &
   PathInfo;
@@ -418,7 +424,7 @@ export type DrizzleFieldSelection =
           | SelectionMap
           | boolean
           | ((args: object, context: object) => MaybePromise<DBQueryConfig<'one'>>),
-        path?: IndirectInclude | string[],
+        path?: IndirectInclude | PathSegment[],
         type?: string,
       ) => DBQueryConfig<'one'> | boolean,
       resolveSelection: (path: string[]) => FieldNode | null,

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -431,6 +431,21 @@ export type DrizzleFieldSelection =
       pathInfo: PathInfo,
     ) => MaybePromise<SelectionMap | false | null | undefined>);
 
+/**
+ * The shape of a row of `Table` loaded with `Query` (a query config, or `true` for every
+ * column): what drizzle returns for that query, and what a resolver on the table's type sees
+ * when the row was planned with it. For rows a resolver loads itself, so what is on them is
+ * named once, next to the query that loaded them. `Query` is read as drizzle reads it: without
+ * `columns`, every column is loaded.
+ */
+export type DrizzleQueriedShape<
+  Types extends SchemaTypes,
+  Table extends keyof Types['DrizzleRelations'],
+  Query extends
+    | DBQueryConfig<'one', Types['DrizzleRelations'], Types['DrizzleRelations'][Table]>
+    | true = true,
+> = BuildQueryResult<Types['DrizzleRelations'], Types['DrizzleRelations'][Table], Query>;
+
 export type ExtractTable<Types extends SchemaTypes, Shape> = Shape extends {
   [drizzleTableName]?: keyof Types['DrizzleRelations'];
 }

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -345,16 +345,68 @@ export type DrizzleObjectFieldOptions<
         | ((
             args: InputShapeFromFields<Args>,
             ctx: Types['Context'],
-            nestedSelection: (<Selection extends boolean | {}>(
-              selection?: Selection,
-              path?: string[],
-            ) => Selection) &
-              PathInfo,
+            nestedSelection: NestedSelectionFn<Types, Type>,
           ) => MaybePromise<
             DBQueryConfig<'one', Types['DrizzleRelations'], ExtractTable<Types, ParentShape>>
           >)
       );
   };
+
+/** The table a field's type param names: a drizzle ref, or a list of one. */
+export type TableForTypeParam<Types extends SchemaTypes, Type> = Type extends [infer Item]
+  ? TableForTypeParam<Types, Item>
+  : // biome-ignore lint/suspicious/noExplicitAny: matching against any ref
+    Type extends DrizzleRef<any, infer Table>
+    ? Table & keyof Types['DrizzleRelations']
+    : never;
+
+/**
+ * The query config for the table a field's type param names (a `many` config for a list field),
+ * or never when the type has no table.
+ */
+export type QueryForTypeParam<Types extends SchemaTypes, Type> =
+  TableForTypeParam<Types, Type> extends infer Table
+    ? [Table] extends [never]
+      ? never
+      : DBQueryConfig<
+          Type extends [unknown] ? 'many' : 'one',
+          Types['DrizzleRelations'],
+          Types['DrizzleRelations'][Table & keyof Types['DrizzleRelations']]
+        >
+    : never;
+
+/**
+ * What `nestedSelection` returns: the query config for the field's table, keeping the keys of
+ * the given selection as they were given (so `columns` in it still narrow the parent shape).
+ * With no selection, or `true`, it is the config itself. A field whose type has no table keeps
+ * the selection it was given.
+ */
+export type NestedSelectionResult<Types extends SchemaTypes, Selection, Type> = [
+  QueryForTypeParam<Types, Type>,
+] extends [never]
+  ? Selection
+  : Selection extends boolean
+    ? QueryForTypeParam<Types, Type>
+    : Normalize<Omit<QueryForTypeParam<Types, Type>, keyof Selection> & Selection>;
+
+/**
+ * The callback a field's `select` function plans the selection beneath the field with: `path`
+ * walks a field nested under the field's type, `type` names the type the selection is read as.
+ * It also carries the `PathInfo` of the field being planned. The selection is typed by the
+ * field's table when it has one, so `columns: { title: true }` keeps its literal `true`.
+ */
+export type NestedSelectionFn<Types extends SchemaTypes, Type> = (<
+  Selection extends
+    | boolean
+    | ([QueryForTypeParam<Types, Type>] extends [never]
+        ? {}
+        : QueryForTypeParam<Types, Type>) = true,
+>(
+  selection?: Selection,
+  path?: string[],
+  type?: string,
+) => NestedSelectionResult<Types, Selection, Type>) &
+  PathInfo;
 
 export type DrizzleFieldSelection =
   | DBQueryConfig<'one'>

--- a/packages/plugin-drizzle/src/types.ts
+++ b/packages/plugin-drizzle/src/types.ts
@@ -535,6 +535,42 @@ export type RelatedCountOptions<
     | ((args: InputShapeFromFields<Args>, context: Types['Context']) => MaybePromise<Where>);
 };
 
+/**
+ * The options of `t.relatedField`: the ordinary object field options (description, deprecation,
+ * extensions, and what other plugins add), with a `select` that plans a query on the relation.
+ */
+export type RelatedSelectionFieldOptions<
+  Types extends SchemaTypes,
+  TableConfig extends TableRelationalConfig,
+  Type extends TypeParam<Types>,
+  Nullable extends boolean,
+  Args extends InputFieldMap,
+  Select,
+  ShapeWithSelection,
+> = Omit<
+  PothosSchemaTypes.ObjectFieldOptions<Types, ShapeWithSelection, Type, Nullable, Args, unknown>,
+  InferredFieldOptionKeys
+> & {
+  /**
+   * The query planned on the parent row for this field: `buildFilter` filters the related table
+   * to the parent's rows, `nestedQuery` plans the field's own selection beneath a query.
+   */
+  select: (
+    buildFilter: (parentTable: TableConfig['table']) => SQL,
+    args: InputShapeFromFields<Args>,
+    ctx: Types['Context'],
+    nestedQuery: (
+      query: DBQueryConfig<'many', Types['DrizzleRelations'], TableConfig>,
+    ) => DBQueryConfig<'many', Types['DrizzleRelations'], TableConfig>,
+  ) => MaybePromise<Select>;
+  resolve: (
+    parent: ShapeWithSelection,
+    args: InputShapeFromFields<Args>,
+    ctx: Types['Context'],
+    info: GraphQLResolveInfo,
+  ) => MaybePromise<ShapeFromTypeParam<Types, Type, Nullable>>;
+};
+
 export type TypesForRelation<Types extends SchemaTypes, Rel extends Relation> = BuildQueryResult<
   Types['DrizzleRelations'],
   Types['DrizzleRelations'][Rel['targetTableName']],

--- a/packages/plugin-drizzle/src/utils/cursors.ts
+++ b/packages/plugin-drizzle/src/utils/cursors.ts
@@ -720,7 +720,6 @@ export async function resolveDrizzleCursorConnection<T extends {}>(
       paths: [['nodes'], ['edges', 'node']],
       typeName,
       config,
-      // withUsageCheck: !!this.builder.options.prisma?.onUnusedQuery,
     });
 
     return query;

--- a/packages/plugin-drizzle/src/utils/map-query.ts
+++ b/packages/plugin-drizzle/src/utils/map-query.ts
@@ -24,7 +24,6 @@ export interface QueryFromInfoOptions<T extends SelectionMap> {
   select?: T;
   path?: PathSegment[];
   paths?: PathSegment[][];
-  withUsageCheck?: boolean;
 }
 
 export function queryFromInfo<T extends SelectionMap>({
@@ -66,7 +65,7 @@ export function queryFromWalk<T extends SelectionMap>(
   walk: DrizzleWalk | undefined,
   options: QueryFromInfoOptions<T>,
 ): T {
-  const { config, select, withUsageCheck } = options;
+  const { config, select } = options;
 
   if (!walk) {
     // Nothing is selected under the paths: the caller gets its own selection back.
@@ -77,7 +76,7 @@ export function queryFromWalk<T extends SelectionMap>(
   const conflict = initial && drizzleAdapter(config).typeLevelConflict(walk.root, initial);
 
   if (!conflict) {
-    return walkQueryFromWalk(walk, initial, withUsageCheck) as T;
+    return walkQueryFromWalk(walk, initial) as T;
   }
 
   const query = queryFromInfo(options);

--- a/packages/plugin-drizzle/src/utils/map-query.ts
+++ b/packages/plugin-drizzle/src/utils/map-query.ts
@@ -1,6 +1,7 @@
 import { isThenable, PothosValidationError } from '@pothos/core';
 import {
   type IndirectInclude,
+  type PathSegment,
   selectedFieldNames,
   queryFromInfo as walkQueryFromInfo,
   queryFromWalk as walkQueryFromWalk,
@@ -21,8 +22,8 @@ export interface QueryFromInfoOptions<T extends SelectionMap> {
   info: GraphQLResolveInfo;
   typeName?: string;
   select?: T;
-  path?: (string | { name: string; type?: string })[];
-  paths?: (string | { name: string; type?: string })[][];
+  path?: PathSegment[];
+  paths?: PathSegment[][];
   withUsageCheck?: boolean;
 }
 

--- a/packages/plugin-drizzle/tests/interface-fields-by-table.test.ts
+++ b/packages/plugin-drizzle/tests/interface-fields-by-table.test.ts
@@ -1,0 +1,108 @@
+import SchemaBuilder from '@pothos/core';
+import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
+import { execute } from '@pothos/test-utils';
+import { getTableConfig } from 'drizzle-orm/sqlite-core';
+import { type GraphQLInterfaceType, isInterfaceType } from 'graphql';
+import { gql } from 'graphql-tag';
+import DrizzlePlugin from '../src';
+import { clearDrizzleLogs, type DrizzleRelations, db, relations } from './example/db';
+
+// `drizzleInterfaceField(s)` take the table name as well as the interface ref, as the docs say:
+// the name resolves to the interface `drizzleInterface` registered under it, not to an object.
+const builder = new SchemaBuilder<{
+  DrizzleRelations: DrizzleRelations;
+}>({
+  plugins: [ScopeAuthPlugin, DrizzlePlugin],
+  drizzle: {
+    client: () => db,
+    getTableConfig,
+    relations,
+  },
+  scopeAuth: {
+    authScopes: () => ({}),
+  },
+});
+
+const Viewer = builder.drizzleInterface('users', {
+  select: { columns: { id: true } },
+  resolveType: () => 'NormalViewer',
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+
+builder.drizzleObject('users', {
+  variant: 'NormalViewer',
+  interfaces: [Viewer],
+});
+
+builder.drizzleInterfaceField('users', 'username', (t) =>
+  t.string({
+    select: { columns: { username: true } },
+    resolve: (user) => `@${user.username}`,
+  }),
+);
+
+builder.drizzleInterfaceFields('users', (t) => ({
+  firstName: t.exposeString('firstName', { nullable: true }),
+  postCount: t.relatedCount('posts'),
+}));
+
+builder.queryType({
+  fields: (t) => ({
+    viewer: t.drizzleField({
+      type: Viewer,
+      resolve: (query) => db.query.users.findFirst(query({ where: { id: 1 } })),
+    }),
+  }),
+});
+
+const schema = builder.toSchema();
+
+describe('interface fields added by table name', () => {
+  afterEach(() => {
+    clearDrizzleLogs();
+  });
+
+  it('adds the fields to the interface', () => {
+    const viewer = schema.getType('users');
+
+    expect(isInterfaceType(viewer)).toBe(true);
+    expect(Object.keys((viewer as GraphQLInterfaceType).getFields()).sort()).toEqual([
+      'firstName',
+      'id',
+      'postCount',
+      'username',
+    ]);
+  });
+
+  it('resolves them on an implementation, planned into the interface query', async () => {
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          viewer {
+            id
+            username
+            firstName
+            postCount
+            ... on NormalViewer {
+              id
+            }
+          }
+        }
+      `,
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      viewer: {
+        id: '1',
+        username: expect.stringMatching(/^@/),
+        firstName: expect.any(String),
+        postCount: expect.any(Number),
+      },
+    });
+  });
+});

--- a/packages/plugin-drizzle/tests/selection-types.test-d.ts
+++ b/packages/plugin-drizzle/tests/selection-types.test-d.ts
@@ -4,6 +4,7 @@ import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
 import type * as SelectionMapper from '@pothos/selection-mapper';
 import type { DBQueryConfig } from 'drizzle-orm';
 import { getTableConfig } from 'drizzle-orm/sqlite-core';
+import type { GraphQLResolveInfo } from 'graphql';
 import { expectTypeOf, it } from 'vitest';
 import DrizzlePlugin, {
   drizzleConnectionHelpers,
@@ -13,6 +14,7 @@ import DrizzlePlugin, {
 } from '../src';
 import { queryFromInfo } from '../src/utils/map-query';
 import { type DrizzleRelations, db, relations } from './example/db';
+import { posts } from './example/db/schema';
 
 // One path segment type, shared with the planner, for `queryFromInfo` paths, `nestedSelection`
 // paths, and the `IndirectInclude` a type's extensions carry.
@@ -152,6 +154,26 @@ builder.drizzleObjectFields('users', (t) => ({
   postCount: t.relatedCount('posts'),
   // @ts-expect-error a to-one relation has no count
   profileCount: t.relatedCount('profile'),
+}));
+
+// `t.relatedField` takes the ordinary field options, an async `resolve`, and the resolve info.
+builder.drizzleObjectFields('users', (t) => ({
+  postsTotal: t.relatedField('posts', {
+    type: 'Int',
+    description: 'how many posts',
+    deprecationReason: 'use postCount',
+    extensions: { complexity: 1 },
+    authScopes: {},
+    select: async (buildFilter) => ({
+      extras: { postsTotal: (parent) => db.$count(posts, buildFilter(parent)) },
+    }),
+    resolve: (user, _args, _ctx, info) => {
+      expectTypeOf(info).toEqualTypeOf<GraphQLResolveInfo>();
+      expectTypeOf(user.postsTotal).toEqualTypeOf<number>();
+
+      return Promise.resolve(user.postsTotal);
+    },
+  }),
 }));
 
 it('types the nested selection as the query it returns', () => {

--- a/packages/plugin-drizzle/tests/selection-types.test-d.ts
+++ b/packages/plugin-drizzle/tests/selection-types.test-d.ts
@@ -184,9 +184,10 @@ builder.drizzleObjectFields('users', (t) => ({
     deprecationReason: 'use postCount',
     extensions: { complexity: 1 },
     authScopes: {},
-    select: async (buildFilter) => ({
-      extras: { postsTotal: (parent) => db.$count(posts, buildFilter(parent)) },
-    }),
+    select: (buildFilter) =>
+      Promise.resolve({
+        extras: { postsTotal: (parent) => db.$count(posts, buildFilter(parent)) },
+      }),
     resolve: (user, _args, _ctx, info) => {
       expectTypeOf(info).toEqualTypeOf<GraphQLResolveInfo>();
       expectTypeOf(user.postsTotal).toEqualTypeOf<number>();

--- a/packages/plugin-drizzle/tests/selection-types.test-d.ts
+++ b/packages/plugin-drizzle/tests/selection-types.test-d.ts
@@ -103,6 +103,42 @@ builder.drizzleObject('users', {
         return user.posts;
       },
     }),
+    // The selection may also be a callback of the field's arguments, context, and path info, or a
+    // promise; the result is typed by the query config either way.
+    recentPosts: t.field({
+      type: [Post],
+      args: { limit: t.arg.int() },
+      select: (_args, _ctx, nestedSelection) => {
+        const query = nestedSelection((args, ctx, pathInfo) => {
+          expectTypeOf(args).toEqualTypeOf<{ limit?: number | null }>();
+          expectTypeOf(ctx).toEqualTypeOf<{}>();
+          expectTypeOf(pathInfo.path).toEqualTypeOf<string[]>();
+
+          return { limit: args.limit ?? 1 };
+        });
+
+        expectTypeOf(query.limit).toEqualTypeOf<number>();
+        expectTypeOf(query.columns).toEqualTypeOf<PostsQuery['columns']>();
+
+        return { with: { posts: query } };
+      },
+      resolve: (user) => user.posts,
+    }),
+    awaitedPosts: t.field({
+      type: [Post],
+      select: async (_args, _ctx, nestedSelection) => {
+        const query = await nestedSelection(Promise.resolve({ limit: 1 }));
+        const fromAsyncCallback = await nestedSelection(async () => ({ offset: 1 }));
+
+        expectTypeOf(query.limit).toEqualTypeOf<number>();
+        expectTypeOf(query.with).toEqualTypeOf<PostsQuery['with']>();
+        expectTypeOf(fromAsyncCallback.offset).toEqualTypeOf<number>();
+        expectTypeOf(fromAsyncCallback.columns).toEqualTypeOf<PostsQuery['columns']>();
+
+        return { with: { posts: query } };
+      },
+      resolve: (user) => user.posts,
+    }),
     postTitles: t.field({
       type: [Post],
       select: (_args, _ctx, nestedSelection) => {

--- a/packages/plugin-drizzle/tests/selection-types.test-d.ts
+++ b/packages/plugin-drizzle/tests/selection-types.test-d.ts
@@ -7,6 +7,7 @@ import { getTableConfig } from 'drizzle-orm/sqlite-core';
 import type { GraphQLResolveInfo } from 'graphql';
 import { expectTypeOf, it } from 'vitest';
 import DrizzlePlugin, {
+  type DrizzleQueriedShape,
   drizzleConnectionHelpers,
   type IndirectInclude,
   type IndirectPathSegment,
@@ -175,6 +176,23 @@ builder.drizzleObjectFields('users', (t) => ({
     },
   }),
 }));
+
+// `DrizzleQueriedShape` names the row shape a query loads, for rows a resolver loads itself.
+it('names the shape of a row loaded with a query', () => {
+  type Types = typeof builder.$inferSchemaTypes;
+
+  expectTypeOf<DrizzleQueriedShape<Types, 'users'>>().toEqualTypeOf<
+    DrizzleRelations['users']['table']['$inferSelect']
+  >();
+
+  expectTypeOf<
+    DrizzleQueriedShape<
+      Types,
+      'users',
+      { columns: { id: true }; with: { posts: { columns: { title: true } } } }
+    >
+  >().toEqualTypeOf<{ id: number; posts: { title: string }[] }>();
+});
 
 it('types the nested selection as the query it returns', () => {
   expectTypeOf(builder).not.toBeAny();

--- a/packages/plugin-drizzle/tests/selection-types.test-d.ts
+++ b/packages/plugin-drizzle/tests/selection-types.test-d.ts
@@ -1,0 +1,126 @@
+import SchemaBuilder from '@pothos/core';
+import RelayPlugin from '@pothos/plugin-relay';
+import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
+import type { DBQueryConfig } from 'drizzle-orm';
+import { getTableConfig } from 'drizzle-orm/sqlite-core';
+import { expectTypeOf, it } from 'vitest';
+import DrizzlePlugin, { drizzleConnectionHelpers } from '../src';
+import { type DrizzleRelations, db, relations } from './example/db';
+
+const builder = new SchemaBuilder<{
+  DrizzleRelations: DrizzleRelations;
+}>({
+  plugins: [ScopeAuthPlugin, RelayPlugin, DrizzlePlugin],
+  drizzle: {
+    client: () => db,
+    getTableConfig,
+    relations,
+  },
+  scopeAuth: {
+    authScopes: () => ({}),
+  },
+});
+
+type PostsQuery = DBQueryConfig<'many', DrizzleRelations, DrizzleRelations['posts']>;
+type ProfileQuery = DBQueryConfig<'one', DrizzleRelations, DrizzleRelations['userProfile']>;
+
+const Post = builder.drizzleObject('posts', {
+  name: 'Post',
+  fields: (t) => ({
+    id: t.exposeID('postId'),
+  }),
+});
+
+const Profile = builder.drizzleObject('userProfile', {
+  name: 'Profile',
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+
+const Comment = builder.drizzleObject('comments', {
+  name: 'Comment',
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+
+const commentHelpers = drizzleConnectionHelpers(builder, 'comments');
+
+// `nestedSelection` is typed as the query config for the field's table (a `many` config for a
+// list field), keeping the keys it was given, so `columns` in it still narrow the parent shape.
+builder.drizzleObject('users', {
+  name: 'User',
+  fields: (t) => ({
+    latestPosts: t.field({
+      type: [Post],
+      select: (_args, _ctx, nestedSelection) => {
+        expectTypeOf(nestedSelection()).toEqualTypeOf<PostsQuery>();
+        expectTypeOf(nestedSelection(true)).toEqualTypeOf<PostsQuery>();
+        expectTypeOf(nestedSelection.path).toEqualTypeOf<string[]>();
+
+        const query = nestedSelection({ limit: 1 });
+
+        expectTypeOf(query.limit).toEqualTypeOf<number>();
+        expectTypeOf(query.columns).toEqualTypeOf<PostsQuery['columns']>();
+        expectTypeOf(query.with).toEqualTypeOf<PostsQuery['with']>();
+
+        return { with: { posts: query } };
+      },
+      resolve: (user) => {
+        // A query config without `columns` of its own loads every column.
+        expectTypeOf(user.posts[0].title).toEqualTypeOf<string>();
+
+        return user.posts;
+      },
+    }),
+    postTitles: t.field({
+      type: [Post],
+      select: (_args, _ctx, nestedSelection) => {
+        // The given selection's keys are kept as given, with the literal `true`.
+        const query = nestedSelection({ columns: { title: true } });
+
+        expectTypeOf(query.columns).toEqualTypeOf<{ title: true }>();
+
+        return { with: { posts: query } };
+      },
+      resolve: (user) => {
+        expectTypeOf(user.posts[0]).toEqualTypeOf<{ title: string }>();
+
+        return null as never;
+      },
+    }),
+    profileBio: t.string({
+      nullable: true,
+      select: (_args, _ctx, nestedSelection) => {
+        // A field type without a table keeps the given selection.
+        expectTypeOf(nestedSelection({ limit: 1 })).toEqualTypeOf<{ limit: number }>();
+
+        return { with: { profile: nestedSelection() } };
+      },
+      resolve: (user) => user.profile?.bio,
+    }),
+    profile: t.field({
+      type: Profile,
+      nullable: true,
+      select: (_args, _ctx, nestedSelection) => {
+        expectTypeOf(nestedSelection()).toEqualTypeOf<ProfileQuery>();
+
+        return { with: { profile: nestedSelection() } };
+      },
+      resolve: (user) => user.profile,
+    }),
+    comments: t.connection({
+      type: Comment,
+      // The field's nested selection is accepted by the helpers' `getQuery`.
+      select: (args, ctx, nestedSelection) => ({
+        with: { comments: commentHelpers.getQuery(args, ctx, nestedSelection) },
+      }),
+      resolve: (user, args, ctx) => commentHelpers.resolve(user.comments, args, ctx),
+    }),
+  }),
+});
+
+it('types the nested selection as the query it returns', () => {
+  expectTypeOf(builder).not.toBeAny();
+});

--- a/packages/plugin-drizzle/tests/selection-types.test-d.ts
+++ b/packages/plugin-drizzle/tests/selection-types.test-d.ts
@@ -1,11 +1,32 @@
 import SchemaBuilder from '@pothos/core';
 import RelayPlugin from '@pothos/plugin-relay';
 import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
+import type * as SelectionMapper from '@pothos/selection-mapper';
 import type { DBQueryConfig } from 'drizzle-orm';
 import { getTableConfig } from 'drizzle-orm/sqlite-core';
 import { expectTypeOf, it } from 'vitest';
-import DrizzlePlugin, { drizzleConnectionHelpers } from '../src';
+import DrizzlePlugin, {
+  drizzleConnectionHelpers,
+  type IndirectInclude,
+  type IndirectPathSegment,
+  type PathSegment,
+} from '../src';
+import { queryFromInfo } from '../src/utils/map-query';
 import { type DrizzleRelations, db, relations } from './example/db';
+
+// One path segment type, shared with the planner, for `queryFromInfo` paths, `nestedSelection`
+// paths, and the `IndirectInclude` a type's extensions carry.
+it('re-exports the shared path segment types', () => {
+  expectTypeOf<PathSegment>().toEqualTypeOf<SelectionMapper.PathSegment>();
+  expectTypeOf<IndirectPathSegment>().toEqualTypeOf<SelectionMapper.IndirectPathSegment>();
+  expectTypeOf<IndirectInclude>().toEqualTypeOf<SelectionMapper.IndirectInclude>();
+  expectTypeOf<PathSegment>().toEqualTypeOf<string | { name: string; type?: string }>();
+
+  expectTypeOf(queryFromInfo)
+    .parameter(0)
+    .toHaveProperty('path')
+    .toEqualTypeOf<PathSegment[] | undefined>();
+});
 
 const builder = new SchemaBuilder<{
   DrizzleRelations: DrizzleRelations;
@@ -58,6 +79,11 @@ builder.drizzleObject('users', {
         expectTypeOf(nestedSelection()).toEqualTypeOf<PostsQuery>();
         expectTypeOf(nestedSelection(true)).toEqualTypeOf<PostsQuery>();
         expectTypeOf(nestedSelection.path).toEqualTypeOf<string[]>();
+
+        // A path segment is a name, or `{ name, type }`, as for `queryFromInfo`.
+        expectTypeOf(
+          nestedSelection({ limit: 1 }, [{ name: 'post', type: 'PostEntry' }]),
+        ).toEqualTypeOf(nestedSelection({ limit: 1 }, ['post']));
 
         const query = nestedSelection({ limit: 1 });
 

--- a/packages/plugin-drizzle/tests/selection-types.test-d.ts
+++ b/packages/plugin-drizzle/tests/selection-types.test-d.ts
@@ -147,6 +147,13 @@ builder.drizzleObject('users', {
   }),
 });
 
+// Only a list relation can be counted.
+builder.drizzleObjectFields('users', (t) => ({
+  postCount: t.relatedCount('posts'),
+  // @ts-expect-error a to-one relation has no count
+  profileCount: t.relatedCount('profile'),
+}));
+
 it('types the nested selection as the query it returns', () => {
   expectTypeOf(builder).not.toBeAny();
 });

--- a/packages/plugin-drizzle/tests/selection-types.test-d.ts
+++ b/packages/plugin-drizzle/tests/selection-types.test-d.ts
@@ -150,6 +150,25 @@ builder.drizzleObject('users', {
   }),
 });
 
+// A `t.variant` field can carry a `select` of its own (the docs' Variants example).
+const Viewer = builder.drizzleObject('users', {
+  variant: 'Viewer',
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+
+builder.drizzleObjectFields('users', (t) => ({
+  viewer: t.variant(Viewer, {
+    select: { columns: { firstName: true } },
+    isNull: (user) => {
+      expectTypeOf(user.firstName).toEqualTypeOf<string | null>();
+
+      return false;
+    },
+  }),
+}));
+
 // Only a list relation can be counted.
 builder.drizzleObjectFields('users', (t) => ({
   postCount: t.relatedCount('posts'),

--- a/packages/plugin-prisma/src/connection-helpers.ts
+++ b/packages/plugin-prisma/src/connection-helpers.ts
@@ -10,7 +10,12 @@ import {
 import { createNode } from '@pothos/selection-mapper';
 import type { PrismaRef } from './interface-ref.js';
 import { ModelLoader } from './model-loader.js';
-import type { PrismaModelTypes, ShapeFromSelection, UniqueFieldsFromWhereUnique } from './types.js';
+import type {
+  PrismaModelTypes,
+  SelectionMap,
+  ShapeFromSelection,
+  UniqueFieldsFromWhereUnique,
+} from './types.js';
 import { prismaAdapter } from './util/adapter.js';
 import {
   getCursorFormatter,
@@ -55,6 +60,7 @@ export function prismaConnectionHelpers<
   }: {
     cursor: UniqueFieldsFromWhereUnique<Model['WhereUnique']>;
     select?: (
+      // The node's selection: its model is the connection field's, which the helper does not know.
       nestedSelection: <T extends true | {}>(selection?: T) => T,
       args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
       ctx: Types['Context'],
@@ -137,16 +143,21 @@ export function prismaConnectionHelpers<
   function getQuery(
     args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
     ctx: Types['Context'],
-    nestedSelection: <T extends true | {}>(selection?: T, path?: string[]) => T,
+    // The `nestedSelection` of the field's `select`, whatever model its type names.
+    nestedSelection: (selection?: SelectionMap | true, path?: string[]) => unknown,
   ) {
     // Both callbacks start now; the query waits for whichever of them is async (A-3, A-7: the
     // declared type stays synchronous, so an async schema awaits the result).
     const nestedSelect: MaybePromise<Record<string, unknown> | true> = select
       ? completeValue(
-          select((sel) => nestedSelection(sel, ['edges', 'node']), args, ctx),
+          select(
+            (sel) => nestedSelection(sel as SelectionMap, ['edges', 'node']) as never,
+            args,
+            ctx,
+          ),
           wrapSelect,
         )
-      : nestedSelection(true, ['edges', 'node']);
+      : (nestedSelection(true, ['edges', 'node']) as never);
     const baseQuery = typeof query === 'function' ? query(args, ctx) : (query ?? {});
 
     return (isThenable(nestedSelect) || isThenable(baseQuery)

--- a/packages/plugin-prisma/src/connection-helpers.ts
+++ b/packages/plugin-prisma/src/connection-helpers.ts
@@ -7,7 +7,7 @@ import {
   type ObjectRef,
   type SchemaTypes,
 } from '@pothos/core';
-import { createNode } from '@pothos/selection-mapper';
+import { createNode, type PathSegment } from '@pothos/selection-mapper';
 import type { PrismaRef } from './interface-ref.js';
 import { ModelLoader } from './model-loader.js';
 import type {
@@ -144,7 +144,7 @@ export function prismaConnectionHelpers<
     args: InputShapeFromFields<ExtraArgs> & PothosSchemaTypes.DefaultConnectionArguments,
     ctx: Types['Context'],
     // The `nestedSelection` of the field's `select`, whatever model its type names.
-    nestedSelection: (selection?: SelectionMap | true, path?: string[]) => unknown,
+    nestedSelection: (selection?: SelectionMap | true, path?: PathSegment[]) => unknown,
   ) {
     // Both callbacks start now; the query waits for whichever of them is async (A-3, A-7: the
     // declared type stays synchronous, so an async schema awaits the result).

--- a/packages/plugin-prisma/src/prisma-field-builder.ts
+++ b/packages/plugin-prisma/src/prisma-field-builder.ts
@@ -501,7 +501,7 @@ export class PrismaObjectFieldBuilder<
     }) as FieldRef<Types, Model['Relations'][Field]['Shape'], 'Object'>;
   }
 
-  relationCount<Field extends Model['RelationName'], Args extends InputFieldMap>(
+  relationCount<Field extends Model['ListRelations'], Args extends InputFieldMap>(
     name: Field,
     ...allArgs: NormalizeArgs<
       [

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -79,13 +79,19 @@ type ExtractModel<Types extends SchemaTypes, ParentShape> = ParentShape extends 
     : never
   : never;
 
-/** The model a field's type param names: a prisma ref, or a list of one. */
-export type ModelForTypeParam<Type> = Type extends [infer Item]
-  ? ModelForTypeParam<Item>
+/**
+ * The model a field's type param names: a prisma ref, the name of a prisma object type (one
+ * registered under its model's name, as `prismaObject` does without `name` or `variant`, and so
+ * a key of `Types['PrismaTypes']`), or a list of either.
+ */
+export type ModelForTypeParam<Types extends SchemaTypes, Type> = Type extends [infer Item]
+  ? ModelForTypeParam<Types, Item>
   : // biome-ignore lint/suspicious/noExplicitAny: matching against any ref
     Type extends PrismaRef<any, infer Model>
     ? Model
-    : never;
+    : Type extends keyof Types['PrismaTypes']
+      ? PrismaModelTypes & Types['PrismaTypes'][Type]
+      : never;
 
 /**
  * The query a relation of `Model` is loaded with: the arguments prisma accepts on a list relation
@@ -171,7 +177,7 @@ export type PrismaObjectFieldOptions<
         | ((
             args: InputShapeFromFields<Args>,
             ctx: Types['Context'],
-            nestedSelection: NestedSelectionFn<ModelForTypeParam<Type>>,
+            nestedSelection: NestedSelectionFn<ModelForTypeParam<Types, Type>>,
           ) => MaybePromise<ExtractModel<Types, ParentShape>['Select']>)
       );
   };

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -23,7 +23,12 @@ import {
   type TypeParam,
   typeBrandKey,
 } from '@pothos/core';
-import type { Mappings } from '@pothos/selection-mapper';
+import type {
+  IndirectInclude,
+  IndirectPathSegment,
+  Mappings,
+  PathSegment,
+} from '@pothos/selection-mapper';
 import type { FieldNode, GraphQLResolveInfo } from 'graphql';
 import type { PrismaInterfaceRef, PrismaRef } from './interface-ref.js';
 import type { PrismaObjectFieldBuilder } from './prisma-field-builder.js';
@@ -120,7 +125,7 @@ export type NestedSelectionFn<Model extends PrismaModelTypes> = <
   Selection extends boolean | ([Model] extends [never] ? {} : PrismaRelationQuery<Model>) = true,
 >(
   selection?: Selection,
-  path?: string[],
+  path?: PathSegment[],
   type?: string,
 ) => NestedSelectionResult<Selection, Model>;
 
@@ -841,7 +846,7 @@ export type FieldSelection =
           | SelectionMap
           | boolean
           | ((args: object, context: object) => MaybePromise<SelectionMap>),
-        path?: IndirectInclude | string[],
+        path?: IndirectInclude | PathSegment[],
         type?: string,
       ) => SelectionMap | boolean,
       resolveSelection: (path: string[]) => FieldNode | null,
@@ -853,11 +858,11 @@ export type FieldSelection =
  */
 export type LoaderMappings = Mappings;
 
-export interface IndirectInclude {
-  getType: () => string;
-  path?: { type?: string; name: string }[];
-  paths?: { type?: string; name: string }[][];
-}
+/**
+ * A segment of a `path` given to `queryFromInfo` or `nestedSelection`: a field name, or
+ * `{ name, type }` to pin the type the field must be selected under (a fragment on it).
+ */
+export type { IndirectInclude, IndirectPathSegment, PathSegment };
 
 export type ShapeFromConnection<T> = T extends { shape: unknown } ? T['shape'] : never;
 

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -211,6 +211,24 @@ export type ShapeFromSelection<
     : Model['Shape']
 >;
 
+/**
+ * The shape of a row of `Model` loaded with `Query` (a `select` or `include` map): what a
+ * resolver on the model's type sees when the row was planned with that query. For rows a
+ * resolver loads itself, so what is on them is named once, next to the query that loaded them.
+ * `Model` is the model's name, or its `PrismaModelTypes`.
+ */
+export type PrismaQueriedShape<
+  Types extends SchemaTypes,
+  Model extends keyof Types['PrismaTypes'] | PrismaModelTypes,
+  Query,
+> = ShapeFromSelection<
+  Types,
+  Model extends PrismaModelTypes
+    ? Model
+    : PrismaModelTypes & Types['PrismaTypes'][Model & keyof Types['PrismaTypes']],
+  Query
+>;
+
 export type ShapeFromCount<Selection> = Selection extends true
   ? { _count: number }
   : Selection extends { select: infer Counts }

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -127,15 +127,30 @@ export type NestedSelectionResult<Selection, Model extends PrismaModelTypes> = [
     : Normalize<Omit<PrismaRelationQuery<Model>, keyof Selection> & Selection>;
 
 /**
+ * The selection given to `nestedSelection`: the query itself, a promise of it, or a callback
+ * building it from the field's arguments and the context (which may be async). The result is
+ * typed by the query either way; it is a promise at runtime only when a promise or an async
+ * callback was given, or a selection beneath it is async, and must then be awaited.
+ */
+export type NestedSelectionArg<Selection, Args extends InputFieldMap, Context> =
+  | Selection
+  | PromiseLike<Selection>
+  | ((args: InputShapeFromFields<Args>, ctx: Context) => MaybePromise<Selection>);
+
+/**
  * The callback a field's `select` function plans the selection beneath the field with: `path`
  * walks a field nested under the field's type, `type` names the type the selection is read as.
  * The selection is typed by the field's model when it has one, so `select: { title: true }`
  * keeps its literal `true`.
  */
-export type NestedSelectionFn<Model extends PrismaModelTypes> = <
+export type NestedSelectionFn<
+  Model extends PrismaModelTypes,
+  Args extends InputFieldMap = {},
+  Context = object,
+> = <
   Selection extends boolean | ([Model] extends [never] ? {} : PrismaRelationQuery<Model>) = true,
 >(
-  selection?: Selection,
+  selection?: NestedSelectionArg<Selection, Args, Context>,
   path?: PathSegment[],
   type?: string,
 ) => NestedSelectionResult<Selection, Model>;
@@ -177,7 +192,11 @@ export type PrismaObjectFieldOptions<
         | ((
             args: InputShapeFromFields<Args>,
             ctx: Types['Context'],
-            nestedSelection: NestedSelectionFn<ModelForTypeParam<Types, Type>>,
+            nestedSelection: NestedSelectionFn<
+              ModelForTypeParam<Types, Type>,
+              Args,
+              Types['Context']
+            >,
           ) => MaybePromise<ExtractModel<Types, ParentShape>['Select']>)
       );
   };

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -213,14 +213,17 @@ export type ShapeFromSelection<
     ? // A `select` that is absent, or only possibly present (a planned relation query), does not
       // narrow the row: every column may be there.
       undefined extends Selection['select']
-      ? Model['Shape'] & RelationShapeFromInclude<Types, Model, Selection['include']>
-      : Pick<Model['Shape'], SelectedKeys<Selection['select']>> &
+      ? Model['Shape'] &
+          RelationShapeFromInclude<Types, Model, Selection['include']> &
+          ShapeFromCount<CountSelection<Selection['include']>, Model>
+      : Pick<Model['Shape'], SelectedKeys<Selection['select']> & keyof Model['Shape']> &
           RelationShapeFromInclude<Types, Model, Selection['select']> &
-          ('_count' extends keyof Selection['select']
-            ? ShapeFromCount<Selection['select']['_count']>
-            : {})
+          ShapeFromCount<CountSelection<Selection['select']>, Model>
     : Model['Shape']
 >;
+
+/** The `_count` entry of a `select` or `include` map, or `undefined` when there is none. */
+type CountSelection<Map> = Map extends { _count?: infer Count } ? Count : undefined;
 
 /**
  * The shape of a row of `Model` loaded with `Query` (a `select` or `include` map): what a
@@ -240,11 +243,18 @@ export type PrismaQueriedShape<
   Query
 >;
 
-export type ShapeFromCount<Selection> = Selection extends true
-  ? { _count: number }
+/**
+ * What a `_count` selection adds to a row, as prisma returns it: `_count: true` counts every list
+ * relation of `Model`, `_count: { select }` the selected ones, and each count is a number.
+ */
+export type ShapeFromCount<
+  Selection,
+  Model extends PrismaModelTypes = PrismaModelTypes,
+> = Selection extends true
+  ? { _count: { [K in Model['ListRelations']]: number } }
   : Selection extends { select: infer Counts }
-    ? { _count: { [K in keyof Counts]: number } }
-    : never;
+    ? { _count: { [K in SelectedKeys<Counts>]: number } }
+    : {};
 
 export type TypesForRelation<
   Types extends SchemaTypes,

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -88,17 +88,22 @@ export type ModelForTypeParam<Type> = Type extends [infer Item]
     : never;
 
 /**
- * The query a relation of `Model` is loaded with: the arguments prisma accepts on the relation,
- * and the `select` or `include` the planner adds beneath it.
+ * The query a relation of `Model` is loaded with: the arguments prisma accepts on a list relation
+ * (the generated `Parent$relationArgs`, which `PrismaModelTypes` does not carry, so the keys are
+ * named here from what it does carry), and the `select` or `include` the planner adds beneath it.
+ * The scalar fields of the model are the keys of its `Shape`, so `omit` and `distinct` are typed
+ * by them.
  */
 export interface PrismaRelationQuery<Model extends PrismaModelTypes> {
   select?: Model['Select'];
   include?: Model['Include'];
+  omit?: { [K in keyof Model['Shape']]?: boolean };
   where?: Model['Where'];
   orderBy?: Model['OrderBy'] | Model['OrderBy'][];
   cursor?: Model['WhereUnique'];
   take?: number;
   skip?: number;
+  distinct?: (keyof Model['Shape'] & string) | (keyof Model['Shape'] & string)[];
 }
 
 /**

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -433,7 +433,12 @@ type QueryForField<
         ) => MaybePromise<Omit<Include, 'include' | 'select'>>)
   : never;
 
-type QueryFromRelation<
+/**
+ * The query a relation's fallback `resolve` is handed: the arguments prisma accepts on the
+ * relation (`where`, `orderBy`, `take`, ... for a list relation), with the planned `select` or
+ * `include` beneath it.
+ */
+export type QueryFromRelation<
   Model extends PrismaModelTypes,
   Field extends keyof Model['Include'],
 > = Model['Include'][Field] extends infer Include
@@ -441,7 +446,7 @@ type QueryFromRelation<
       include?: infer I;
       select?: infer S;
     }
-    ? {
+    ? Omit<Include, 'include' | 'select'> & {
         include?: NonNullable<I>;
         select?: NonNullable<S>;
       }

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -74,6 +74,56 @@ type ExtractModel<Types extends SchemaTypes, ParentShape> = ParentShape extends 
     : never
   : never;
 
+/** The model a field's type param names: a prisma ref, or a list of one. */
+export type ModelForTypeParam<Type> = Type extends [infer Item]
+  ? ModelForTypeParam<Item>
+  : // biome-ignore lint/suspicious/noExplicitAny: matching against any ref
+    Type extends PrismaRef<any, infer Model>
+    ? Model
+    : never;
+
+/**
+ * The query a relation of `Model` is loaded with: the arguments prisma accepts on the relation,
+ * and the `select` or `include` the planner adds beneath it.
+ */
+export interface PrismaRelationQuery<Model extends PrismaModelTypes> {
+  select?: Model['Select'];
+  include?: Model['Include'];
+  where?: Model['Where'];
+  orderBy?: Model['OrderBy'] | Model['OrderBy'][];
+  cursor?: Model['WhereUnique'];
+  take?: number;
+  skip?: number;
+}
+
+/**
+ * What `nestedSelection` returns: the relation query for `Model`, keeping the keys of the given
+ * selection as they were given (so a `select` in it still narrows the parent shape). With no
+ * selection, or `true`, it is the relation query itself. A field whose type has no model keeps
+ * the selection it was given.
+ */
+export type NestedSelectionResult<Selection, Model extends PrismaModelTypes> = [Model] extends [
+  never,
+]
+  ? Selection
+  : Selection extends boolean
+    ? PrismaRelationQuery<Model>
+    : Normalize<Omit<PrismaRelationQuery<Model>, keyof Selection> & Selection>;
+
+/**
+ * The callback a field's `select` function plans the selection beneath the field with: `path`
+ * walks a field nested under the field's type, `type` names the type the selection is read as.
+ * The selection is typed by the field's model when it has one, so `select: { title: true }`
+ * keeps its literal `true`.
+ */
+export type NestedSelectionFn<Model extends PrismaModelTypes> = <
+  Selection extends boolean | ([Model] extends [never] ? {} : PrismaRelationQuery<Model>) = true,
+>(
+  selection?: Selection,
+  path?: string[],
+  type?: string,
+) => NestedSelectionResult<Selection, Model>;
+
 export type PrismaObjectFieldOptions<
   Types extends SchemaTypes,
   ParentShape,
@@ -111,11 +161,7 @@ export type PrismaObjectFieldOptions<
         | ((
             args: InputShapeFromFields<Args>,
             ctx: Types['Context'],
-            nestedSelection: <Selection extends boolean | {}>(
-              selection?: Selection,
-              path?: string[],
-              type?: string,
-            ) => Selection,
+            nestedSelection: NestedSelectionFn<ModelForTypeParam<Type>>,
           ) => MaybePromise<ExtractModel<Types, ParentShape>['Select']>)
       );
   };
@@ -148,7 +194,9 @@ export type ShapeFromSelection<
   Selection,
 > = Normalize<
   Selection extends BaseSelection
-    ? unknown extends Selection['select']
+    ? // A `select` that is absent, or only possibly present (a planned relation query), does not
+      // narrow the row: every column may be there.
+      undefined extends Selection['select']
       ? Model['Shape'] & RelationShapeFromInclude<Types, Model, Selection['include']>
       : Pick<Model['Shape'], SelectedKeys<Selection['select']>> &
           RelationShapeFromInclude<Types, Model, Selection['select']> &

--- a/packages/plugin-prisma/src/util/map-query.ts
+++ b/packages/plugin-prisma/src/util/map-query.ts
@@ -11,15 +11,20 @@ import { type PrismaWalk, prismaAdapter } from './adapter.js';
 export { selectedFieldNames };
 
 /**
- * What `queryFromInfo` returns: the shape that was passed in, or, when neither `select` nor
- * `include` was given, whichever of the two the walked type's mode produced. Both keys are
- * optional so the result spreads into a prisma call either way.
+ * What `queryFromInfo` returns. The walked type's mode wins: a given `include` puts the query in
+ * include mode, so the result is `{ include }`; with neither given it is whichever of the two the
+ * mode produced, both optional so the result spreads into a prisma call either way. A given
+ * `select` is kept as `{ select }` by a type in select mode, but a type in include mode merges it
+ * into an `include` query (`{ include }`, or `{}` when nothing is included), so the result is the
+ * union of the two; the selected columns are on the rows in both.
  */
 export type QueryFromInfoResult<Select, Include> = undefined extends Select
   ? undefined extends Include
     ? { select?: SelectionMap['select']; include?: SelectionMap['include'] }
     : { include: Include }
-  : { select: Select };
+  :
+      | { select: Select; include?: undefined }
+      | { select?: undefined; include?: SelectionMap['include'] };
 
 /**
  * The query for the field `info` resolves. A given `select` is merged as the initial selection;

--- a/packages/plugin-prisma/src/util/map-query.ts
+++ b/packages/plugin-prisma/src/util/map-query.ts
@@ -1,4 +1,5 @@
 import {
+  type PathSegment,
   selectedFieldNames,
   queryFromInfo as walkQueryFromInfo,
   selectionStateFromInfo as walkSelectionStateFromInfo,
@@ -42,8 +43,8 @@ export function queryFromInfo<
   context: object;
   info: GraphQLResolveInfo;
   typeName?: string;
-  path?: (string | { name: string; type?: string })[];
-  paths?: (string | { name: string; type?: string })[][];
+  path?: PathSegment[];
+  paths?: PathSegment[][];
   withUsageCheck?: boolean;
   skipDeferredFragments?: boolean;
 } & (

--- a/packages/plugin-prisma/src/util/map-query.ts
+++ b/packages/plugin-prisma/src/util/map-query.ts
@@ -9,9 +9,25 @@ import { type PrismaWalk, prismaAdapter } from './adapter.js';
 
 export { selectedFieldNames };
 
+/**
+ * What `queryFromInfo` returns: the shape that was passed in, or, when neither `select` nor
+ * `include` was given, whichever of the two the walked type's mode produced. Both keys are
+ * optional so the result spreads into a prisma call either way.
+ */
+export type QueryFromInfoResult<Select, Include> = undefined extends Select
+  ? undefined extends Include
+    ? { select?: SelectionMap['select']; include?: SelectionMap['include'] }
+    : { include: Include }
+  : { select: Select };
+
+/**
+ * The query for the field `info` resolves. A given `select` is merged as the initial selection;
+ * for a type in include mode the walk still produces `include`, with the columns of that
+ * `select` implied by the row.
+ */
 export function queryFromInfo<
   Select extends SelectionMap['select'] | undefined = undefined,
-  Include extends SelectionMap['select'] | undefined = undefined,
+  Include extends SelectionMap['include'] | undefined = undefined,
 >({
   context,
   info,
@@ -33,11 +49,7 @@ export function queryFromInfo<
 } & (
   | { include?: Include; select?: never }
   | { select?: Select; include?: never }
-)): undefined extends Include
-  ? {
-      select: Select;
-    }
-  : { include: Include } {
+)): QueryFromInfoResult<Select, Include> {
   return walkQueryFromInfo(prismaAdapter, {
     context,
     info,

--- a/packages/plugin-prisma/tests/example/schema/index.ts
+++ b/packages/plugin-prisma/tests/example/schema/index.ts
@@ -129,24 +129,18 @@ const Viewer = builder.prismaInterface('User', {
       type: PostRef,
       args: postConnectionHelpers.getArgs(),
       resolve: async (user, args, ctx, info) => {
+        // The nodes are posts reached through the viewer's comments: the post query is planned
+        // from the connection's `edges { node }` selection and nested under `post`.
         const comments = await prisma.comment.findMany({
-          ...(queryFromInfo({
-            context: ctx,
-            info,
-            path: ['edges', 'node'],
-            select: {
-              post: {
-                include: {
-                  author: true,
-                  comments: true,
-                },
-              },
-            },
-          }) as {
-            include: {
-              post: { include: { comments: { include: { author: true } } } };
-            };
-          }),
+          select: {
+            id: true,
+            post: queryFromInfo({
+              context: ctx,
+              info,
+              path: ['edges', 'node'],
+              include: { comments: { include: { author: true } } },
+            }),
+          },
           where: {
             authorId: user.id,
           },

--- a/packages/plugin-prisma/tests/example/schema/index.ts
+++ b/packages/plugin-prisma/tests/example/schema/index.ts
@@ -300,7 +300,7 @@ const User = builder.prismaNode('User', {
       resolve: (query, user) =>
         prisma.post.findMany({
           ...query,
-          where: { ...(query as { where?: object }).where, authorId: user.id },
+          where: { ...query.where, authorId: user.id },
         }),
     }),
     postNodes: t.relation('posts', {
@@ -320,7 +320,7 @@ const User = builder.prismaNode('User', {
       resolve: (query, user) =>
         prisma.post.findMany({
           ...query,
-          where: { ...(query as { where?: object }).where, authorId: user.id },
+          where: { ...query.where, authorId: user.id },
         }),
     }),
     postsConnection: t.relatedConnection(

--- a/packages/plugin-prisma/tests/nested-selection-typed-path.test.ts
+++ b/packages/plugin-prisma/tests/nested-selection-typed-path.test.ts
@@ -1,0 +1,164 @@
+import SchemaBuilder from '@pothos/core';
+import { execute } from '@pothos/test-utils';
+import { gql } from 'graphql-tag';
+import PrismaPlugin, { type PrismaTypesFromClient } from '../src';
+import type { Post as PostRow } from './client/client.js';
+import { prisma, queries } from './example/builder';
+import { getDatamodel } from './generated.js';
+
+// Two implementations of an interface expose the same field, returning the same model. A path
+// handed to `nestedSelection` can pin the implementation a segment is found under with a
+// `{ name, type }` segment, like a `queryFromInfo` path can.
+const builder = new SchemaBuilder<{
+  PrismaTypes: PrismaTypesFromClient<typeof prisma>;
+}>({
+  plugins: [PrismaPlugin],
+  prisma: {
+    client: () => prisma,
+    dmmf: getDatamodel(),
+  },
+});
+
+const Post = builder.prismaObject('Post', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    author: t.relation('author'),
+    comments: t.relation('comments'),
+  }),
+});
+
+builder.prismaObject('Comment', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+
+interface EntryShape {
+  kind: 'draft' | 'post';
+  post: PostRow;
+}
+
+const Entry = builder.interfaceRef<EntryShape>('Entry').implement({
+  fields: (t) => ({
+    kind: t.exposeString('kind'),
+    post: t.field({
+      type: Post,
+      resolve: (entry) => entry.post,
+    }),
+  }),
+  resolveType: (entry) => (entry.kind === 'post' ? 'PostEntry' : 'DraftEntry'),
+});
+
+builder.objectRef<EntryShape>('PostEntry').implement({ interfaces: [Entry] });
+builder.objectRef<EntryShape>('DraftEntry').implement({ interfaces: [Entry] });
+
+const User = builder.prismaObject('User', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    entries: t.field({
+      type: [Entry],
+      select: (_args, _ctx, nestedSelection) => ({
+        // Only what is selected on `post` under a fragment on PostEntry is planned.
+        posts: nestedSelection({ take: 1 }, [{ name: 'post', type: 'PostEntry' }]),
+      }),
+      resolve: (user) => user.posts.map((post) => ({ kind: 'post' as const, post })),
+    }),
+    allEntries: t.field({
+      type: [Entry],
+      select: (_args, _ctx, nestedSelection) => ({
+        // A plain segment merges what every implementation selects on `post`.
+        posts: nestedSelection({ take: 1 }, ['post']),
+      }),
+      resolve: (user) => user.posts.map((post) => ({ kind: 'post' as const, post })),
+    }),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    user: t.prismaField({
+      type: User,
+      resolve: (query) => prisma.user.findUniqueOrThrow({ ...query, where: { id: 1 } }),
+    }),
+  }),
+});
+
+const schema = builder.toSchema();
+
+const document = (field: string) => gql`
+  query {
+    user {
+      ${field} {
+        kind
+        ... on PostEntry {
+          post {
+            id
+            comments {
+              id
+            }
+          }
+        }
+        ... on DraftEntry {
+          post {
+            id
+            author {
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+`;
+
+describe('nestedSelection with a typed path segment', () => {
+  afterEach(() => {
+    queries.length = 0;
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('plans only the selection found under the pinned type', async () => {
+    const result = await execute({ schema, document: document('entries'), contextValue: {} });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      user: {
+        entries: [
+          {
+            kind: 'post',
+            post: { id: expect.any(String), comments: expect.any(Array) },
+          },
+        ],
+      },
+    });
+    expect(queries).toEqual([
+      {
+        action: 'findUniqueOrThrow',
+        model: 'User',
+        args: {
+          include: { posts: { take: 1, include: { comments: true } } },
+          where: { id: 1 },
+        },
+      },
+    ]);
+  });
+
+  it('merges every implementation with a plain segment', async () => {
+    const result = await execute({ schema, document: document('allEntries'), contextValue: {} });
+
+    expect(result.errors).toBeUndefined();
+    expect(queries).toEqual([
+      {
+        action: 'findUniqueOrThrow',
+        model: 'User',
+        args: {
+          include: { posts: { take: 1, include: { comments: true, author: true } } },
+          where: { id: 1 },
+        },
+      },
+    ]);
+  });
+});

--- a/packages/plugin-prisma/tests/selection-types.test-d.ts
+++ b/packages/plugin-prisma/tests/selection-types.test-d.ts
@@ -157,6 +157,53 @@ builder.prismaObject('User', {
   }),
 });
 
+// A field whose type is the name of a prisma object type (registered under its model's name) gets
+// the same model inference as one typed with the ref.
+const stringBuilder = new SchemaBuilder<{
+  PrismaTypes: PrismaTypes;
+  Objects: { Post: PrismaTypes['Post']['Shape']; Profile: PrismaTypes['Profile']['Shape'] };
+}>({
+  plugins: [PrismaPlugin],
+  prisma: {
+    client: () => null as never,
+    dmmf: getDatamodel(),
+  },
+});
+
+stringBuilder.prismaObject('Post', { fields: (t) => ({ id: t.exposeID('id') }) });
+stringBuilder.prismaObject('Profile', { fields: (t) => ({ id: t.exposeID('id') }) });
+
+stringBuilder.prismaObject('User', {
+  fields: (t) => ({
+    latestPosts: t.field({
+      type: ['Post'],
+      select: (_args, _ctx, nestedSelection) => {
+        expectTypeOf(nestedSelection()).toEqualTypeOf<PrismaRelationQuery<PrismaTypes['Post']>>();
+
+        const query = nestedSelection({ take: 1 });
+
+        expectTypeOf(query.take).toEqualTypeOf<number>();
+        expectTypeOf(query.select).toEqualTypeOf<PrismaTypes['Post']['Select'] | undefined>();
+
+        return { posts: query };
+      },
+      resolve: (user) => user.posts,
+    }),
+    profile: t.field({
+      type: 'Profile',
+      nullable: true,
+      select: (_args, _ctx, nestedSelection) => {
+        expectTypeOf(nestedSelection({ select: { bio: true } }).select).toEqualTypeOf<{
+          bio: true;
+        }>();
+
+        return { profile: nestedSelection() };
+      },
+      resolve: (user) => user.profile,
+    }),
+  }),
+});
+
 // A relation's fallback `resolve` is handed the relation's own query: prisma's arguments for
 // the relation, with the planned `select`/`include`, so it spreads into a query without a cast.
 builder.prismaObject('Comment', {

--- a/packages/plugin-prisma/tests/selection-types.test-d.ts
+++ b/packages/plugin-prisma/tests/selection-types.test-d.ts
@@ -159,6 +159,34 @@ builder.prismaObject('Comment', {
   }),
 });
 
+// A `t.prismaField` on a prisma object takes a `select` planned into the parent row, and still
+// receives the query for its own model (the docs' "Selections on t.prismaField" example).
+builder.prismaObject('User', {
+  variant: 'SelectUser',
+  select: { email: true },
+  fields: (t) => ({
+    email: t.exposeString('email'),
+    latestPost: t.prismaField({
+      type: 'Post',
+      nullable: true,
+      select: { id: true },
+      resolve: (query, user) => {
+        expectTypeOf(user.id).toEqualTypeOf<number>();
+        expectTypeOf(query).toEqualTypeOf<{
+          include?: PrismaTypes['Post']['Include'];
+          select?: PrismaTypes['Post']['Select'];
+        }>();
+
+        return prisma.post.findFirst({
+          ...query,
+          where: { authorId: user.id },
+          orderBy: { createdAt: 'desc' },
+        });
+      },
+    }),
+  }),
+});
+
 // Only a list relation can be counted.
 builder.prismaObjectFields('User', (t) => ({
   postCount: t.relationCount('posts'),

--- a/packages/plugin-prisma/tests/selection-types.test-d.ts
+++ b/packages/plugin-prisma/tests/selection-types.test-d.ts
@@ -293,6 +293,49 @@ it('names the shape of a row loaded with a query', () => {
     PrismaTypes['User']['Shape']
   >();
 
+  // `_count` is typed as prisma returns it, in a `select` or an `include`: `true` counts every
+  // list relation, `{ select }` the selected ones.
+  expectTypeOf<
+    PrismaQueriedShape<Types, 'User', { select: { id: true; _count: true } }>
+  >().toEqualTypeOf<{
+    id: number;
+    _count: {
+      posts: number;
+      comments: number;
+      followers: number;
+      following: number;
+      Media: number;
+    };
+  }>();
+  expectTypeOf<
+    PrismaQueriedShape<Types, 'User', { select: { _count: { select: { posts: true } } } }>
+  >().toEqualTypeOf<{ _count: { posts: number } }>();
+  expectTypeOf<
+    PrismaQueriedShape<Types, 'User', { include: { _count: { select: { posts: true } } } }>
+  >().toEqualTypeOf<{
+    id: number;
+    email: string;
+    name: string | null;
+    _count: { posts: number };
+  }>();
+  expectTypeOf<PrismaQueriedShape<Types, 'User', { include: { _count: true } }>>()
+    .toHaveProperty('_count')
+    .toEqualTypeOf<{
+      posts: number;
+      comments: number;
+      followers: number;
+      following: number;
+      Media: number;
+    }>();
+  // A count with a filter is still a number.
+  expectTypeOf<
+    PrismaQueriedShape<
+      Types,
+      'User',
+      { select: { _count: { select: { posts: { where: { published: true } } } } } }
+    >
+  >().toEqualTypeOf<{ _count: { posts: number } }>();
+
   // The model can be given as its types rather than its name.
   expectTypeOf<
     PrismaQueriedShape<Types, PrismaTypes['User'], { select: { email: true } }>

--- a/packages/plugin-prisma/tests/selection-types.test-d.ts
+++ b/packages/plugin-prisma/tests/selection-types.test-d.ts
@@ -158,6 +158,13 @@ builder.prismaObject('Comment', {
   }),
 });
 
+// Only a list relation can be counted.
+builder.prismaObjectFields('User', (t) => ({
+  postCount: t.relationCount('posts'),
+  // @ts-expect-error a to-one relation has no count
+  profileCount: t.relationCount('profile'),
+}));
+
 builder.prismaObjectField('User', 'publishedPosts', (t) =>
   t.relation('posts', {
     query: { where: { published: true } },

--- a/packages/plugin-prisma/tests/selection-types.test-d.ts
+++ b/packages/plugin-prisma/tests/selection-types.test-d.ts
@@ -9,6 +9,7 @@ import PrismaPlugin, {
   type PrismaRelationQuery,
   type PrismaTypesFromClient,
   prismaConnectionHelpers,
+  type QueryFromRelation,
   queryFromInfo,
   type SelectionMap,
 } from '../src';
@@ -138,6 +139,41 @@ builder.prismaObject('User', {
     }),
   }),
 });
+
+// A relation's fallback `resolve` is handed the relation's own query: prisma's arguments for
+// the relation, with the planned `select`/`include`, so it spreads into a query without a cast.
+builder.prismaObject('Comment', {
+  fields: (t) => ({
+    author: t.relation('author', {
+      resolve: (query, comment) => {
+        expectTypeOf(query).toEqualTypeOf<QueryFromRelation<PrismaTypes['Comment'], 'author'>>();
+        expectTypeOf(query.select).toEqualTypeOf<PrismaTypes['User']['Select'] | undefined>();
+        expectTypeOf(query.include).toEqualTypeOf<PrismaTypes['User']['Include'] | undefined>();
+        // @ts-expect-error a to-one relation has no `take`
+        expectTypeOf(query.take);
+
+        return prisma.user.findUniqueOrThrow({ ...query, where: { id: comment.authorId } });
+      },
+    }),
+  }),
+});
+
+builder.prismaObjectField('User', 'publishedPosts', (t) =>
+  t.relation('posts', {
+    query: { where: { published: true } },
+    resolve: (query, user) => {
+      expectTypeOf(query.where).toEqualTypeOf<PrismaTypes['Post']['Where'] | undefined>();
+      expectTypeOf(query.take).toEqualTypeOf<number | undefined>();
+      expectTypeOf(query.skip).toEqualTypeOf<number | undefined>();
+      expectTypeOf(query.cursor).toEqualTypeOf<PrismaTypes['Post']['WhereUnique'] | undefined>();
+      expectTypeOf(query.orderBy).toEqualTypeOf<
+        PrismaTypes['Post']['OrderBy'] | PrismaTypes['Post']['OrderBy'][] | undefined
+      >();
+
+      return prisma.post.findMany({ ...query, where: { ...query.where, authorId: user.id } });
+    },
+  }),
+);
 
 // One path segment type, shared with the planner, for `queryFromInfo` paths, `nestedSelection`
 // paths, and the `IndirectInclude` a type's extensions carry.

--- a/packages/plugin-prisma/tests/selection-types.test-d.ts
+++ b/packages/plugin-prisma/tests/selection-types.test-d.ts
@@ -395,24 +395,28 @@ it('re-exports the shared path segment types', () => {
     .toEqualTypeOf<PathSegment[] | undefined>();
 });
 
-// `queryFromInfo` is typed by what it was given: the `select` or `include` passed in, or, when
-// neither was, whichever of the two the walked type's mode produces (both optional, so the
-// result spreads into a prisma call).
+// `queryFromInfo` is typed by what it was given and by what the walked type's mode can make of
+// it: an `include` passed in, or, when neither was, whichever of the two the mode produces (both
+// optional, so the result spreads into a prisma call). A given `select` is kept by a type in
+// select mode, and merged into an `include` query by a type in include mode, so the result is the
+// union of the two.
 it('types queryFromInfo by what was passed', () => {
   expectTypeOf(queryFromInfo({ context, info })).toEqualTypeOf<{
     select?: SelectionMap['select'];
     include?: SelectionMap['include'];
   }>();
 
-  expectTypeOf(queryFromInfo({ context, info, select: { id: true } })).toEqualTypeOf<{
-    select: { id: true };
-  }>();
+  expectTypeOf(queryFromInfo({ context, info, select: { id: true } })).toEqualTypeOf<
+    | { select: { id: true }; include?: undefined }
+    | { select?: undefined; include?: SelectionMap['include'] }
+  >();
 
   expectTypeOf(queryFromInfo({ context, info, include: { posts: true } })).toEqualTypeOf<{
     include: { posts: true };
   }>();
 
-  // Both spread into a prisma call without a cast; a given select narrows the rows.
+  // All three spread into a prisma call without a cast. The columns of a given select are on the
+  // rows either way (an include-mode query loads every column).
   expectTypeOf(
     prisma.user.findMany({ ...queryFromInfo({ context, info }), where: { id: 1 } }),
   ).resolves.items.toMatchTypeOf<{ id: number; email: string }>();
@@ -421,5 +425,11 @@ it('types queryFromInfo by what was passed', () => {
       ...queryFromInfo({ context, info, select: { email: true } }),
       where: { id: 1 },
     }),
-  ).resolves.items.toEqualTypeOf<{ email: string }>();
+  ).resolves.items.toMatchTypeOf<{ email: string }>();
+  expectTypeOf(
+    prisma.user.findMany({
+      ...queryFromInfo({ context, info, include: { posts: true } }),
+      where: { id: 1 },
+    }),
+  ).resolves.items.toMatchTypeOf<{ email: string; posts: { title: string }[] }>();
 });

--- a/packages/plugin-prisma/tests/selection-types.test-d.ts
+++ b/packages/plugin-prisma/tests/selection-types.test-d.ts
@@ -6,6 +6,7 @@ import PrismaPlugin, {
   type IndirectInclude,
   type IndirectPathSegment,
   type PathSegment,
+  type PrismaQueriedShape,
   type PrismaRelationQuery,
   type PrismaTypesFromClient,
   prismaConnectionHelpers,
@@ -181,6 +182,33 @@ builder.prismaObjectField('User', 'publishedPosts', (t) =>
     },
   }),
 );
+
+// `PrismaQueriedShape` names the row shape a query loads, for rows a resolver loads itself.
+it('names the shape of a row loaded with a query', () => {
+  type Types = typeof builder.$inferSchemaTypes;
+
+  expectTypeOf<
+    PrismaQueriedShape<Types, 'User', { select: { id: true; posts: { select: { title: true } } } }>
+  >().toEqualTypeOf<{ id: number; posts: { title: string }[] }>();
+
+  expectTypeOf<PrismaQueriedShape<Types, 'User', { include: { profile: true } }>>().toEqualTypeOf<{
+    id: number;
+    email: string;
+    name: string | null;
+    profile: { id: number; bio: string | null; userId: number } | null;
+  }>();
+
+  expectTypeOf<PrismaQueriedShape<Types, 'User', {}>>().toEqualTypeOf<
+    PrismaTypes['User']['Shape']
+  >();
+
+  // The model can be given as its types rather than its name.
+  expectTypeOf<
+    PrismaQueriedShape<Types, PrismaTypes['User'], { select: { email: true } }>
+  >().toEqualTypeOf<{
+    email: string;
+  }>();
+});
 
 // One path segment type, shared with the planner, for `queryFromInfo` paths, `nestedSelection`
 // paths, and the `IndirectInclude` a type's extensions carry.

--- a/packages/plugin-prisma/tests/selection-types.test-d.ts
+++ b/packages/plugin-prisma/tests/selection-types.test-d.ts
@@ -1,7 +1,11 @@
 import SchemaBuilder from '@pothos/core';
+import type * as SelectionMapper from '@pothos/selection-mapper';
 import type { GraphQLResolveInfo } from 'graphql';
 import { expectTypeOf, it } from 'vitest';
 import PrismaPlugin, {
+  type IndirectInclude,
+  type IndirectPathSegment,
+  type PathSegment,
   type PrismaRelationQuery,
   type PrismaTypesFromClient,
   prismaConnectionHelpers,
@@ -53,6 +57,11 @@ builder.prismaObject('User', {
         expectTypeOf(nestedSelection(true)).toEqualTypeOf<
           PrismaRelationQuery<PrismaTypes['Post']>
         >();
+
+        // A path segment is a name, or `{ name, type }`, as for `queryFromInfo`.
+        expectTypeOf(
+          nestedSelection({ take: 1 }, [{ name: 'post', type: 'PostEntry' }]),
+        ).toEqualTypeOf(nestedSelection({ take: 1 }, ['post']));
 
         const query = nestedSelection({ take: 1, where: { published: true } });
 
@@ -128,6 +137,20 @@ builder.prismaObject('User', {
       resolve: (user, args, ctx) => commentHelpers.resolve(user.comments, args, ctx),
     }),
   }),
+});
+
+// One path segment type, shared with the planner, for `queryFromInfo` paths, `nestedSelection`
+// paths, and the `IndirectInclude` a type's extensions carry.
+it('re-exports the shared path segment types', () => {
+  expectTypeOf<PathSegment>().toEqualTypeOf<SelectionMapper.PathSegment>();
+  expectTypeOf<IndirectPathSegment>().toEqualTypeOf<SelectionMapper.IndirectPathSegment>();
+  expectTypeOf<IndirectInclude>().toEqualTypeOf<SelectionMapper.IndirectInclude>();
+  expectTypeOf<PathSegment>().toEqualTypeOf<string | { name: string; type?: string }>();
+
+  expectTypeOf(queryFromInfo)
+    .parameter(0)
+    .toHaveProperty('path')
+    .toEqualTypeOf<PathSegment[] | undefined>();
 });
 
 // `queryFromInfo` is typed by what it was given: the `select` or `include` passed in, or, when

--- a/packages/plugin-prisma/tests/selection-types.test-d.ts
+++ b/packages/plugin-prisma/tests/selection-types.test-d.ts
@@ -1,0 +1,36 @@
+import type { GraphQLResolveInfo } from 'graphql';
+import { expectTypeOf, it } from 'vitest';
+import { queryFromInfo, type SelectionMap } from '../src';
+import { prisma } from './example/builder';
+
+declare const info: GraphQLResolveInfo;
+declare const context: {};
+
+// `queryFromInfo` is typed by what it was given: the `select` or `include` passed in, or, when
+// neither was, whichever of the two the walked type's mode produces (both optional, so the
+// result spreads into a prisma call).
+it('types queryFromInfo by what was passed', () => {
+  expectTypeOf(queryFromInfo({ context, info })).toEqualTypeOf<{
+    select?: SelectionMap['select'];
+    include?: SelectionMap['include'];
+  }>();
+
+  expectTypeOf(queryFromInfo({ context, info, select: { id: true } })).toEqualTypeOf<{
+    select: { id: true };
+  }>();
+
+  expectTypeOf(queryFromInfo({ context, info, include: { posts: true } })).toEqualTypeOf<{
+    include: { posts: true };
+  }>();
+
+  // Both spread into a prisma call without a cast; a given select narrows the rows.
+  expectTypeOf(
+    prisma.user.findMany({ ...queryFromInfo({ context, info }), where: { id: 1 } }),
+  ).resolves.items.toMatchTypeOf<{ id: number; email: string }>();
+  expectTypeOf(
+    prisma.user.findMany({
+      ...queryFromInfo({ context, info, select: { email: true } }),
+      where: { id: 1 },
+    }),
+  ).resolves.items.toEqualTypeOf<{ email: string }>();
+});

--- a/packages/plugin-prisma/tests/selection-types.test-d.ts
+++ b/packages/plugin-prisma/tests/selection-types.test-d.ts
@@ -14,6 +14,7 @@ import PrismaPlugin, {
   queryFromInfo,
   type SelectionMap,
 } from '../src';
+import type { Prisma } from './client/client';
 import { prisma } from './example/builder';
 import { getDatamodel } from './generated.js';
 
@@ -64,6 +65,21 @@ builder.prismaObject('User', {
         expectTypeOf(
           nestedSelection({ take: 1 }, [{ name: 'post', type: 'PostEntry' }]),
         ).toEqualTypeOf(nestedSelection({ take: 1 }, ['post']));
+
+        // Every argument prisma accepts on a list relation is accepted, `omit` and `distinct`
+        // among them, and the query is one prisma accepts for the relation.
+        expectTypeOf(nestedSelection({ omit: { content: true } }).omit).toEqualTypeOf<{
+          content: true;
+        }>();
+        expectTypeOf(
+          nestedSelection({ distinct: 'title' as const }).distinct,
+        ).toEqualTypeOf<'title'>();
+        expectTypeOf(nestedSelection({ distinct: ['title', 'content'] }).distinct).toEqualTypeOf<
+          ('title' | 'content')[]
+        >();
+        expectTypeOf<
+          PrismaRelationQuery<PrismaTypes['Post']>
+        >().toMatchTypeOf<Prisma.User$postsArgs>();
 
         const query = nestedSelection({ take: 1, where: { published: true } });
 

--- a/packages/plugin-prisma/tests/selection-types.test-d.ts
+++ b/packages/plugin-prisma/tests/selection-types.test-d.ts
@@ -98,6 +98,43 @@ builder.prismaObject('User', {
         return user.posts;
       },
     }),
+    // The selection may also be a callback of the field's arguments and context, or a promise;
+    // the result is typed by the query either way.
+    recentPosts: t.field({
+      type: [Post],
+      args: { limit: t.arg.int() },
+      select: (_args, _ctx, nestedSelection) => {
+        const query = nestedSelection((args, ctx) => {
+          expectTypeOf(args).toEqualTypeOf<{ limit?: number | null }>();
+          expectTypeOf(ctx).toEqualTypeOf<{}>();
+
+          return { take: args.limit ?? 1 };
+        });
+
+        expectTypeOf(query.take).toEqualTypeOf<number>();
+        expectTypeOf(query.select).toEqualTypeOf<PrismaTypes['Post']['Select'] | undefined>();
+
+        return { posts: query };
+      },
+      resolve: (user) => user.posts,
+    }),
+    awaitedPosts: t.field({
+      type: [Post],
+      select: async (_args, _ctx, nestedSelection) => {
+        const query = await nestedSelection(Promise.resolve({ take: 1 }));
+        const fromAsyncCallback = await nestedSelection(async () => ({ skip: 1 }));
+
+        expectTypeOf(query.take).toEqualTypeOf<number>();
+        expectTypeOf(query.include).toEqualTypeOf<PrismaTypes['Post']['Include'] | undefined>();
+        expectTypeOf(fromAsyncCallback.skip).toEqualTypeOf<number>();
+        expectTypeOf(fromAsyncCallback.select).toEqualTypeOf<
+          PrismaTypes['Post']['Select'] | undefined
+        >();
+
+        return { posts: query };
+      },
+      resolve: (user) => user.posts,
+    }),
     postTitles: t.stringList({
       // A field type without a model keeps the given selection.
       select: (_args, _ctx, nestedSelection) => ({

--- a/packages/plugin-prisma/tests/selection-types.test-d.ts
+++ b/packages/plugin-prisma/tests/selection-types.test-d.ts
@@ -1,10 +1,134 @@
+import SchemaBuilder from '@pothos/core';
 import type { GraphQLResolveInfo } from 'graphql';
 import { expectTypeOf, it } from 'vitest';
-import { queryFromInfo, type SelectionMap } from '../src';
+import PrismaPlugin, {
+  type PrismaRelationQuery,
+  type PrismaTypesFromClient,
+  prismaConnectionHelpers,
+  queryFromInfo,
+  type SelectionMap,
+} from '../src';
 import { prisma } from './example/builder';
+import { getDatamodel } from './generated.js';
 
 declare const info: GraphQLResolveInfo;
 declare const context: {};
+
+type PrismaTypes = PrismaTypesFromClient<typeof prisma>;
+
+const builder = new SchemaBuilder<{ PrismaTypes: PrismaTypes }>({
+  plugins: [PrismaPlugin],
+  prisma: {
+    client: () => null as never,
+    dmmf: getDatamodel(),
+  },
+});
+
+const Post = builder.prismaObject('Post', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+
+const Profile = builder.prismaObject('Profile', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+  }),
+});
+
+const commentHelpers = prismaConnectionHelpers(builder, 'Comment', {
+  cursor: 'id',
+  select: (nodeSelection) => ({ id: true, post: nodeSelection() }),
+  resolveNode: (comment) => comment.post,
+});
+
+// `nestedSelection` is typed as the relation query for the field's model, keeping the keys it
+// was given, so a `select` in it still narrows the parent shape.
+builder.prismaObject('User', {
+  fields: (t) => ({
+    latestPosts: t.field({
+      type: [Post],
+      select: (_args, _ctx, nestedSelection) => {
+        expectTypeOf(nestedSelection()).toEqualTypeOf<PrismaRelationQuery<PrismaTypes['Post']>>();
+        expectTypeOf(nestedSelection(true)).toEqualTypeOf<
+          PrismaRelationQuery<PrismaTypes['Post']>
+        >();
+
+        const query = nestedSelection({ take: 1, where: { published: true } });
+
+        expectTypeOf(query.take).toEqualTypeOf<number>();
+        // The given keys are typed by the model's query, so literals are kept.
+        expectTypeOf(query.where).toEqualTypeOf<{ published: true }>();
+        expectTypeOf(query.select).toEqualTypeOf<PrismaTypes['Post']['Select'] | undefined>();
+        expectTypeOf(query.include).toEqualTypeOf<PrismaTypes['Post']['Include'] | undefined>();
+
+        return { posts: query };
+      },
+      resolve: (user) => {
+        // A relation query without a `select` of its own loads every column.
+        expectTypeOf(user.posts[0].title).toEqualTypeOf<string>();
+
+        return user.posts;
+      },
+    }),
+    postTitles: t.stringList({
+      // A field type without a model keeps the given selection.
+      select: (_args, _ctx, nestedSelection) => ({
+        posts: nestedSelection({ select: { title: true } }),
+      }),
+      resolve: (user) => {
+        expectTypeOf(user.posts[0]).toEqualTypeOf<{ title: string }>();
+
+        return user.posts.map((post) => post.title);
+      },
+    }),
+    bio: t.string({
+      nullable: true,
+      select: (_args, _ctx, nestedSelection) => {
+        // A field type without a model keeps the given selection.
+        expectTypeOf(nestedSelection({ select: { bio: true } })).toEqualTypeOf<{
+          select: { bio: boolean };
+        }>();
+
+        return { profile: nestedSelection({ select: { bio: true } }) };
+      },
+      resolve: (user) => {
+        // A `select` given to `nestedSelection` narrows the parent shape as before.
+        expectTypeOf(user.profile).toEqualTypeOf<{ bio: string | null } | null>();
+
+        return user.profile?.bio;
+      },
+    }),
+    profile: t.field({
+      type: Profile,
+      nullable: true,
+      select: (_args, _ctx, nestedSelection) => {
+        // The given selection's keys are kept as given, with the literal `true`.
+        const query = nestedSelection({ select: { bio: true } });
+
+        expectTypeOf(query.select).toEqualTypeOf<{ bio: true }>();
+        expectTypeOf(query).toMatchTypeOf<
+          Omit<PrismaRelationQuery<PrismaTypes['Profile']>, 'select'>
+        >();
+
+        return { profile: nestedSelection() };
+      },
+      resolve: (user) => {
+        expectTypeOf(user.profile).toEqualTypeOf<PrismaTypes['Profile']['Shape'] | null>();
+
+        return user.profile;
+      },
+    }),
+    comments: t.connection({
+      type: Post,
+      // The field's nested selection is accepted by the helpers' `getQuery`.
+      select: (args, ctx, nestedSelection) => ({
+        comments: commentHelpers.getQuery(args, ctx, nestedSelection),
+      }),
+      resolve: (user, args, ctx) => commentHelpers.resolve(user.comments, args, ctx),
+    }),
+  }),
+});
 
 // `queryFromInfo` is typed by what it was given: the `select` or `include` passed in, or, when
 // neither was, whichever of the two the walked type's mode produces (both optional, so the

--- a/packages/selection-mapper/src/matches.ts
+++ b/packages/selection-mapper/src/matches.ts
@@ -443,28 +443,48 @@ function resolveFragmentTypes(
 }
 
 /**
- * Turns a plain string path handed to `nestedSelection` into an include. Segments intentionally
- * omit `type`: a segment `type` pins the fragment type condition the field must be found under,
- * which is not known for a plain string path. The walker narrows through fragments on its own.
+ * Turns a path handed to `nestedSelection` into an include. A string segment is a field of the
+ * type the previous segment reached; the walker narrows through fragments on its own. A
+ * `{ name, type }` segment pins the fragment type condition the field must be found under, and
+ * is a field of that type.
  */
 export function normalizeInclude(
-  path: string[],
+  path: PathSegment[],
   type: GraphQLNamedType,
-  expectedType?: GraphQLNamedType,
+  expectedType: GraphQLNamedType | undefined,
+  schema: GraphQLSchema,
 ): IndirectInclude {
   let currentType = path.length > 0 ? type : (expectedType ?? type);
 
-  const normalized: { name: string }[] = [];
+  const normalized: IndirectPathSegment[] = [];
 
-  if (!(isObjectType(currentType) || isInterfaceType(currentType))) {
+  if (path.length === 0 && !(isObjectType(currentType) || isInterfaceType(currentType))) {
     throw new PothosValidationError(`Expected ${currentType} to be an Object type`);
   }
 
-  for (const fieldName of path) {
-    const field: GraphQLField<unknown, unknown> = currentType.getFields()[fieldName];
+  for (const segment of path) {
+    const { name, type: pinned } = typeof segment === 'string' ? { name: segment } : segment;
+
+    if (pinned) {
+      const pinnedType = schema.getType(pinned);
+
+      if (!pinnedType) {
+        throw new PothosValidationError(
+          `Unknown type ${pinned} in nested selection path segment ${name}`,
+        );
+      }
+
+      currentType = pinnedType;
+    }
+
+    if (!(isObjectType(currentType) || isInterfaceType(currentType))) {
+      throw new PothosValidationError(`Expected ${currentType} to be an Object type`);
+    }
+
+    const field: GraphQLField<unknown, unknown> = currentType.getFields()[name];
 
     if (!field) {
-      throw new PothosValidationError(`Expected ${currentType} to have a field ${fieldName}`);
+      throw new PothosValidationError(`Expected ${currentType} to have a field ${name}`);
     }
 
     currentType = getNamedType(field.type);
@@ -473,7 +493,7 @@ export function normalizeInclude(
       throw new PothosValidationError(`Expected ${currentType} to be an Object or Interface type`);
     }
 
-    normalized.push({ name: fieldName });
+    normalized.push(pinned ? { name, type: pinned } : { name });
   }
 
   const targetType = currentType;

--- a/packages/selection-mapper/src/walk.ts
+++ b/packages/selection-mapper/src/walk.ts
@@ -51,7 +51,7 @@ export type NestedQuery<Map, X = undefined> =
  */
 export type NestedSelection<Map, X = undefined> = (
   query?: NestedQuery<Map, X> | true,
-  path?: string[] | IndirectInclude,
+  path?: PathSegment[] | IndirectInclude,
   type?: string,
 ) => Map;
 
@@ -968,6 +968,7 @@ function nestedSelectionFor<M, Map, X>(
           pathOrInclude,
           resolveType(info.schema, returnType),
           typeName ? info.schema.getType(typeName) : undefined,
+          info.schema,
         )
       : pathOrInclude;
     const target = include ? info.schema.getType(include.getType())! : returnType;

--- a/packages/selection-mapper/tests/matches.test.ts
+++ b/packages/selection-mapper/tests/matches.test.ts
@@ -239,25 +239,70 @@ describe('resolveType', () => {
 
 describe('normalizeInclude', () => {
   it('turns a string path into an include targeting the type at its end', () => {
-    const include = normalizeInclude(['edges', 'node'], schema.getType('PostConnection')!);
+    const include = normalizeInclude(
+      ['edges', 'node'],
+      schema.getType('PostConnection')!,
+      undefined,
+      schema,
+    );
 
     expect(include.path).toEqual([{ name: 'edges' }, { name: 'node' }]);
     expect(include.getType()).toBe('Post');
   });
 
   it('lets an explicit type override the target', () => {
-    const include = normalizeInclude([], schema.getType('User')!, schema.getType('Viewer')!);
+    const include = normalizeInclude(
+      [],
+      schema.getType('User')!,
+      schema.getType('Viewer')!,
+      schema,
+    );
 
     expect(include.path).toEqual([]);
     expect(include.getType()).toBe('Viewer');
   });
 
-  it('rejects unknown fields and non-object types along the path', () => {
-    expect(() => normalizeInclude(['missing'], schema.getType('User')!)).toThrow(
+  it('looks a typed segment up on the type it pins', () => {
+    // The field only exists on the implementations, each returning a different type.
+    const include = normalizeInclude(
+      [{ name: 'appointment', type: 'OtherEntry' }],
+      schema.getType('Entry')!,
+      undefined,
+      schema,
+    );
+
+    expect(include.path).toEqual([{ name: 'appointment', type: 'OtherEntry' }]);
+    expect(include.getType()).toBe('Post');
+
+    // A pin also names the member of a union the path goes through.
+    const viaUnion = normalizeInclude(
+      [{ name: 'data', type: 'UserSuccess' }],
+      schema.getType('UserResult')!,
+      undefined,
+      schema,
+    );
+
+    expect(viaUnion.path).toEqual([{ name: 'data', type: 'UserSuccess' }]);
+    expect(viaUnion.getType()).toBe('User');
+  });
+
+  it('rejects unknown fields, unknown pinned types, and non-object types along the path', () => {
+    expect(() => normalizeInclude(['missing'], schema.getType('User')!, undefined, schema)).toThrow(
       'Expected User to have a field missing',
     );
-    expect(() => normalizeInclude(['name'], schema.getType('User')!)).toThrow(
+    expect(() => normalizeInclude(['name'], schema.getType('User')!, undefined, schema)).toThrow(
       'Expected String to be an Object or Interface type',
     );
+    expect(() =>
+      normalizeInclude(
+        [{ name: 'appointment', type: 'Nope' }],
+        schema.getType('Entry')!,
+        undefined,
+        schema,
+      ),
+    ).toThrow('Unknown type Nope in nested selection path segment appointment');
+    expect(() =>
+      normalizeInclude(['data'], schema.getType('UserResult')!, undefined, schema),
+    ).toThrow('Expected UserResult to be an Object type');
   });
 });

--- a/website/content/docs/plugins/drizzle.mdx
+++ b/website/content/docs/plugins/drizzle.mdx
@@ -206,17 +206,22 @@ const UserRef = builder.drizzleObject('users', {
 
 ### How selections are planned
 
-Every field on a drizzle object is answered in one of two ways, never both. Either its selection is
+Every field on a drizzle object is answered in one of two ways. Either its selection is
 **planned** into the query of the nearest ancestor that runs one (a `t.drizzleField`, a
 `t.relation`, a connection, or a [fallback query](#fallback-queries)) and the field reads its data
 from the loaded row, or the field is **loaded on its own**: by a `resolve` that queries drizzle
-itself, or by the fallback query the plugin issues for a relation whose data is not on the row.
+itself, or by the fallback query the plugin issues for a relation whose data is not on the row. A
+field can do both: a `t.drizzleField` (or any field with a `select`) nested under such an ancestor
+has its `select` planned into the parent's row, and its `resolve` still runs a query of its own.
+What is planned is the parent data it reads; what it loads itself is what it returns.
 
 Two selections of the same relation share one place in the query only when their arguments
-(`where`, `orderBy`, `limit`, ...) are the same. When they differ, the first in document order is
-planned and the second is loaded by a query of its own. A field-level `select` is merged into the
-same query as its siblings and the type-level selection rather than isolating the field, so two
-fields that need the same relation with different arguments cannot both be answered from one row.
+(`where`, `orderBy`, `limit`, ...) are the same. When they differ, the first to be planned wins and
+the other is loaded by a query of its own. A type-level `select` is planned before any field's
+selection, whatever the document's order; among fields, the first in document order is planned
+first. A field-level `select` is merged into the same query as its siblings and the type-level
+selection rather than isolating the field, so two fields that need the same relation with
+different arguments cannot both be answered from one row.
 
 The callbacks that build a selection may be async; see [Async selections](#async-selections).
 

--- a/website/content/docs/plugins/drizzle.mdx
+++ b/website/content/docs/plugins/drizzle.mdx
@@ -471,10 +471,10 @@ resolver did not pass the result of `query()` to drizzle, and when a relation's 
 with a sibling selection of the same relation that was planned first.
 
 Fallback queries are batched: every row of a table that needs the same selection in the same tick
-is loaded by one `findMany` filtered on the primary key, and the rows are matched back to their
-parents. A parent whose row the query did not return (deleted since it was loaded, or a row that
-never came from the table) rejects with `Model users(1) not found`, where the value in
-parentheses is its primary key.
+is loaded by one `findMany` filtered on the primary key (or, for a table without one, the first
+unique column), and the rows are matched back to their parents. A parent whose row the query did
+not return (deleted since it was loaded, or a row that never came from the table) rejects with
+`Model users(1) not found`, where the value in parentheses is that key.
 
 ## Variants
 

--- a/website/content/docs/plugins/drizzle.mdx
+++ b/website/content/docs/plugins/drizzle.mdx
@@ -82,6 +82,20 @@ const builder = new SchemaBuilder<PothosTypes>({
 });
 ```
 
+### Plugin options
+
+- `client`: the drizzle client, or a function returning one from the request context.
+- `getTableConfig`: the `getTableConfig` of your dialect, used to read primary keys and unique
+  constraints.
+- `relations`: the relations passed to `drizzle()`.
+- `defaultConnectionSize` / `maxConnectionSize`: the page size a connection uses when the query
+  gives none (defaults to 20), and the largest it accepts (defaults to 100). Both can also be set
+  per field with `defaultSize` and `maxSize`.
+- `filterConnectionTotalCount`: see [Connection totalCount](#connection-totalcount).
+- `skipDeferredFragments`: selections inside a `@defer` fragment are left out of the planned query
+  by default, and the fragment's fields load through [fallback queries](#fallback-queries) when it
+  resolves. Set it to `false` to plan deferred selections with the rest of the query.
+
 ## Defining Objects
 
 The `builder.drizzleObject` method can be used to define GraphQL Object types based on a drizzle
@@ -189,6 +203,73 @@ const UserRef = builder.drizzleObject('users', {
   }),
 });
 ```
+
+### How selections are planned
+
+Every field on a drizzle object is answered in one of two ways, never both. Either its selection is
+**planned** into the query of the nearest ancestor that runs one (a `t.drizzleField`, a
+`t.relation`, a connection, or a [fallback query](#fallback-queries)) and the field reads its data
+from the loaded row, or the field is **loaded on its own**: by a `resolve` that queries drizzle
+itself, or by the fallback query the plugin issues for a relation whose data is not on the row.
+
+Two selections of the same relation share one place in the query only when their arguments
+(`where`, `orderBy`, `limit`, ...) are the same. When they differ, the first in document order is
+planned and the second is loaded by a query of its own. A field-level `select` is merged into the
+same query as its siblings and the type-level selection rather than isolating the field, so two
+fields that need the same relation with different arguments cannot both be answered from one row.
+
+The callbacks that build a selection may be async; see [Async selections](#async-selections).
+
+### Nested selections
+
+A `select` function receives `nestedSelection`, which plans the selection beneath the field for
+the field's own type. It returns the query config for that table (a `many` config for a list
+field), keeping the keys it was given as they were given, so `columns` passed to it still narrow
+the parent shape:
+
+```ts
+builder.drizzleObject('users', {
+  name: 'User',
+  fields: (t) => ({
+    latestPosts: t.field({
+      type: [Post],
+      select: (args, ctx, nestedSelection) => ({
+        // what the query selects on the posts, limited to one
+        with: { posts: nestedSelection({ limit: 1 }) },
+      }),
+      resolve: (user) => user.posts,
+    }),
+  }),
+});
+```
+
+`nestedSelection(query, path, type)` can also select a field nested under the field's type
+(`path`: a list of field names, or `{ name, type }` segments pinning the implementation a segment
+must be found under), and read the selection as a specific member of an interface or union
+(`type`). It also carries the `path` and `segments` of the field being planned, described under
+[Relation queries](#relation-queries).
+
+### Typing rows you load yourself
+
+A resolver that loads rows with its own drizzle query decides what is on them.
+`DrizzleQueriedShape` names that shape from the table and the query config, so it can be written
+once next to the query that loads the rows:
+
+```ts
+import type { DrizzleQueriedShape } from '@pothos/plugin-drizzle';
+
+type Types = typeof builder.$inferSchemaTypes;
+
+type PostWithAuthor = DrizzleQueriedShape<Types, 'posts', { with: { author: true } }>;
+// { id: number; title: string; ...; author: { id: number; firstName: string; ... } }
+
+async function loadPost(id: number): Promise<PostWithAuthor | undefined> {
+  return db.query.posts.findFirst({ where: { id }, with: { author: true } });
+}
+```
+
+The query is read as drizzle reads it (without `columns`, every column is loaded), and the shape
+is what `db.query.<table>.findFirst(query)` returns. Without a query, it is the table's full row.
 
 ## Relations
 
@@ -357,6 +438,39 @@ passed to a drizzle `findOne` or `findMany` query. The `query` function optional
 arguments that are normally passed into the query, and will merge these options with the selection
 used to resolve data for the nested GraphQL selections.
 
+### `drizzleFieldWithInput`
+
+With the [with-input plugin](https://pothos-graphql.dev/docs/plugins/with-input),
+`t.drizzleFieldWithInput` combines `t.drizzleField` with `t.fieldWithInput`: the `input` fields
+become an input object argument, and the resolver still receives the `query` function first:
+
+```ts
+builder.queryFields((t) => ({
+  user: t.drizzleFieldWithInput({
+    type: 'users',
+    input: {
+      id: t.input.id({ required: true }),
+    },
+    resolve: (query, root, args, ctx) =>
+      db.query.users.findFirst(query({ where: { id: Number.parseInt(args.input.id, 10) } })),
+  }),
+}));
+```
+
+## Fallback queries
+
+A field whose data is not on the row it resolves from is loaded by a fallback query. That happens
+when the parent row was not loaded through a `t.drizzleField`, `t.relation`, or connection (a
+resolver returned a row it queried itself, or a row from somewhere else), when a `drizzleField`
+resolver did not pass the result of `query()` to drizzle, and when a relation's arguments conflict
+with a sibling selection of the same relation that was planned first.
+
+Fallback queries are batched: every row of a table that needs the same selection in the same tick
+is loaded by one `findMany` filtered on the primary key, and the rows are matched back to their
+parents. A parent whose row the query did not return (deleted since it was loaded, or a row that
+never came from the table) rejects with `Model users(1) not found`, where the value in
+parentheses is its primary key.
+
 ## Variants
 
 It is often useful to be able to define multiple object types based on the same table. This can be
@@ -419,6 +533,77 @@ builder.drizzleNode('users', {
 });
 ```
 
+A `t.variant` field can carry a `select` of its own. It is planned, with the variant's type-level
+selection, when the variant is queried through that field:
+
+```ts
+builder.drizzleNode('users', {
+  name: 'User',
+  fields: (t) => ({
+    viewer: t.variant(Viewer, {
+      // loaded with the row when `viewer` is selected
+      select: { columns: { email: true } },
+      isNull: (user, args, ctx) => user.id !== ctx.user?.id,
+    }),
+  }),
+});
+```
+
+### Conflicting type-level selections
+
+When a query selects two variants of one table for the same row (a fragment on each under one
+field, or a `t.variant` field), their type-level selections are merged into one query, since one
+row answers both. A type-level selection has no per-field fallback, so the plugin throws a
+`PothosValidationError` when the two cannot be merged: a relation selected with different
+arguments on each (`Type-level selections of Viewer and Admin conflict on relation "posts"`), or an
+extra defined with a different function on each (`... conflict on extra "lowercaseName"`). The fix
+is the one the message names: move the relation with its arguments, or the extra, to a field-level
+`select` on one of the variants, where a conflict falls back to a query for that field instead of
+failing the request.
+
+## Interfaces
+
+`builder.drizzleInterface` defines a GraphQL interface backed by a table, the same way
+`drizzleObject` does, so the primary type or a variant of a table can be an interface implemented
+by other variants. Its `select` is planned whenever a field returns the interface; an
+implementation's own `select` is planned when a fragment narrows to it. Selections are not
+inherited, so an implementation that exposes more columns needs a `select` of its own.
+
+```ts
+export const Viewer = builder.drizzleInterface('users', {
+  variant: 'Viewer',
+  select: { columns: { id: true, role: true } },
+  resolveType: (user) => (user.role === 'admin' ? 'AdminViewer' : 'MemberViewer'),
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    user: t.variant('users'),
+  }),
+});
+
+builder.drizzleObject('users', {
+  variant: 'AdminViewer',
+  interfaces: [Viewer],
+  select: { columns: { permissions: true } },
+  fields: (t) => ({
+    permissions: t.exposeStringList('permissions'),
+  }),
+});
+```
+
+Fields can be added to an interface later with `builder.drizzleInterfaceField` and
+`builder.drizzleInterfaceFields`, which take the interface ref (or the table name) like their
+`drizzleObjectField(s)` counterparts:
+
+```ts
+builder.drizzleInterfaceFields(Viewer, (t) => ({
+  posts: t.relatedConnection('posts'),
+}));
+```
+
+An object type implementing a drizzle interface must be backed by the same table. A plain object
+type implementing it is planned with the interface's table, so fragments on it select the
+relations it inherits.
+
 ## Related field
 
 The `t.relatedField` method allows you to define a field based on a relation that uses custom
@@ -455,6 +640,10 @@ builder.drizzleNode('users', {
 The `buildFilter` function passed to `select` generates the appropriate SQL filter based on the
 relation definition.  This is no different than using `t.field`, but the `buildFilter` helper makes
 it easier to filter for the related records.
+
+`t.relatedField` takes the ordinary field options as well (`description`, `deprecationReason`,
+`extensions`, and what other plugins add, such as `authScopes`). `resolve` may be async, and
+receives the resolve `info` as its fourth argument.
 
 ## Related count
 
@@ -1009,3 +1198,4 @@ builder.queryFields((t) => ({
     },
   }),
 }));
+```

--- a/website/content/docs/plugins/prisma/indirect-relations.mdx
+++ b/website/content/docs/plugins/prisma/indirect-relations.mdx
@@ -54,6 +54,62 @@ builder.prismaObject('User', {
 });
 ```
 
+`nestedSelection` returns the relation query for the type it selected (`{ select?, include?,
+where?, orderBy?, take?, skip?, cursor? }` for a `Post`), with the keys it was given kept as they
+were given, so a `select` passed to it still narrows the parent's shape. With no argument, or
+`true`, it is the planned selection alone.
+
+### Pinning a type in the path
+
+The `path` is followed through fragments: a segment is found whether the field is selected
+directly or under a fragment on an implementation of the field's type. When several
+implementations share the field name, a segment can name the implementation it must be found
+under, as `{ name, type }`. Only selections of that field under a fragment on that type (or one of
+its subtypes) are planned:
+
+```typescript
+builder.prismaObject('User', {
+  fields: (t) => ({
+    entries: t.field({
+      type: [Entry],
+      select: (args, ctx, nestedSelection) => ({
+        // Plan what `post` selects under `... on PostEntry`, not under other implementations
+        posts: nestedSelection({ take: 2 }, [{ name: 'post', type: 'PostEntry' }]),
+      }),
+      resolve: (user) => user.posts.map((post) => ({ kind: 'post', post })),
+    }),
+  }),
+});
+```
+
+The same segments are accepted by `queryFromInfo`'s `path` and `paths`; the type is exported as
+`PathSegment`.
+
+### Selecting as a specific type
+
+When the field returns an interface or union, the third argument names the object type the
+selection is read as: its type-level selection and the fields selected under a fragment on it are
+planned, and fragments on other types are left out. With an empty path, that is the field's own
+return type:
+
+```typescript
+// Activity is a union of Post and Comment
+builder.prismaObject('User', {
+  fields: (t) => ({
+    recentActivity: t.field({
+      type: [Activity],
+      select: (args, ctx, nestedSelection) => ({
+        // What the query selects under `... on Post`, as a query for the posts relation
+        posts: nestedSelection({ take: 5 }, [], 'Post'),
+        // and under `... on Comment`, for the comments relation
+        comments: nestedSelection({ take: 5 }, [], 'Comment'),
+      }),
+      resolve: (user) => [...user.posts, ...user.comments],
+    }),
+  }),
+});
+```
+
 ## Indirect relations (eg. Join tables)
 
 If you want to define a GraphQL field that directly exposes data from a nested relationship (many to

--- a/website/content/docs/plugins/prisma/objects.mdx
+++ b/website/content/docs/plugins/prisma/objects.mdx
@@ -69,6 +69,35 @@ to resolve nested parts of the current query. The included/selected fields are b
 are being queried, and the options provided when defining those fields and types.
 
 
+### `prismaFieldWithInput`
+
+With the [with-input plugin](https://pothos-graphql.dev/docs/plugins/with-input),
+`t.prismaFieldWithInput` combines `t.prismaField` with `t.fieldWithInput`: the `input` fields
+become an input object argument, and the resolver still receives the `query` to spread as its
+first argument.
+
+```typescript
+builder.mutationType({
+  fields: (t) => ({
+    createPost: t.prismaFieldWithInput({
+      type: 'Post',
+      input: {
+        title: t.input.string({ required: true }),
+        authorId: t.input.id({ required: true }),
+      },
+      resolve: (query, root, args, ctx) =>
+        prisma.post.create({
+          ...query,
+          data: {
+            title: args.input.title,
+            authorId: Number.parseInt(args.input.authorId, 10),
+          },
+        }),
+    }),
+  }),
+});
+```
+
 ## Extending prisma objects
 
 The normal `builder.objectField(s)` methods can be used to extend prisma objects, but do not support

--- a/website/content/docs/plugins/prisma/relations.mdx
+++ b/website/content/docs/plugins/prisma/relations.mdx
@@ -95,6 +95,26 @@ The following are some edge cases that could cause an additional query to be nec
 All of the above should be relatively uncommon in normal usage, but the plugin ensures that these
 types of edge cases are automatically handled when they do occur.
 
+A fallback query loads the parent row again by its primary key (or by the first required unique
+field or index when the model has no primary key), selecting what the un-loaded fields need. To
+load it some other way, give the type a `findUnique` option returning the `where` for
+`prisma.<model>.findUnique`:
+
+```typescript
+builder.prismaObject('User', {
+  findUnique: (user, ctx) => ({ email: user.email }),
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    posts: t.relation('posts'),
+  }),
+});
+```
+
+A type in include mode can also opt out of fallback queries with `findUnique: null`. A field that
+would need one then throws `Missing findUnique for User` instead of querying, which turns a row
+that reached a resolver without the relations the query asked for into an error you see in
+development rather than an extra query you find in production.
+
 ### Filters, Sorting, and arguments
 
 So far we have been describing very simple queries without any arguments, filtering, or sorting. For
@@ -145,6 +165,29 @@ builder.prismaObject('User', {
           createdAt: args.oldestFirst ? 'asc' : 'desc',
         },
       }),
+    }),
+  }),
+});
+```
+
+### Nullable relations and `onNull`
+
+A relation that is optional in the prisma schema (`profile Profile?`) is exposed as a nullable
+field with `nullable: true`. To expose it as non-nullable, `t.relation` requires an `onNull`
+option saying what happens when the related row is missing: `'error'` lets GraphQL raise the
+non-null error for the field, and a function returns a replacement value, or an `Error` to raise
+instead:
+
+```typescript
+builder.prismaObject('User', {
+  fields: (t) => ({
+    profile: t.relation('profile', { nullable: true }),
+    // An error when the user has no profile
+    requiredProfile: t.relation('profile', { nullable: false, onNull: 'error' }),
+    // A default when the user has no profile
+    profileOrDefault: t.relation('profile', {
+      nullable: false,
+      onNull: (user, args, ctx, info) => ({ id: 0, userId: user.id, bio: null }),
     }),
   }),
 });

--- a/website/content/docs/plugins/prisma/selections.mdx
+++ b/website/content/docs/plugins/prisma/selections.mdx
@@ -302,6 +302,8 @@ async function loadPost(id: number): Promise<PostWithAuthor> {
 ```
 
 The shape is the one a resolver's `parent` has when the row was planned with the same query: a
-`select` narrows it to the selected columns and relations, an `include` adds the relations to every
-column, and `_count` selections are typed as counts. The model can also be given as its
-`PrismaTypes` entry (`PrismaQueriedShape<Types, PrismaTypes['Post'], ...>`).
+`select` narrows it to the selected columns and relations, and an `include` adds the relations to
+every column. A `_count` in either is typed as prisma returns it: `_count: true` adds
+`_count: { posts: number, comments: number, ... }` with every list relation of the model, and
+`_count: { select: { posts: true } }` adds `_count: { posts: number }`. The model can also be given
+as its `PrismaTypes` entry (`PrismaQueriedShape<Types, PrismaTypes['Post'], ...>`).

--- a/website/content/docs/plugins/prisma/selections.mdx
+++ b/website/content/docs/plugins/prisma/selections.mdx
@@ -260,10 +260,14 @@ builder.mutationField(
 );
 ```
 
-`queryFromInfo` returns `{ select }` or `{ include }` when it was given one, and otherwise
-`{ select?, include? }`, whichever the type's mode produced. All three spread into a prisma call.
-A `select` given for a type in include mode is merged into an `include` query: prisma then loads
-every column, the selected ones among them, and the relations in the `select` are included.
+`queryFromInfo` returns `{ include }` when it was given one, and otherwise `{ select?, include? }`,
+whichever the type's mode produced. The type's mode wins over a given `select`: a type in select
+mode returns `{ select }` with the given columns among the selected ones, but a type in include
+mode merges the `select` into an `include` query (prisma then loads every column, the selected
+ones among them, and the relations in the `select` are included), so the result is `{ include }`,
+or `{}` when nothing is included. The return type of a call with `select` is the union of those
+two shapes. All of them spread into a prisma call, and the given columns are on the rows either
+way.
 
 The `path` is followed through fragments in the query, including inline fragments and fragment
 spreads that narrow an interface or union to one of its implementations. Every selection of the

--- a/website/content/docs/plugins/prisma/selections.mdx
+++ b/website/content/docs/plugins/prisma/selections.mdx
@@ -3,6 +3,26 @@ title: Selections
 description: how to use custom includes and selections to optimize your prisma queries
 ---
 
+## How selections are planned
+
+Every field on a prisma object is answered in one of two ways, never both. Either its selection is
+**planned** into the query of the nearest ancestor that runs one (a `t.prismaField`, a
+`t.relation`, a connection, or a [fallback query](./relations#fallback-queries)) and the field
+reads its data from the loaded row, or the field is **loaded on its own**: by a `resolve` that
+queries prisma itself, or by the fallback query the plugin issues for a `t.relation` whose data is
+not on the row.
+
+Two selections of the same relation share one place in the query only when their arguments
+(`where`, `orderBy`, `take`, ...) are the same. When they differ, the first in document order is
+planned and the second is loaded by a query of its own.
+
+A field-level `select` is merged into the same query as its siblings and the type-level selection;
+it does not get a private copy of the row. A relation selected with arguments by one field is the
+relation every other field reads from that row, so two fields that need the same relation with
+different arguments cannot both be answered from one row: the second is loaded on its own.
+
+The callbacks that build a selection may be async; see [Async selections](#async-selections).
+
 ## Includes on types
 
 In some cases, you may want to always pre-load certain relations. This can be helpful for defining
@@ -75,6 +95,33 @@ builder.prismaObject('User', {
         },
       },
       resolve: (user) => user.profile.bio,
+    }),
+  }),
+});
+```
+
+### Selections on `t.prismaField`
+
+A `t.prismaField` defined on a prisma object takes a `select` as well. The selection is planned
+into the parent row like any other field-level `select`, and the resolver still receives the
+`query` for the field's own model:
+
+```typescript
+builder.prismaObject('User', {
+  select: { email: true },
+  fields: (t) => ({
+    email: t.exposeString('email'),
+    latestPost: t.prismaField({
+      type: 'Post',
+      nullable: true,
+      // loaded with the user row, so the resolver can filter on it
+      select: { id: true },
+      resolve: (query, user) =>
+        prisma.post.findFirst({
+          ...query,
+          where: { authorId: user.id },
+          orderBy: { createdAt: 'desc' },
+        }),
     }),
   }),
 });
@@ -163,7 +210,7 @@ builder.objectRef<{
     success: t.boolean(),
     post: t.field({
       type: Post,
-      nullable:
+      nullable: true,
       resolve: (result) => result.post,
     }),
   }),
@@ -185,15 +232,15 @@ builder.mutationField(
         }
       }
 
-      const post = prisma.city.create({
+      const post = prisma.post.create({
         // A promise when a callback beneath the field is async, so it is awaited
         ...(await queryFromInfo({
           context,
           info,
           // nested path where the selections for this type can be found
-          path: ['post']
-          // optionally you can pass a custom initial selection, generally you wouldn't need this
-          // but if the field at `path` is not selected, the initial selection set may be empty
+          path: ['post'],
+          // optionally you can pass an initial selection, generally you wouldn't need this;
+          // when nothing is selected at `path`, it is returned as is
           select: {
             comments: true,
           },
@@ -213,6 +260,11 @@ builder.mutationField(
 );
 ```
 
+`queryFromInfo` returns `{ select }` or `{ include }` when it was given one, and otherwise
+`{ select?, include? }`, whichever the type's mode produced. All three spread into a prisma call.
+A `select` given for a type in include mode is merged into an `include` query: prisma then loads
+every column, the selected ones among them, and the relations in the `select` are included.
+
 The `path` is followed through fragments in the query, including inline fragments and fragment
 spreads that narrow an interface or union to one of its implementations. Every selection of the
 field that is found is merged into the query. If several implementations share a field name,
@@ -229,3 +281,27 @@ queryFromInfo({
   path: [{ name: 'appointment', type: 'AppointmentEntry' }],
 });
 ```
+
+## Typing rows you load yourself
+
+A resolver that loads rows with its own prisma query decides what is on them. `PrismaQueriedShape`
+names that shape from the model and the query, so it can be written once next to the query that
+loads the rows rather than repeated wherever they are used:
+
+```typescript
+import type { PrismaQueriedShape } from '@pothos/plugin-prisma';
+
+type Types = typeof builder.$inferSchemaTypes;
+
+type PostWithAuthor = PrismaQueriedShape<Types, 'Post', { include: { author: true } }>;
+// { id: number; title: string; ...; author: { id: number; email: string; ... } }
+
+async function loadPost(id: number): Promise<PostWithAuthor> {
+  return prisma.post.findUniqueOrThrow({ where: { id }, include: { author: true } });
+}
+```
+
+The shape is the one a resolver's `parent` has when the row was planned with the same query: a
+`select` narrows it to the selected columns and relations, an `include` adds the relations to every
+column, and `_count` selections are typed as counts. The model can also be given as its
+`PrismaTypes` entry (`PrismaQueriedShape<Types, PrismaTypes['Post'], ...>`).

--- a/website/content/docs/plugins/prisma/selections.mdx
+++ b/website/content/docs/plugins/prisma/selections.mdx
@@ -5,16 +5,21 @@ description: how to use custom includes and selections to optimize your prisma q
 
 ## How selections are planned
 
-Every field on a prisma object is answered in one of two ways, never both. Either its selection is
+Every field on a prisma object is answered in one of two ways. Either its selection is
 **planned** into the query of the nearest ancestor that runs one (a `t.prismaField`, a
 `t.relation`, a connection, or a [fallback query](./relations#fallback-queries)) and the field
 reads its data from the loaded row, or the field is **loaded on its own**: by a `resolve` that
 queries prisma itself, or by the fallback query the plugin issues for a `t.relation` whose data is
-not on the row.
+not on the row. A field can do both: a `t.prismaField` (or any field with a `select`) nested under
+such an ancestor has its `select` planned into the parent's row, and its `resolve` still runs a
+query of its own. What is planned is the parent data it reads; what it loads itself is what it
+returns.
 
 Two selections of the same relation share one place in the query only when their arguments
-(`where`, `orderBy`, `take`, ...) are the same. When they differ, the first in document order is
-planned and the second is loaded by a query of its own.
+(`where`, `orderBy`, `take`, ...) are the same. When they differ, the first to be planned wins and
+the other is loaded by a query of its own. A type-level `select` or `include` is planned before
+any field's selection, whatever the document's order; among fields, the first in document order is
+planned first.
 
 A field-level `select` is merged into the same query as its siblings and the type-level selection;
 it does not get a private copy of the row. A relation selected with arguments by one field is the

--- a/website/content/docs/plugins/prisma/setup.mdx
+++ b/website/content/docs/plugins/prisma/setup.mdx
@@ -84,6 +84,8 @@ const builder = new SchemaBuilder<{
     filterConnectionTotalCount: true,
     // warn when not using a query parameter correctly
     onUnusedQuery: process.env.NODE_ENV === 'production' ? null : 'warn',
+    // leave selections inside @defer fragments out of the planned query (defaults to true)
+    skipDeferredFragments: true,
   },
 });
 ```
@@ -141,3 +143,13 @@ a flag if the property is accessed. If no properties are accessed on the query o
 resolver returns, it will trigger the `onUnusedQuery` condition.
 
 It's recommended to enable this check in development to more quickly find potential issues.
+
+## Deferred fragments
+
+Selections inside a `@defer` fragment are left out of the planned query by default: the fragment
+resolves after the initial payload, and loading what it needs up front would delay that payload
+for data the client agreed to wait for. When the deferred fragment resolves, its fields load
+through [fallback queries](./relations#fallback-queries), batched as usual.
+
+Set `skipDeferredFragments: false` in the plugin options to plan deferred selections with the rest
+of the query. `queryFromInfo` takes the same option per call.

--- a/website/content/docs/plugins/prisma/variants.mdx
+++ b/website/content/docs/plugins/prisma/variants.mdx
@@ -100,3 +100,19 @@ builder.prismaObjectField(Viewer, 'user', t.variant(User));
 ```
 
 This same workaround applies when defining relations using variants.
+
+## Conflicting type-level selections
+
+When a query selects two variants of one model for the same row (a fragment on each under one
+field, or a `t.variant` field), their type-level `select`/`include` are merged into one query,
+since one row answers both. A type-level selection has no per-field fallback, so two variants that
+select the same relation with different arguments cannot be merged, and the plugin throws:
+
+```
+PothosValidationError: Type-level selections of Viewer and Admin conflict on relation "posts".
+Move the relation arguments to a field-level select on one of the types.
+```
+
+The fix is the one the message names: keep the relation with its arguments in the `select` of the
+field that needs it, on one of the variants. A field-level selection that conflicts with what the
+row already holds falls back to a query of its own instead of failing the request.


### PR DESCRIPTION
Stacked on #1673. Sixth and last PR in the selection-mapper stack. Developer experience only: types and docs, no runtime enforcement.

## Type helpers (each pinned by a type test in `selection-types.test-d.ts` in both plugins)

1. **`queryFromInfo` is typed by what it returns.** With `select`/`include` the corresponding shape; otherwise a `{ select?; include? }` that spreads into a Prisma call. The example schema's cast around it is gone. Caveat documented: `select` on an include-mode type still yields `include` at runtime.
2. **`nestedSelection` is typed as the query it returns**, not the identity of its argument, and its argument is constrained to the field's relation query when the field's type names a model or table. Unknown keys still pass, so every existing usage compiles. The connection helpers' own `select` callback stays identity-typed: the node's model is the field's `type`, which the helper cannot know, and typing it broke the documented indirect-relations pattern.
3. **One `PathSegment` type** (`string | { name; type? }`) shared by `nestedSelection`, `queryFromInfo` and `IndirectInclude`, exported from the package and re-exported by both plugins. A runtime test shows a typed segment restricting the plan to the pinned implementation.
4. **A relation's fallback `resolve` receives a `query` typed with the relation's own keys** (`where`, `orderBy`, `take`, ...). The two casts in the example schema are gone.
5. **`relationCount` / `relatedCount` reject to-one relations** in the types.
6. **`t.relatedField` accepts the ordinary field options** (`deprecationReason`, `extensions`, `authScopes`, ...), `resolve` may return a promise, `info` is `GraphQLResolveInfo`.
7. **`PrismaQueriedShape<Types, Model, Query>` / `DrizzleQueriedShape<Types, Table, Query>`**: opt-in row-origin helper types for users who wrap rows themselves. Pure types.
8. **Drizzle's dead `withUsageCheck` plumbing is deleted.** Prisma's `onUnusedQuery` wraps a query object in getters; a drizzle resolver is handed a builder function, so that mechanism cannot see the realistic mistake (never calling `query()`), and a call-tracking equivalent is out of this PR's scope. The changeset says so.

## Docs

Each plugin's selections page gains a "how selections are planned" section: a field is either planned into an ancestor's query and mapped, or loaded by its own resolver or the loader, never both; two selections share a node only when their arguments match; `select` merges with siblings. Everything the audit found undocumented is now documented: `findUnique: null`, `onNull`, `select` on a nested `t.prismaField`, typed path segments and `nestedSelection`'s third argument, `skipDeferredFragments`, the `*FieldWithInput` methods, drizzle's connection size options, `drizzleInterface` and `drizzleInterfaceField(s)`, `t.variant(Ref, { select })`, the drizzle fallback loader, and the conflict validation error. Doc examples where the code won: `prisma.city.create` → `prisma.post.create`, a bare `nullable:` → `nullable: true`, and an unclosed code block at the end of the drizzle page.

## Verification

selection-mapper 76 tests, prisma 160, drizzle 191; `pnpm type` and biome clean (no warnings) in all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf25mwTTUmeM2ogHxq3idp

## Review round 1 fixes (last ten commits)

- `PrismaRelationQuery` gains `omit` and `distinct`, matching the generated relation args (the generated `Parent$relationArgs` type is not reachable from `PrismaModelTypes`, so the keys are spelled out and pinned against `Prisma.User$postsArgs`).
- String-named prisma object types (`type: 'Post'` with `Objects: { Post }`) get the same model-typed `nestedSelection` as refs.
- `PrismaQueriedShape` models `_count` the way Prisma returns it, for `include` and for `select` with `true` or a selection.
- `nestedSelection` accepts the callback and promise forms the runtime always accepted.
- `queryFromInfo({ select })` is typed as the union of the select and include shapes, since the type's mode wins at runtime; spreading into `findMany` still compiles.
- drizzle `drizzleInterfaceField(s)` now resolves a table name to the interface ref, as the docs promised (runtime fix with a test).
- Changeset corrected (`IndirectInclude` paths take object segments only) and docs qualified: a nested field with a `select` is planned into the parent and still runs its own query; type-level selections are planned before fields; the drizzle loader falls back to the first unique column for a table without a primary key.

## Open decision for the maintainer

`relationCount` / `relatedCount` now reject to-one relations at the type level. Code calling them on a to-one relation compiled before and failed at runtime with a query Prisma or drizzle rejects. The changeset says so plainly and keeps the `patch` bump; whether that should be a larger bump is your call.

selection-mapper 88 tests, prisma 164, drizzle 201; `pnpm type` and biome clean in all three.