### PR TITLE
fix(relay): treat a connection page size of 0 as a requested page size

### DIFF
--- a/.changeset/olive-pugs-repeat.md
+++ b/.changeset/olive-pugs-repeat.md
@@ -1,0 +1,7 @@
+---
+'@pothos/plugin-relay': patch
+---
+
+Fix pageInfo flags when a connection is asked for a page size of 0. A backward page requested with
+`last: 0` was treated as a forward page, so `hasNextPage` and `hasPreviousPage` came back reversed.
+`first: 0` combined with a `before` cursor (or with `last`) was likewise treated as a backward page.

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -211,8 +211,14 @@ export function parseCursorConnectionArgs(options: ResolveOffsetConnectionOption
     throw new PothosValidationError('Argument "last" must be a non-negative integer');
   }
 
+  // `first`/`last` are checked for presence rather than truthiness so that a page size of 0
+  // (which the validation above allows) is treated as a requested page size, and not as an
+  // omitted argument.
+  const hasFirst = first != null;
+  const hasLast = last != null;
+
   const limit = Math.min(first ?? last ?? defaultSize, maxSize) + 1;
-  const inverted = after ? !!last && !first : (!!before && !first) || (!first && !!last);
+  const inverted = after ? hasLast && !hasFirst : (!!before && !hasFirst) || (!hasFirst && hasLast);
 
   return {
     before: before ?? undefined,

--- a/packages/plugin-relay/tests/cursors.test.ts
+++ b/packages/plugin-relay/tests/cursors.test.ts
@@ -186,4 +186,79 @@ describe('cursor based connection', () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  describe('page size of 0', () => {
+    async function pageOf(args: string) {
+      const query = gql`
+        query {
+          connection: cursorConnection(${args}) {
+            pageInfo {
+              hasNextPage
+              hasPreviousPage
+            }
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      `;
+
+      const result = await execute({ schema, document: query, contextValue: {} });
+
+      expect(result.errors).toBeUndefined();
+
+      return (result.data as { connection: unknown }).connection;
+    }
+
+    it('first: 0 returns no edges, and reports a next page', async () => {
+      expect(await pageOf('first: 0')).toEqual({
+        edges: [],
+        pageInfo: { hasNextPage: true, hasPreviousPage: false },
+      });
+    });
+
+    it('first: 0 with an after cursor returns no edges, and reports pages on both sides', async () => {
+      expect(await pageOf('first: 0, after: 10')).toEqual({
+        edges: [],
+        pageInfo: { hasNextPage: true, hasPreviousPage: true },
+      });
+    });
+
+    it('first: 0 with a before cursor pages forward, not backward', async () => {
+      expect(await pageOf('first: 0, before: 10')).toEqual({
+        edges: [],
+        pageInfo: { hasNextPage: true, hasPreviousPage: false },
+      });
+    });
+
+    it('first: 0 with a last argument pages forward, not backward', async () => {
+      expect(await pageOf('first: 0, last: 2')).toEqual({
+        edges: [],
+        pageInfo: { hasNextPage: true, hasPreviousPage: false },
+      });
+    });
+
+    it('last: 0 returns no edges, and reports a previous page', async () => {
+      expect(await pageOf('last: 0')).toEqual({
+        edges: [],
+        pageInfo: { hasNextPage: false, hasPreviousPage: true },
+      });
+    });
+
+    it('last: 0 with a before cursor returns no edges, and reports pages on both sides', async () => {
+      expect(await pageOf('last: 0, before: 10')).toEqual({
+        edges: [],
+        pageInfo: { hasNextPage: true, hasPreviousPage: true },
+      });
+    });
+
+    it('last: 0 with an after cursor pages backward, not forward', async () => {
+      expect(await pageOf('last: 0, after: 10')).toEqual({
+        edges: [],
+        pageInfo: { hasNextPage: false, hasPreviousPage: true },
+      });
+    });
+  });
 });


### PR DESCRIPTION
## The bug

`parseCursorConnectionArgs` in `packages/plugin-relay/src/utils/connections.ts` validates that `first` and `last` are non-negative — explicitly allowing `0` — and then decides whether the page is inverted by testing both arguments for **truthiness**:

```ts
const inverted = after ? !!last && !first : (!!before && !first) || (!first && !!last);
```

So `last: 0` reads as "no `last` given" and `first: 0` reads as "no `first` given". Both pageInfo predicates hang off `inverted`, so the navigation flags come back wrong.

This is the shared path behind relay's own cursor resolvers, so it affects every Pothos connection that goes through `resolveCursorConnection`.

## What a user sees

Asking a connection for zero items backward — `cursorConnection(last: 0)` — got its navigation flags reversed: `hasNextPage: true` and `hasPreviousPage: false`, when a backward page at the end of the list has a previous page and no next page.

Enumerating all 36 combinations of `first`/`last`/`before`/`after` (each of absent, `0`, non-zero) turns up **nine** broken ones, in two families:

- **`last: 0` treated as a forward page** — alone, with `after`, and with `before` + `after`. Flags exactly reversed.
- **`first: 0` treated as a backward page** — whenever a `before` cursor or a `last` argument is also present.

`last: 0` with only a `before` cursor happened to come out right, via the `before` clause.

## The fix

Check both arguments for presence rather than truthiness. The sibling `offsetForArgs` in the same file already uses `!= null` throughout and handles a zero page size correctly, so this brings the cursor path in line with the offset path. `limit` needed no change: `first: 0` already yields a limit of 1 and an expected size of 0, which is right for a zero-length page that still has to detect a following page.

## Tests

Seven new cases in `packages/plugin-relay/tests/cursors.test.ts` covering a zero page size forward and backward, with and without a cursor on each side, asserting the returned edges and both pageInfo flags. Four of the seven fail without the fix — the four combinations the enumeration predicted:

- `first: 0, before: 10`
- `first: 0, last: 2`
- `last: 0`
- `last: 0, after: 10`

No existing expected value or snapshot moved. `pnpm turbo test` is green across the repo (56/56 tasks, with the prisma/drizzle suites running against the compose Postgres).

## Provenance

Three independent code reviews of unrelated packages surfaced this while auditing other plugins. Other packages carry their own copies of this logic; two were fixed separately for the same class of bug.

## Deliberately left

Two nearby predicates test `before`/`after` by truthiness, so an empty-string cursor reads as absent there while `resolveCursorConnection` still forwards `''` to the resolver. No Pothos-generated cursor is ever the empty string, and treating `''` as absent is what `offsetForArgs` does too (where the alternative would throw on an invalid cursor), so this is left as-is rather than widened into this fix. Separately, `resolveOffsetConnection` and `resolveArrayConnection` build `endCursor` as `offsetToCursor(offset + trimmed.length - 1)`, which for an empty page points one before the start; that is a pre-existing question about empty-page cursors, unrelated to the truthiness bug, and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tf25mwTTUmeM2ogHxq3idp
