### PR TITLE
perf(drizzle): optimize SQLite many-to-many filters with target identity lookups

### DIFF
--- a/packages/plugin-drizzle/README.md
+++ b/packages/plugin-drizzle/README.md
@@ -394,6 +394,26 @@ The `buildFilter` function passed to `select` generates the appropriate SQL filt
 relation definition.  This is no different than using `t.field`, but the `buildFilter` helper makes
 it easier to filter for the related records.
 
+### SQLite many-to-many filters
+
+On SQLite, `buildFilter` can look up related target identities through the junction join when the
+target has a non-null unique key. PostgreSQL retains an `EXISTS` predicate to avoid an additional
+target join.
+
+For a custom `RAW` scope in a Drizzle relation definition, use the table supplied to the callback:
+
+```ts
+where: {
+  RAW: (target) => sql`${target.published} = true`,
+},
+```
+
+This lets Drizzle use the target's alias inside the lookup. A static SQL scope referencing the
+original target table, such as ``RAW: sql`${posts.published} = true` ``, is passed through unchanged
+and can still force SQLite to scan the target table. The same applies to a callback that ignores
+its table argument and references `posts` directly. Object filters such as
+`where: { published: true }` also use the supplied alias.
+
 ## Related count
 
 For the common case of counting related records, there's a simpler `t.relatedCount` method that handles

--- a/packages/plugin-drizzle/src/drizzle-field-builder.ts
+++ b/packages/plugin-drizzle/src/drizzle-field-builder.ts
@@ -669,6 +669,14 @@ export class DrizzleObjectFieldBuilder<
       );
     }
 
+    // Explicit NOT NULL is required even for primary keys: SQLite permits nullable text and
+    // composite primary keys. Without a total identity the relation filter keeps EXISTS.
+    const targetKey = relationField.throughTable
+      ? schemaConfig
+          .getUniqueConstraints(relationField.targetTableName)
+          .find((columns) => columns.every((column) => column.notNull))
+      : undefined;
+
     const relationSelect = (
       args: object,
       context: Types['Context'],
@@ -679,6 +687,7 @@ export class DrizzleObjectFieldBuilder<
           getClient(this.builder, context) as never,
           relationField as Relation,
           parentTable as Table,
+          targetKey,
         ).filter;
 
       return completeValue(

--- a/packages/plugin-drizzle/src/utils/relation-filter.ts
+++ b/packages/plugin-drizzle/src/utils/relation-filter.ts
@@ -1,9 +1,14 @@
 import {
+  aliasedTable,
+  aliasedTableColumn,
   and,
   type Column,
   count,
   countDistinct,
   exists,
+  getTableName,
+  inArray,
+  is,
   type Relation,
   relationToSQL,
   type SQL,
@@ -11,6 +16,7 @@ import {
   sql,
   type Table,
 } from 'drizzle-orm';
+import { SQLiteTable } from 'drizzle-orm/sqlite-core';
 
 /**
  * The part of a drizzle client this module needs: enough of the core query builder to describe a
@@ -31,8 +37,8 @@ export interface RelationFilter {
   /**
    * A predicate over the target table alone, for the places where only the target table is in
    * scope: a `where` handed to a user `select`, or a count that selects from the target table.
-   * A many-to-many relation becomes an `exists` over the junction table, so the predicate stays
-   * one row of the target at a time.
+   * SQLite many-to-many relations with a non-null unique target key project identities through
+   * Drizzle's join. Other cases use an `exists` over the junction.
    */
   filter: SQL;
   /**
@@ -50,10 +56,10 @@ export interface RelationFilter {
    * row once however many junction rows lead to it. `key` identifies a target row, so it has to
    * be a single column the database guarantees is unique.
    *
-   * This exists because the alternative — counting the target table filtered by `filter` — asks
-   * sqlite to scan the whole target table once per parent row: sqlite does not rewrite the
-   * `exists` into a semijoin the way postgres does, so a relation the join reads in microseconds
-   * takes a second over a thousand parents.
+   * This counts off the junction rather than counting the target table filtered by `filter`,
+   * which says the same thing the long way round: the join reads the junction rows the parent
+   * reaches and stops, where the filter reads the same rows and then looks every key it found
+   * back up in the target table.
    */
   countDistinctRows: (key: Column, where?: SQL) => SQL<number>;
 }
@@ -67,9 +73,8 @@ const one = { one: sql`1` };
  * `where`, and a reversed relation's inherited `where` all come from drizzle rather than from a
  * join reassembled here out of source and target columns.
  *
- * Nothing here writes SQL text either: `relationToSQL` produces the correlations, and the
- * `exists` and the junction join are drizzle's own `exists` operator and core query builder, so
- * they emit the same SQL the relational query builder emits for the same relation.
+ * Both the join and its restrictions come from `relationToSQL`, including when the target is
+ * aliased for the identity lookup. No junction columns or comparisons are reconstructed here.
  *
  * `parentTable` is the parent as it appears in the surrounding query, so the aliased table when
  * the query builder aliased it.
@@ -78,6 +83,7 @@ export function buildRelationFilter(
   client: RelationQueryBuilder,
   relation: Relation,
   parentTable: Table,
+  targetKey?: Column[],
 ): RelationFilter {
   const targetTable = relation.targetTable as Table;
   const throughTable = relation.throughTable as Table | undefined;
@@ -109,12 +115,70 @@ export function buildRelationFilter(
     );
 
   return {
-    // An `exists` over the junction alone: the target row is already in scope in the query this
-    // predicate goes into, so the junction is all the subquery has to look at.
-    filter: exists(client.select(one).from(throughTable).where(and(filter, joinCondition))),
+    // SQLite needs the identity lookup to avoid target scans. PostgreSQL can plan EXISTS as
+    // a semijoin; projecting identities adds a target join its planner may not eliminate.
+    filter:
+      targetKey?.length && is(targetTable, SQLiteTable)
+        ? targetIdentityInRelation(
+            client,
+            relation,
+            parentTable,
+            targetTable,
+            throughTable,
+            targetKey,
+          )
+        : exists(client.select(one).from(throughTable).where(and(filter, joinCondition))),
     countRows: (where) => relatedRows(countStar(), where),
     countDistinctRows: (key, where) => relatedRows({ count: countDistinct(key) }, where),
   };
+}
+
+/**
+ * Project a non-null unique target key through the original relation join, then compare that
+ * key with itself. Comparing the target key directly with a junction column would change
+ * SQLite's collation precedence. Keeping the join also handles composite relation keys and
+ * excludes null junction keys without special truth-table guards.
+ *
+ * `key` must be a database-enforced unique constraint whose columns are all NOT NULL. That
+ * makes membership identify exactly one target row and keeps negation two-valued. SQLite can
+ * allow nulls even in primary keys, so callers must check notNull, not just primary.
+ *
+ * Build object restrictions and RAW callbacks against the inner target alias. Static RAW SQL
+ * is passed through by Drizzle: references to the outer target can still force a target scan.
+ * A RAW callback must use its supplied table to benefit from the identity lookup.
+ */
+function targetIdentityInRelation(
+  client: RelationQueryBuilder,
+  relation: Relation,
+  parentTable: Table,
+  targetTable: Table,
+  throughTable: Table,
+  key: Column[],
+): SQL {
+  const names = new Set([parentTable, targetTable, throughTable].map(getTableName));
+  let alias = '_pothos_related';
+
+  while (names.has(alias)) {
+    alias += '_';
+  }
+
+  const matchedTable = aliasedTable(targetTable, alias);
+  const { filter, joinCondition } = relationToSQL(
+    relation,
+    parentTable,
+    matchedTable,
+    throughTable,
+  ) as { filter: SQL; joinCondition: SQL };
+  const fields = Object.fromEntries(
+    key.map((column, i) => [String(i), sql`${aliasedTableColumn(column, alias)}`]),
+  );
+  const columns = key.map((column) => sql`${column}`);
+  const identity = columns.length === 1 ? columns[0] : sql`(${sql.join(columns, sql`, `)})`;
+
+  return inArray(
+    identity,
+    client.select(fields).from(throughTable).innerJoin(matchedTable, joinCondition).where(filter),
+  );
 }
 
 // A fresh `count(*)` each time: `mapWith` mutates the `SQL` it is called on, so a shared one

--- a/packages/plugin-drizzle/tests/junction-keys.test.ts
+++ b/packages/plugin-drizzle/tests/junction-keys.test.ts
@@ -1,0 +1,167 @@
+import { execute } from '@pothos/test-utils';
+import { aliasedTable, eq, inArray, relationToSQL, sql } from 'drizzle-orm';
+import { gql } from 'graphql-tag';
+import { buildRelationFilter } from '../src/utils/relation-filter';
+import {
+  client,
+  db,
+  EDITION_COUNT,
+  POST_ID,
+  posts,
+  postTags,
+  relations,
+  seed,
+  TAG_COUNT,
+  tags,
+} from './junction-keys/db';
+import { schema } from './junction-keys/schema';
+
+const statements: { sql: string; args: unknown }[] = [];
+const runStatement = client.execute.bind(client);
+(client as unknown as { execute: unknown }).execute = (statement: unknown, ...rest: unknown[]) => {
+  statements.push(
+    typeof statement === 'string'
+      ? { sql: statement, args: [] }
+      : (statement as { sql: string; args: unknown }),
+  );
+  return (runStatement as (...args: unknown[]) => unknown)(statement, ...rest);
+};
+beforeAll(seed);
+afterAll(() => client.close());
+
+async function query(fields: string, id = POST_ID) {
+  statements.length = 0;
+  const result = await execute({
+    schema,
+    document: gql(`{ post(id: ${id}) { ${fields} } }`),
+    contextValue: {},
+  });
+  expect(result.errors).toBeUndefined();
+  expect(statements).toHaveLength(1);
+  return (result.data as { post: Record<string, number> }).post;
+}
+async function plan() {
+  const statement = statements[0];
+  const result = await runStatement({
+    sql: `explain query plan ${statement.sql}`,
+    args: statement.args as never,
+  });
+  return result.rows.map((row) => String(row.detail)).join('\n');
+}
+
+describe('many-to-many target identity lookup', () => {
+  it('counts each target once, ignores dangling/null junction keys, and preserves negation', async () => {
+    expect(await query('relatedTagCount unrelatedTagCount')).toEqual({
+      relatedTagCount: 2,
+      unrelatedTagCount: TAG_COUNT - 2,
+    });
+    expect(await query('relatedTagCount unrelatedTagCount', 2)).toEqual({
+      relatedTagCount: 1,
+      unrelatedTagCount: TAG_COUNT - 1,
+    });
+    expect(await query('relatedTagCount unrelatedTagCount', 3)).toEqual({
+      relatedTagCount: 0,
+      unrelatedTagCount: TAG_COUNT,
+    });
+  });
+  it('looks up target identities without scanning the outer target table', async () => {
+    await query('relatedTagCount');
+    expect(statements[0].sql).toContain('"tags"."id" in (select "_pothos_related"."id"');
+    expect(statements[0].sql).toContain('inner join "tags" "_pothos_related"');
+    expect(await plan()).toContain('SEARCH tags USING INTEGER PRIMARY KEY');
+    expect(await plan()).not.toContain('SCAN tags');
+  });
+  it('applies target restrictions inside the join without correlating back to the outer target', async () => {
+    expect(await query('scopedTagCount')).toEqual({ scopedTagCount: 1 });
+    expect(statements[0].sql).toContain('"_pothos_related"."name" =');
+    expect(await plan()).toContain('SEARCH tags USING INTEGER PRIMARY KEY');
+    expect(await plan()).not.toContain('SCAN tags');
+  });
+  it('preserves static RAW scope semantics even though the outer reference requires a scan', async () => {
+    expect(await query('staticRawTagCount unrelatedStaticRawTagCount')).toEqual({
+      staticRawTagCount: 1,
+      unrelatedStaticRawTagCount: TAG_COUNT - 1,
+    });
+    await query('staticRawTagCount');
+    expect(statements[0].sql).toContain('"tags"."name" =');
+    expect(await plan()).toContain('SCAN tags');
+  });
+  it('uses an indexed target lookup when a RAW callback uses the supplied table', async () => {
+    expect(await query('callbackRawTagCount')).toEqual({ callbackRawTagCount: 1 });
+    expect(statements[0].sql).toContain('"_pothos_related"."name" =');
+    expect(await plan()).toContain('SEARCH tags USING INTEGER PRIMARY KEY');
+    expect(await plan()).not.toContain('SCAN tags');
+  });
+  it('preserves collation precedence even when numeric columns contain text', async () => {
+    const relation = relations.posts.relations.numericCodes;
+    const { filter, joinCondition } = relationToSQL(relation, posts, tags, postTags);
+    const [{ count: joined }] = await db
+      .select({ count: sql<number>`count(distinct ${tags.id})` })
+      .from(posts)
+      .innerJoin(postTags, filter!)
+      .innerJoin(tags, joinCondition!)
+      .where(eq(posts.id, POST_ID));
+    const directLookup = await db.$count(
+      tags,
+      inArray(
+        tags.code,
+        db.select({ code: postTags.code }).from(postTags).where(eq(postTags.postId, POST_ID)),
+      ),
+    );
+    expect(joined).toBe(1);
+    expect(directLookup).toBe(2);
+    expect(await query('numericCodeCount unrelatedNumericCodeCount')).toEqual({
+      numericCodeCount: joined,
+      unrelatedNumericCodeCount: TAG_COUNT - joined,
+    });
+    expect(statements[0].sql).not.toContain('exists');
+  });
+  it.each([
+    'editionCount',
+    'editionCodeCount',
+    'editionSlotCount',
+  ])('supports composite target identities with numeric, text, and composite joins: %s', async (field) => {
+    expect(await query(field)).toEqual({ [field]: 2 });
+    expect(statements[0].sql).toContain('("editions"."series", "editions"."number") in (select');
+    expect(statements[0].sql).not.toContain('exists');
+    expect(await plan()).not.toContain('SCAN editions');
+  });
+  it('preserves differing text collations in a composite relation', async () => {
+    const directLookup = await client.execute(`
+      select count(*) as count from editions where (series, number) in (
+        select series, number from post_editions where post_id = 1
+      )
+    `);
+    expect(directLookup.rows[0].count).toBe(3);
+    expect(await query('editionSlotCount')).toEqual({ editionSlotCount: 2 });
+  });
+
+  it('preserves negation for composite identities and nullable composite junction keys', async () => {
+    expect(await query('editionSlotCount unrelatedEditionSlotCount')).toEqual({
+      editionSlotCount: 2,
+      unrelatedEditionSlotCount: EDITION_COUNT - 2,
+    });
+    expect(await query('editionSlotCount unrelatedEditionSlotCount', 3)).toEqual({
+      editionSlotCount: 0,
+      unrelatedEditionSlotCount: EDITION_COUNT,
+    });
+  });
+  it('falls back to EXISTS when the only identity allows nulls', async () => {
+    expect(await query('relatedLabelCount unrelatedLabelCount')).toEqual({
+      relatedLabelCount: 2,
+      unrelatedLabelCount: 1,
+    });
+    expect(statements[0].sql).toContain('exists (select 1 from "post_labels"');
+  });
+  it('does not shadow a parent alias when creating the matched-target alias', async () => {
+    const parent = aliasedTable(posts, '_pothos_related');
+    const filter = buildRelationFilter(db as never, relations.posts.relations.tags, parent, [
+      tags.id,
+    ]).filter;
+    const result = await db
+      .select({ id: parent.id, count: db.$count(tags, filter) })
+      .from(parent)
+      .where(eq(parent.id, POST_ID));
+    expect(result).toEqual([{ id: POST_ID, count: 2 }]);
+  });
+});

--- a/packages/plugin-drizzle/tests/junction-keys/db.ts
+++ b/packages/plugin-drizzle/tests/junction-keys/db.ts
@@ -1,0 +1,159 @@
+import { createClient } from '@libsql/client';
+import { defineRelations, sql } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/libsql';
+import { integer, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+export const posts = sqliteTable('posts', {
+  id: integer('id').primaryKey(),
+});
+export const tags = sqliteTable('tags', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+  // The DDL gives this INTEGER column NOCASE collation and stores text in it.
+  code: integer('code'),
+});
+export const postTags = sqliteTable('post_tags', {
+  postId: integer('post_id').notNull(),
+  tagId: integer('tag_id'),
+  code: integer('code'),
+});
+export const editions = sqliteTable(
+  'editions',
+  {
+    series: text('series').notNull(),
+    number: integer('number').notNull(),
+    serial: integer('serial').notNull(),
+    code: text('code').notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.series, t.number] })],
+);
+export const postEditions = sqliteTable('post_editions', {
+  postId: integer('post_id').notNull(),
+  editionSerial: integer('edition_serial'),
+  editionCode: text('edition_code'),
+  series: text('series'),
+  number: integer('number'),
+});
+// Nullable unique keys cannot identify the two rows whose name is NULL.
+export const labels = sqliteTable('labels', {
+  name: text('name').unique(),
+  code: integer('code').notNull(),
+});
+export const postLabels = sqliteTable('post_labels', {
+  postId: integer('post_id').notNull(),
+  code: integer('code'),
+});
+export const schema = { posts, tags, postTags, editions, postEditions, labels, postLabels };
+export const relations = defineRelations(schema, (r) => ({
+  posts: {
+    tags: r.many.tags({
+      from: r.posts.id.through(r.postTags.postId),
+      to: r.tags.id.through(r.postTags.tagId),
+    }),
+    scopedTags: r.many.tags({
+      from: r.posts.id.through(r.postTags.postId),
+      to: r.tags.id.through(r.postTags.tagId),
+      where: { name: 'tag 1' },
+    }),
+    staticRawTags: r.many.tags({
+      from: r.posts.id.through(r.postTags.postId),
+      to: r.tags.id.through(r.postTags.tagId),
+      where: { RAW: sql`${tags.name} = 'tag 1'` },
+    }),
+    callbackRawTags: r.many.tags({
+      from: r.posts.id.through(r.postTags.postId),
+      to: r.tags.id.through(r.postTags.tagId),
+      where: { RAW: (table) => sql`${table.name} = 'tag 1'` },
+    }),
+    numericCodes: r.many.tags({
+      from: r.posts.id.through(r.postTags.postId),
+      to: r.tags.code.through(r.postTags.code),
+    }),
+    editions: r.many.editions({
+      from: r.posts.id.through(r.postEditions.postId),
+      to: r.editions.serial.through(r.postEditions.editionSerial),
+    }),
+    editionCodes: r.many.editions({
+      from: r.posts.id.through(r.postEditions.postId),
+      to: r.editions.code.through(r.postEditions.editionCode),
+    }),
+    editionSlots: r.many.editions({
+      from: r.posts.id.through(r.postEditions.postId),
+      to: [
+        r.editions.series.through(r.postEditions.series),
+        r.editions.number.through(r.postEditions.number),
+      ],
+    }),
+    labels: r.many.labels({
+      from: r.posts.id.through(r.postLabels.postId),
+      to: r.labels.code.through(r.postLabels.code),
+    }),
+  },
+  tags: {},
+  editions: {},
+  labels: {},
+}));
+export const client = createClient({ url: ':memory:' });
+export const db = drizzle({ client, relations });
+export type DrizzleRelations = typeof relations;
+export const POST_ID = 1;
+export const TAG_COUNT = 200;
+export const EDITION_COUNT = 5;
+
+export async function seed() {
+  await client.executeMultiple(`
+    create table posts (id integer primary key);
+    create table tags (id integer primary key, name text not null, code integer collate nocase);
+    create table post_tags (post_id integer not null, tag_id integer, code integer);
+    create index post_tags_parent on post_tags (post_id, tag_id);
+    create table editions (
+      series text collate nocase not null, number integer not null, serial integer not null, code text not null,
+      primary key (series, number)
+    );
+    create index editions_serial on editions (serial);
+    create index editions_code on editions (code);
+    create table post_editions (
+      post_id integer not null, edition_serial integer, edition_code text, series text, number integer
+    );
+    create index post_editions_parent on post_editions (post_id);
+    create table labels (name text unique, code integer not null);
+    create table post_labels (post_id integer not null, code integer);
+  `);
+  await db.insert(posts).values([{ id: POST_ID }, { id: 2 }, { id: 3 }]);
+  await db
+    .insert(tags)
+    .values(Array.from({ length: TAG_COUNT }, (_, i) => ({ id: i + 1, name: `tag ${i + 1}` })));
+  await db.insert(postTags).values([
+    { postId: POST_ID, tagId: 1 },
+    { postId: POST_ID, tagId: 1 },
+    { postId: POST_ID, tagId: 2 },
+    { postId: POST_ID, tagId: null },
+    { postId: POST_ID, tagId: 999 },
+    { postId: 2, tagId: 3 },
+  ]);
+  // Bypass the TypeScript number type: legal SQLite values must retain join semantics.
+  await client.executeMultiple(`
+    update tags set code = 'A' where id = 1;
+    update tags set code = 'B' where id = 2;
+    update post_tags set code = 'a' where tag_id = 1;
+    update post_tags set code = 'B' where tag_id = 2;
+    insert into labels values (null, 1), (null, 1), ('other', 2);
+    insert into post_labels values (1, 1);
+  `);
+  await db.insert(editions).values([
+    { series: 'a', number: 1, serial: 11, code: 'a1' },
+    { series: 'a', number: 2, serial: 12, code: 'a2' },
+    { series: 'a', number: 3, serial: 13, code: 'a3' },
+    { series: 'b', number: 1, serial: 21, code: 'b1' },
+    { series: 'b', number: 2, serial: 22, code: 'b2' },
+  ]);
+  await db.insert(postEditions).values([
+    { postId: POST_ID, editionSerial: 11, editionCode: 'a1', series: 'a', number: 1 },
+    { postId: POST_ID, editionSerial: 12, editionCode: 'a2', series: null, number: null },
+    { postId: POST_ID, editionSerial: null, editionCode: null, series: 'b', number: 1 },
+    // The target's NOCASE collation must not override the junction's binary comparison.
+    { postId: POST_ID, editionSerial: null, editionCode: null, series: 'A', number: 3 },
+    { postId: 2, editionSerial: 13, editionCode: 'a3', series: 'a', number: 3 },
+  ]);
+  await client.execute('analyze');
+}

--- a/packages/plugin-drizzle/tests/junction-keys/schema.ts
+++ b/packages/plugin-drizzle/tests/junction-keys/schema.ts
@@ -1,0 +1,116 @@
+import SchemaBuilder from '@pothos/core';
+import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
+import { not } from 'drizzle-orm';
+import { getTableConfig } from 'drizzle-orm/sqlite-core';
+import DrizzlePlugin from '../../src';
+import { type DrizzleRelations, db, editions, labels, relations, tags } from './db';
+
+interface Types {
+  DrizzleRelations: DrizzleRelations;
+}
+
+const builder = new SchemaBuilder<Types>({
+  plugins: [ScopeAuthPlugin, DrizzlePlugin],
+  drizzle: { client: db, getTableConfig, relations },
+  scopeAuth: { authScopes: () => ({}) },
+});
+
+builder.drizzleObject('posts', {
+  name: 'Post',
+  fields: (t) => ({
+    relatedTagCount: t.relatedField('tags', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { relatedTagCount: (post) => db.$count(tags, buildFilter(post)) },
+      }),
+      resolve: (post) => post.relatedTagCount,
+    }),
+    unrelatedTagCount: t.relatedField('tags', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { unrelatedTagCount: (post) => db.$count(tags, not(buildFilter(post))) },
+      }),
+      resolve: (post) => post.unrelatedTagCount,
+    }),
+    scopedTagCount: t.relatedField('scopedTags', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { scopedTagCount: (post) => db.$count(tags, buildFilter(post)) },
+      }),
+      resolve: (post) => post.scopedTagCount,
+    }),
+    staticRawTagCount: t.relatedField('staticRawTags', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { staticRawTagCount: (post) => db.$count(tags, buildFilter(post)) },
+      }),
+      resolve: (post) => post.staticRawTagCount,
+    }),
+    unrelatedStaticRawTagCount: t.relatedField('staticRawTags', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { unrelatedStaticRawTagCount: (post) => db.$count(tags, not(buildFilter(post))) },
+      }),
+      resolve: (post) => post.unrelatedStaticRawTagCount,
+    }),
+    callbackRawTagCount: t.relatedField('callbackRawTags', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { callbackRawTagCount: (post) => db.$count(tags, buildFilter(post)) },
+      }),
+      resolve: (post) => post.callbackRawTagCount,
+    }),
+    numericCodeCount: t.relatedField('numericCodes', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { numericCodeCount: (post) => db.$count(tags, buildFilter(post)) },
+      }),
+      resolve: (post) => post.numericCodeCount,
+    }),
+    unrelatedNumericCodeCount: t.relatedField('numericCodes', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { unrelatedNumericCodeCount: (post) => db.$count(tags, not(buildFilter(post))) },
+      }),
+      resolve: (post) => post.unrelatedNumericCodeCount,
+    }),
+    editionCount: t.relatedCount('editions'),
+    editionCodeCount: t.relatedCount('editionCodes'),
+    editionSlotCount: t.relatedCount('editionSlots'),
+    relatedLabelCount: t.relatedField('labels', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { relatedLabelCount: (post) => db.$count(labels, buildFilter(post)) },
+      }),
+      resolve: (post) => post.relatedLabelCount,
+    }),
+    unrelatedLabelCount: t.relatedField('labels', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { unrelatedLabelCount: (post) => db.$count(labels, not(buildFilter(post))) },
+      }),
+      resolve: (post) => post.unrelatedLabelCount,
+    }),
+    unrelatedEditionSlotCount: t.relatedField('editionSlots', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: {
+          unrelatedEditionSlotCount: (post) => db.$count(editions, not(buildFilter(post))),
+        },
+      }),
+      resolve: (post) => post.unrelatedEditionSlotCount,
+    }),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    post: t.drizzleField({
+      type: 'posts',
+      args: { id: t.arg.int({ required: true }) },
+      resolve: (query, _root, { id }) => db.query.posts.findFirst(query({ where: { id } })),
+    }),
+  }),
+});
+
+export const schema = builder.toSchema();

--- a/packages/plugin-drizzle/tests/postgres-junction-keys.test.ts
+++ b/packages/plugin-drizzle/tests/postgres-junction-keys.test.ts
@@ -1,0 +1,124 @@
+import { execute } from '@pothos/test-utils';
+import { eq, not, notInArray, sql } from 'drizzle-orm';
+import { gql } from 'graphql-tag';
+import { queryClient } from './postgres/db';
+import {
+  db,
+  EDITION_COUNT,
+  POST_ID,
+  postTags,
+  seed,
+  TAG_COUNT,
+  tags,
+} from './postgres/junction-keys/db';
+import { schema } from './postgres/junction-keys/schema';
+
+const statements: string[] = [];
+
+const session = Object.getPrototypeOf((db as unknown as { _: { session: object } })._.session) as {
+  prepareQuery: (...args: unknown[]) => unknown;
+};
+const prepareQuery = session.prepareQuery;
+
+session.prepareQuery = function patched(this: unknown, ...args: unknown[]) {
+  statements.push((args[0] as { sql: string }).sql);
+
+  return prepareQuery.apply(this, args);
+};
+
+beforeAll(seed);
+
+afterAll(async () => {
+  await queryClient.end();
+});
+
+async function query(document: string) {
+  statements.length = 0;
+
+  const result = await execute({ schema, document: gql(document), contextValue: {} });
+
+  expect(result.errors).toBeUndefined();
+
+  return result.data as Record<string, { [field: string]: number }>;
+}
+
+function onlyStatement() {
+  expect(statements).toHaveLength(1);
+
+  return statements[0] as string;
+}
+
+describe('a many-to-many relation the target table alone has to be filtered by, on postgres', () => {
+  describe('a `through` column that is nullable', () => {
+    it('reproduces `not exists`, which an unguarded `not in` does not', async () => {
+      const notExists = await db.$count(
+        tags,
+        not(
+          sql`exists (select 1 from ${postTags} where ${postTags.postId} = ${POST_ID} and ${postTags.tagId} = ${tags.id})`,
+        ),
+      );
+
+      const unguarded = await db.$count(
+        tags,
+        notInArray(
+          tags.id,
+          db.select({ key: postTags.tagId }).from(postTags).where(eq(postTags.postId, POST_ID)),
+        ),
+      );
+
+      expect(notExists).toBe(TAG_COUNT - 1);
+      expect(unguarded).toBe(0);
+
+      const data = await query(`{ post(id: ${POST_ID}) { relatedTagCount unrelatedTagCount } }`);
+
+      expect(data.post).toEqual({ relatedTagCount: 1, unrelatedTagCount: notExists });
+    });
+  });
+
+  describe('the SQL it emits', () => {
+    it('keeps EXISTS without adding a target self-join', async () => {
+      await query(`{ post(id: ${POST_ID}) { relatedTagCount } }`);
+
+      const statement = onlyStatement();
+
+      expect(statement).toContain('exists (select 1 from "jk_post_tags"');
+      expect(statement).not.toContain('_pothos_related');
+      expect(statement).not.toContain('inner join');
+    });
+
+    it('preserves scoped target restrictions in EXISTS', async () => {
+      const data = await query(`{ post(id: ${POST_ID}) { scopedTagCount } }`);
+      expect(data.post).toEqual({ scopedTagCount: 0 });
+      expect(onlyStatement()).toContain('"jk_tags"."name" =');
+    });
+
+    it('counts a target a composite key names without a distinct column to count by', async () => {
+      const data = await query(`{ post(id: ${POST_ID}) { editionCount } }`);
+
+      expect(data.post).toEqual({ editionCount: 2 });
+      expect(onlyStatement()).toContain('exists (select 1 from "jk_post_editions"');
+    });
+
+    it('keeps EXISTS for a text relation key', async () => {
+      const data = await query(`{ post(id: ${POST_ID}) { editionCodeCount } }`);
+
+      expect(data.post).toEqual({ editionCodeCount: 2 });
+      expect(onlyStatement()).toContain('exists (select 1 from "jk_post_editions"');
+    });
+  });
+
+  describe('a `through` spanning two columns', () => {
+    it('keeps EXISTS for composite joins and preserves negation', async () => {
+      const data = await query(
+        `{ post(id: ${POST_ID}) { editionSlotCount unrelatedEditionSlotCount } }`,
+      );
+
+      expect(data.post).toEqual({
+        editionSlotCount: 2,
+        unrelatedEditionSlotCount: EDITION_COUNT - 2,
+      });
+
+      expect(onlyStatement()).toContain('exists (select 1 from "jk_post_editions"');
+    });
+  });
+});

--- a/packages/plugin-drizzle/tests/postgres/junction-keys/db.ts
+++ b/packages/plugin-drizzle/tests/postgres/junction-keys/db.ts
@@ -1,0 +1,137 @@
+import { defineRelations } from 'drizzle-orm';
+import { integer, pgTable, primaryKey, text } from 'drizzle-orm/pg-core';
+import { drizzle } from 'drizzle-orm/postgres-js';
+import { queryClient } from '../db';
+
+export const posts = pgTable('jk_posts', {
+  id: integer('id').primaryKey(),
+  title: text('title').notNull(),
+});
+
+export const tags = pgTable('jk_tags', {
+  id: integer('id').primaryKey(),
+  name: text('name').notNull(),
+});
+
+export const postTags = pgTable('jk_post_tags', {
+  postId: integer('post_id').notNull(),
+  tagId: integer('tag_id'),
+});
+
+export const editions = pgTable(
+  'jk_editions',
+  {
+    series: text('series').notNull(),
+    number: integer('number').notNull(),
+    serial: integer('serial').notNull(),
+    code: text('code').notNull(),
+  },
+  (t) => [primaryKey({ columns: [t.series, t.number] })],
+);
+
+export const postEditions = pgTable('jk_post_editions', {
+  postId: integer('post_id').notNull(),
+  editionSerial: integer('edition_serial'),
+  editionCode: text('edition_code'),
+  series: text('series'),
+  number: integer('number'),
+});
+
+export const schema = { posts, tags, postTags, editions, postEditions };
+
+export const relations = defineRelations(schema, (r) => ({
+  posts: {
+    tags: r.many.tags({
+      from: r.posts.id.through(r.postTags.postId),
+      to: r.tags.id.through(r.postTags.tagId),
+    }),
+    scopedTags: r.many.tags({
+      from: r.posts.id.through(r.postTags.postId),
+      to: r.tags.id.through(r.postTags.tagId),
+      where: { name: 'tag 2' },
+    }),
+    editions: r.many.editions({
+      from: r.posts.id.through(r.postEditions.postId),
+      to: r.editions.serial.through(r.postEditions.editionSerial),
+    }),
+    editionCodes: r.many.editions({
+      alias: 'editionCodes',
+      from: r.posts.id.through(r.postEditions.postId),
+      to: r.editions.code.through(r.postEditions.editionCode),
+    }),
+    editionSlots: r.many.editions({
+      alias: 'editionSlots',
+      from: r.posts.id.through(r.postEditions.postId),
+      to: [
+        r.editions.series.through(r.postEditions.series),
+        r.editions.number.through(r.postEditions.number),
+      ],
+    }),
+  },
+  tags: {},
+  editions: {},
+}));
+
+export const db = drizzle({ client: queryClient, relations });
+
+export type DrizzleRelations = typeof relations;
+
+export const POST_ID = 1;
+export const TAG_COUNT = 20;
+export const EDITION_COUNT = 5;
+
+export async function seed() {
+  await queryClient.unsafe(`
+    drop table if exists jk_posts, jk_tags, jk_post_tags, jk_editions, jk_post_editions;
+    create table if not exists jk_posts (id integer primary key, title text not null);
+    create table if not exists jk_tags (id integer primary key, name text not null);
+    create table if not exists jk_post_tags (post_id integer not null, tag_id integer);
+    create table if not exists jk_editions (
+      series text not null,
+      number integer not null,
+      serial integer not null unique,
+      code text not null unique,
+      primary key (series, number)
+    );
+    create table if not exists jk_post_editions (
+      post_id integer not null,
+      edition_serial integer,
+      edition_code text,
+      series text,
+      number integer
+    );
+  `);
+
+  await db.insert(posts).values([
+    { id: POST_ID, title: 'the post under test' },
+    { id: 2, title: 'another post' },
+  ]);
+
+  await db.insert(tags).values(
+    Array.from({ length: TAG_COUNT }, (_, index) => ({
+      id: index + 1,
+      name: `tag ${index + 1}`,
+    })),
+  );
+
+  await db.insert(postTags).values([
+    { postId: POST_ID, tagId: 1 },
+    { postId: POST_ID, tagId: null },
+    { postId: 2, tagId: 2 },
+  ]);
+
+  await db.insert(editions).values([
+    { series: 'a', number: 1, serial: 11, code: 'a1' },
+    { series: 'a', number: 2, serial: 12, code: 'a2' },
+    { series: 'a', number: 3, serial: 13, code: 'a3' },
+    { series: 'b', number: 1, serial: 21, code: 'b1' },
+    { series: 'b', number: 2, serial: 22, code: 'b2' },
+  ]);
+
+  await db.insert(postEditions).values([
+    { postId: POST_ID, editionSerial: 11, editionCode: 'a1', series: 'a', number: 1 },
+    { postId: POST_ID, editionSerial: 12, editionCode: 'a2', series: null, number: null },
+    { postId: POST_ID, editionSerial: null, editionCode: null, series: 'b', number: 1 },
+    { postId: 2, editionSerial: 13, editionCode: 'a3', series: 'a', number: 3 },
+  ]);
+}

--- a/packages/plugin-drizzle/tests/postgres/junction-keys/schema.ts
+++ b/packages/plugin-drizzle/tests/postgres/junction-keys/schema.ts
@@ -1,0 +1,68 @@
+import SchemaBuilder from '@pothos/core';
+import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
+import { not } from 'drizzle-orm';
+import { getTableConfig } from 'drizzle-orm/pg-core';
+import DrizzlePlugin from '../../../src';
+import { type DrizzleRelations, db, editions, relations, tags } from './db';
+
+interface Types {
+  DrizzleRelations: DrizzleRelations;
+}
+
+const builder = new SchemaBuilder<Types>({
+  plugins: [ScopeAuthPlugin, DrizzlePlugin],
+  drizzle: { client: db, getTableConfig, relations },
+  scopeAuth: { authScopes: () => ({}) },
+});
+
+builder.drizzleObject('posts', {
+  name: 'Post',
+  fields: (t) => ({
+    title: t.exposeString('title'),
+    relatedTagCount: t.relatedField('tags', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { relatedTagCount: (post) => db.$count(tags, buildFilter(post)) },
+      }),
+      resolve: (post) => post.relatedTagCount,
+    }),
+    unrelatedTagCount: t.relatedField('tags', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { unrelatedTagCount: (post) => db.$count(tags, not(buildFilter(post))) },
+      }),
+      resolve: (post) => post.unrelatedTagCount,
+    }),
+    scopedTagCount: t.relatedField('scopedTags', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: { scopedTagCount: (post) => db.$count(tags, buildFilter(post)) },
+      }),
+      resolve: (post) => post.scopedTagCount,
+    }),
+    editionCount: t.relatedCount('editions'),
+    editionCodeCount: t.relatedCount('editionCodes'),
+    editionSlotCount: t.relatedCount('editionSlots'),
+    unrelatedEditionSlotCount: t.relatedField('editionSlots', {
+      type: 'Int',
+      select: (buildFilter) => ({
+        extras: {
+          unrelatedEditionSlotCount: (post) => db.$count(editions, not(buildFilter(post))),
+        },
+      }),
+      resolve: (post) => post.unrelatedEditionSlotCount,
+    }),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    post: t.drizzleField({
+      type: 'posts',
+      args: { id: t.arg.int({ required: true }) },
+      resolve: (query, _root, { id }) => db.query.posts.findFirst(query({ where: { id } })),
+    }),
+  }),
+});
+
+export const schema = builder.toSchema();

--- a/website/content/docs/plugins/drizzle/relations.mdx
+++ b/website/content/docs/plugins/drizzle/relations.mdx
@@ -149,6 +149,26 @@ it easier to filter for the related records.
 `extensions`, and options added by other plugins like `authScopes`). Its `resolve` may be async,
 and receives the resolve `info` as its fourth argument.
 
+### SQLite many-to-many filters
+
+On SQLite, `buildFilter` can look up related target identities through the junction join when the
+target has a non-null unique key. PostgreSQL retains an `EXISTS` predicate to avoid an additional
+target join.
+
+For a custom `RAW` scope in a Drizzle relation definition, use the table supplied to the callback:
+
+```ts
+where: {
+  RAW: (target) => sql`${target.published} = true`,
+},
+```
+
+This lets Drizzle use the target's alias inside the lookup. A static SQL scope referencing the
+original target table, such as ``RAW: sql`${posts.published} = true` ``, is passed through unchanged
+and can still force SQLite to scan the target table. The same applies to a callback that ignores
+its table argument and references `posts` directly. Object filters such as
+`where: { published: true }` also use the supplied alias.
+
 ## Related count
 
 For the common case of counting related records, there's a simpler `t.relatedCount` method that handles


### PR DESCRIPTION
Many-to-many predicates passed to `t.relatedField` currently use a correlated `EXISTS` over the junction. On SQLite this can scan the entire target table for every parent. This also affects `relatedCount` when it cannot count a single target column distinctly.

On SQLite, project the target's non-null unique identity through Drizzle's original relation join, then use that identity to filter the outer target:

```sql
target.id IN (
  SELECT matched.id
  FROM junction
  JOIN target AS matched ON <Drizzle's join condition>
  WHERE <parent correlation and relation restrictions>
)
```

The junction-to-target comparison retains Drizzle's operand order and collation semantics. The outer membership comparison uses the same target columns on both sides. This supports numeric, text, and composite relation keys without inspecting junction-column internals or inferring storage semantics from TypeScript types. Object restrictions and RAW callbacks using their supplied table are built against the inner alias so they do not correlate the lookup back to the outer target. Static RAW SQL is passed through unchanged; references to the outer target can still force a scan. The README and website document the alias-safe callback form.

PostgreSQL and other non-SQLite tables retain the original `EXISTS` predicate. PostgreSQL can plan it as a semijoin; projecting identities adds a target join the planner may retain, so the SQLite optimization is not applied there.

The identity comes from existing unique-constraint metadata, with every column required to be non-null. Composite identities use row-value membership. Tables without a suitable identity retain `EXISTS`; nullable unique keys cannot identify rows containing null. The join excludes null or dangling junction keys, and membership ignores duplicate junction rows while preserving negation. Existing join-based count paths and relations without a junction retain their behavior.

Drizzle's documented [`$count(table, filter)`](https://orm.drizzle.team/docs/query-utils#count) still requires a caller-supplied correlation. It does not infer junction joins or replace the composable target predicate exposed by `relatedField`; the plugin continues using Drizzle's count primitives and relation compiler.

Validation:

- All 301 plugin tests across 47 files pass, including SQLite and PostgreSQL.
- Type checking, CJS/ESM/declaration builds, Biome, and `git diff --check` pass.
- Regression coverage includes scoped relations, text and composite keys, mismatched text collations, text stored in SQLite INTEGER columns, nullable unique-key fallback, null/dangling/duplicate junction rows, empty relations, negation, parent-alias collisions, static RAW scope semantics, and indexed RAW callbacks.
- SQLite query-plan assertions verify indexed outer-target lookups for numeric, text, composite, object-scoped, and callback-scoped relations. PostgreSQL SQL assertions exclude the extra target join.

A local check of the generated SQL against 100,000 SQLite target rows, one parent, and ten measured repetitions after warmup gave approximately 3.74 ms → 0.016 ms for an unscoped relation and 2.00 ms → 0.018 ms for a scoped relation. Both plans changed from `SCAN tags` to an integer-primary-key lookup. These are local measurements, not timing assertions. The replacement adds an inner target join; database indexes and collations still determine how efficiently that join runs, while PostgreSQL retains the correctness-only base predicate.

Targets #1676. No changeset: the corrected many-to-many predicate belongs to that unpublished branch.
