### PR TITLE
fix(prisma-next): await nested selections in built-in fields

### DIFF
--- a/packages/core/src/utils/connection-args.ts
+++ b/packages/core/src/utils/connection-args.ts
@@ -1,0 +1,48 @@
+import { PothosValidationError } from '../errors.js';
+
+/** Arguments and limits for a cursor connection, independent of the Relay plugin. */
+export interface CursorConnectionOptions {
+  args: {
+    before?: string | null;
+    after?: string | null;
+    first?: number | null;
+    last?: number | null;
+  };
+  defaultSize?: number;
+  maxSize?: number;
+  totalCount?: number;
+}
+
+export function parseCursorConnectionArgs(options: CursorConnectionOptions) {
+  const { before, after, first, last } = options.args;
+
+  const defaultSize = options.defaultSize ?? 20;
+  const maxSize = options.maxSize ?? 100;
+
+  if (first != null && first < 0) {
+    throw new PothosValidationError('Argument "first" must be a non-negative integer');
+  }
+
+  if (last != null && last < 0) {
+    throw new PothosValidationError('Argument "last" must be a non-negative integer');
+  }
+
+  // `first`/`last` are checked for presence rather than truthiness so that a page size of 0
+  // (which the validation above allows) is treated as a requested page size, and not as an
+  // omitted argument.
+  const hasFirst = first != null;
+  const hasLast = last != null;
+
+  const limit = Math.min(first ?? last ?? defaultSize, maxSize) + 1;
+  const inverted = after ? hasLast && !hasFirst : (!!before && !hasFirst) || (!hasFirst && hasLast);
+
+  return {
+    before: before ?? undefined,
+    after: after ?? undefined,
+    limit,
+    expectedSize: limit - 1,
+    inverted,
+    hasPreviousPage: (resultSize: number) => (inverted ? resultSize >= limit : !!after),
+    hasNextPage: (resultSize: number) => (inverted ? !!before : resultSize >= limit),
+  };
+}

--- a/packages/core/src/utils/connection-args.ts
+++ b/packages/core/src/utils/connection-args.ts
@@ -13,12 +13,11 @@ export interface CursorConnectionOptions {
   totalCount?: number;
 }
 
-export function parseCursorConnectionArgs(options: CursorConnectionOptions) {
-  const { before, after, first, last } = options.args;
-
-  const defaultSize = options.defaultSize ?? 20;
-  const maxSize = options.maxSize ?? 100;
-
+/** Validate page-size arguments without imposing cursor or direction restrictions. */
+export function validateConnectionArguments({
+  first,
+  last,
+}: Pick<CursorConnectionOptions['args'], 'first' | 'last'>) {
   if (first != null && first < 0) {
     throw new PothosValidationError('Argument "first" must be a non-negative integer');
   }
@@ -26,6 +25,23 @@ export function parseCursorConnectionArgs(options: CursorConnectionOptions) {
   if (last != null && last < 0) {
     throw new PothosValidationError('Argument "last" must be a non-negative integer');
   }
+}
+
+/** Include one extra row so a connection can determine whether another page exists. */
+export function getConnectionPageSize({
+  args: { first, last },
+  defaultSize = 20,
+  maxSize = 100,
+}: Pick<CursorConnectionOptions, 'args' | 'defaultSize' | 'maxSize'>) {
+  const expectedSize = Math.min(first ?? last ?? defaultSize, maxSize);
+
+  return { limit: expectedSize + 1, expectedSize };
+}
+
+export function parseCursorConnectionArgs(options: CursorConnectionOptions) {
+  const { before, after, first, last } = options.args;
+
+  validateConnectionArguments(options.args);
 
   // `first`/`last` are checked for presence rather than truthiness so that a page size of 0
   // (which the validation above allows) is treated as a requested page size, and not as an
@@ -33,14 +49,18 @@ export function parseCursorConnectionArgs(options: CursorConnectionOptions) {
   const hasFirst = first != null;
   const hasLast = last != null;
 
-  const limit = Math.min(first ?? last ?? defaultSize, maxSize) + 1;
+  const { limit, expectedSize } = getConnectionPageSize({
+    ...options,
+    defaultSize: options.defaultSize ?? 20,
+    maxSize: options.maxSize ?? 100,
+  });
   const inverted = after ? hasLast && !hasFirst : (!!before && !hasFirst) || (!hasFirst && hasLast);
 
   return {
     before: before ?? undefined,
     after: after ?? undefined,
     limit,
-    expectedSize: limit - 1,
+    expectedSize,
     inverted,
     hasPreviousPage: (resultSize: number) => (inverted ? resultSize >= limit : !!after),
     hasNextPage: (resultSize: number) => (inverted ? !!before : resultSize >= limit),

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -21,6 +21,7 @@ import {
 } from '../types/index.js';
 
 export * from './base64.js';
+export * from './connection-args.js';
 export * from './context-cache.js';
 export * from './cursors.js';
 export * from './enums.js';

--- a/packages/plugin-prisma-next/ARCHITECTURE.md
+++ b/packages/plugin-prisma-next/ARCHITECTURE.md
@@ -29,7 +29,7 @@ around those two steps.
 | `src/prisma-next-object-field-builder.ts` | `PrismaNextObjectFieldBuilder`: `t.relation` / `t.relatedConnection` / `t.variant` / `t.expose*` / `t.withAuth`. |
 | `src/connection-helpers.ts` | `prismaConnectionHelpers` — public composable for custom paginators. |
 | `src/utils/adapter.ts` | The `@pothos/selection-mapper` adapter: the node, the spec map, the compile of `select` shapes, and `emit` (spec → builder chain). |
-| `src/utils/map-query.ts` | Public entry: `applySelectionToCollection` over `Plan.fromInfo` / `plan.query()`. |
+| `src/utils/map-query.ts` | Public entry: `applySelectionToCollection` over `Plan.fromInfo` / `adapter.toQuery(plan.play().root)`. |
 | `src/utils/model.ts` | One `PrismaNextModel` per contract model (relations with resolved targets, column set), built from the contract. |
 | `src/utils/branding.ts` | `rebrandForVariant` (used by `t.variant` only). |
 | `src/utils/refs.ts` | Per-builder ref cache (drizzle shape). |
@@ -74,13 +74,13 @@ The wrap runs in this order:
         await augmented.all() → rows
         return rows[0] ?? null  OR  rows  (based on isListType(returnType))
    if no: pass through (raw rows / null)
-4. normalizeRowsForType(rows): lift object-level combine slots to flat
-   row props (per-type-namespaced; see Combine slots below).
 ```
 
-If the user returned rows directly (already materialized), the plugin
-only runs step 4 — the auto-include step is skipped. This makes
-`t.prismaField({ resolve: () => null })` work as expected.
+Materialized rows pass through unchanged, including rows returned directly
+by the user. Model field resolvers lift their type-level and field-level
+combine slots into immutable parent overlays as each field resolves. This
+also covers rows reached through connections and nested relations without
+mutating shared source rows.
 
 ## The walker
 
@@ -90,8 +90,9 @@ supplies a `PrismaNextAdapter`, a subclass of the walker's `Adapter`,
 for prisma-next's builder-chain query format
 (`src/utils/adapter.ts`). `applySelectionToCollection(baseCollection,
 info, contract, ctx, opts)` (`src/utils/map-query.ts`) runs
-`Plan.fromInfo`, serializes the root with `plan.query()`, and emits the
-result onto the collection. The plan is synchronous unless a `select`
+`Plan.fromInfo`, waits for any pending selections, serializes the settled
+root with `adapter.toQuery(plan.play().root)`, and emits the result onto
+the collection. It does not publish unused loader mappings. The plan is synchronous unless a `select`
 callback returned a promise, in which case the augmented collection is
 a promise the plugin's own consumers await.
 
@@ -133,7 +134,8 @@ first walk, by `fieldSelection(field, type)`:
 - `t.variant` writes a field-level `pothosIndirectInclude { getType }`
   (no path) → a select function returning `nested(true)`, the variant
   type's selection set walked on the same row, plus the forced columns
-  of its `select` option.
+  of its `select` option. Its relation consumers receive a distinct
+  namespace for the variant field alias.
 - `t.relatedConnection` precompiles its own select function into
   `pothosPrismaNextFieldSelect` (see Connections).
 - Type-level `pothosPrismaNextSelect` (`prismaObject({ select })`) is
@@ -148,9 +150,10 @@ relation for the first time runs **FK augmentation**: the relation's
 `localFields` (the parent-side join columns) go into the node's columns,
 the workaround for prisma-next's nested-stitch plan needing the parent's
 FK on depth-2+ includes. The adapter extends `Adapter` directly and
-answers its six members and no more: every consumer has its own slot, so
-nothing conflicts, and the four merge rules are inherited from the base
-class ("nothing conflicts", "nothing to leave out"). Rows are read back
+answers its six members. To-many consumers have separate slots; shared
+to-one consumers must have compatible arguments and refinements. The
+adapter checks that compatibility when adding branches, while inheriting
+the base adapter's merge-policy hooks. Rows are read back
 through the per-resolve overlay, so the loader
 mappings the plan records are never looked up.
 
@@ -159,7 +162,10 @@ Then **emission** (`emit`, from the serialized root):
 ```
 acc = base.select(...columns)
 for each relation:
-  if single consumer (to-one, or one branch and no function entry):
+  if compatible to-one consumers:
+      merge child selections with distinct consumer scopes
+      acc = acc.include(name, cb => emitMergedChildren(cb))
+  else if single consumer (one branch and no function entry):
       acc = acc.include(name, cb => emitBranch(cb))   // fast path
   else:
       acc = acc.include(name, cb => cb.combine(specObject))  // multi-consumer
@@ -233,9 +239,9 @@ So inside `t.relation('posts').resolve` the parent's
 `posts['drafts:posts']` lifts to `overlay.posts` for the `drafts` field
 specifically. Each field sees its own slot under unprefixed keys.
 
-Object-level selects use a similar lift inside `normalizeRowsForType`,
-runs once per row on the result of `t.prismaField` rather than per
-field.
+Type-level relation slots are lifted into each model field's immutable
+parent overlay. The field's own slots are then read from the original
+source row, preserving independent type-level and field-level filters.
 
 ## Connections
 
@@ -351,3 +357,10 @@ See `feedback/prisma-next-painpoints.md` for the live list. Highlights:
 - N:M relations are emitted like any to-many include; prisma-next
   resolves the junction from the contract's `through` (painpoint #7,
   resolved upstream in 0.14).
+
+Type prerequisites and field selections read from the original source row
+into separate overlays. Shared to-one includes and same-row variants carry
+consumer scopes on these overlays so identical child field aliases remain
+independent. To-many includes own their rows and restart local scopes.
+Scopes are attached before downstream resolver wrappers run, preserving
+selection routing through errors-plugin result wrappers.

--- a/packages/plugin-prisma-next/README.md
+++ b/packages/plugin-prisma-next/README.md
@@ -6,8 +6,10 @@ prisma-next, makes it easier to define types backed by your contract, helps
 solve N+1 queries for relations, and ships Relay integrations for nodes and
 connections.
 
-> **Experimental.** `prisma-next` isn't on npm yet; this package is `private:
-> true` in the workspace until prisma-next publishes.
+> **Experimental.** This plugin tracks prisma-next `^0.16.0` (the `@prisma-next/*`
+> client packages, published on npm). Both prisma-next and this plugin are pre-1.0
+> and their APIs may still change. Pending a stable npm release, the plugin is
+> available as a PR preview via [pkg.pr.new](https://pkg.pr.new).
 
 ## Features
 

--- a/packages/plugin-prisma-next/package.json
+++ b/packages/plugin-prisma-next/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@pothos/plugin-prisma-next",
   "version": "0.1.0",
+  "private": true,
   "description": "A Pothos plugin for the new prisma-next client",
   "main": "./lib/index.js",
   "types": "./dts/index.d.ts",

--- a/packages/plugin-prisma-next/src/index.ts
+++ b/packages/plugin-prisma-next/src/index.ts
@@ -4,6 +4,7 @@ import './prisma-next-field-builder.js';
 import './schema-builder.js';
 import SchemaBuilder, {
   BasePlugin,
+  isThenable,
   type PothosOutputFieldConfig,
   PothosSchemaError,
   type PothosTypeConfig,
@@ -12,6 +13,7 @@ import SchemaBuilder, {
 import {
   type GraphQLFieldResolver,
   type GraphQLResolveInfo,
+  getNamedType,
   getNullableType,
   isListType,
 } from 'graphql';
@@ -22,7 +24,6 @@ import {
   PRISMA_NEXT_RELATIONS,
   PRISMA_NEXT_SELECT,
 } from './constants.js';
-import type { PreparedFieldExtension } from './extensions.js';
 import type { AnyContract } from './types.js';
 import { fieldAliasPrefix, objectLevelFieldAlias } from './utils/adapter.js';
 import { createApply } from './utils/apply.js';
@@ -132,79 +133,67 @@ async function materializeCollection(
   return wantsList ? rows : (rows[0] ?? null);
 }
 
-/**
- * Source-row normalize: lift object-level select entries from their
- * per-type namespaced combine slots (`row[rel][':object:<TypeName>:<key>']`)
- * up to top-level properties on each row. Runs at the t.prismaField
- * boundary so plain `t.field` resolvers on the type see the expected
- * flat shape.
- *
- * Per-type prefix means variants that share a row but declare distinct
- * object-level selects route to distinct slots without collision —
- * each variant's normalize uses its own type-name prefix.
- */
-function normalizeRowsForType(
-  value: unknown,
-  typeConfig: PothosTypeConfig | undefined,
-  contract: AnyContract | undefined,
-): unknown {
-  if (!typeConfig || !contract) {
-    return value;
-  }
-  const ext = (typeConfig.extensions ?? {}) as Record<string, unknown>;
-  const spec = ext[PRISMA_NEXT_SELECT];
-  if (!spec || Array.isArray(spec) || typeof spec !== 'object') {
-    return value;
-  }
-  const modelName = ext[PRISMA_NEXT_MODEL] as string | undefined;
-  if (!modelName) {
-    return value;
-  }
-  const relations = resolveContractModel(contract, modelName)?.relations;
-  if (!relations) {
-    return value;
-  }
-  const entries = Object.entries(spec as Record<string, unknown>).filter(
-    ([k]) => relations[k] !== undefined,
-  );
-  if (entries.length === 0) {
-    return value;
-  }
-  // The prefix the adapter wrote these slots under: e.g. `:object:User:` for the User
-  // prismaObject. Per-type, so variants sharing a row route to distinct slots.
-  const prefix = fieldAliasPrefix(objectLevelFieldAlias(typeConfig.name));
+// Inherited by variant wrappers so later resolvers can still read the original combine maps.
+const sourceRow = Symbol('prismaNextSourceRow');
 
-  const normalize = (row: unknown): unknown => {
-    if (row == null || typeof row !== 'object' || Array.isArray(row)) {
-      return row;
-    }
-    const r = row as Record<string, unknown>;
-    for (const [rel] of entries) {
-      const slot = r[rel];
-      if (slot && typeof slot === 'object' && !Array.isArray(slot)) {
-        const slotMap = slot as Record<string, unknown>;
-        for (const k of Object.keys(slotMap)) {
-          if (k.startsWith(prefix)) {
-            r[k.slice(prefix.length)] = slotMap[k];
-          }
-        }
-      }
-    }
-    return r;
-  };
+// A shared to-one include scopes child consumers, while the single-include fast
+// path keeps them local. Candidates record those explicit planner alternatives;
+// they are carried with the row, never reconstructed from a GraphQL response path.
+const rowScopes = Symbol('prismaNextRowScopes');
+type ScopedRow = { [sourceRow]?: object; [rowScopes]?: readonly string[] };
 
-  if (
-    value &&
-    typeof value === 'object' &&
-    'then' in value &&
-    typeof (value as { then?: unknown }).then === 'function'
-  ) {
-    return (value as Promise<unknown>).then((v) => normalizeRowsForType(v, typeConfig, contract));
+function childScopes(parent: object, alias: string): string[] {
+  return [...((parent as ScopedRow)[rowScopes] ?? []).map((scope) => `${scope}:${alias}`), alias];
+}
+
+function scopedRow(row: object, scopes: readonly string[]): object {
+  const wrapper = Object.create(row) as object;
+  Object.defineProperties(wrapper, {
+    [sourceRow]: { value: (row as ScopedRow)[sourceRow] ?? row },
+    [rowScopes]: { value: scopes },
+  });
+  return wrapper;
+}
+
+function selectedPrefix(slot: object, scopes: readonly string[]): string | undefined {
+  const keys = Object.keys(slot);
+  return scopes.map(fieldAliasPrefix).find((prefix) => keys.some((key) => key.startsWith(prefix)));
+}
+
+function liftSlots(overlay: object, slot: object, scopes: readonly string[]) {
+  const prefix = selectedPrefix(slot, scopes);
+  if (!prefix) {
+    return;
   }
-  if (Array.isArray(value)) {
-    return value.map(normalize);
+  for (const key of Object.keys(slot)) {
+    if (key.startsWith(prefix)) {
+      Object.defineProperty(overlay, key.slice(prefix.length), {
+        value: (slot as Record<string, unknown>)[key],
+        enumerable: true,
+        configurable: true,
+        writable: true,
+      });
+    }
   }
-  return normalize(value);
+}
+
+/** Present type-level selections without modifying the shared ORM row or its combine maps. */
+function normalizeParentForType(
+  parent: object,
+  relations: readonly string[],
+  alias: string,
+): Record<string, unknown> {
+  const overlay = Object.create(parent) as Record<string, unknown>;
+  const source = (parent as ScopedRow)[sourceRow] ?? parent;
+  Object.defineProperty(overlay, sourceRow, { value: source });
+  const scopes = childScopes(parent, alias);
+  for (const relation of relations) {
+    const slot = (source as Record<string, unknown>)[relation];
+    if (slot && typeof slot === 'object' && !Array.isArray(slot)) {
+      liftSlots(overlay, slot, scopes);
+    }
+  }
+  return overlay;
 }
 
 export class PothosPrismaNextPlugin<Types extends SchemaTypes> extends BasePlugin<Types> {
@@ -255,8 +244,6 @@ export class PothosPrismaNextPlugin<Types extends SchemaTypes> extends BasePlugi
     const ext = (fieldConfig.extensions ?? {}) as Record<string | symbol, unknown>;
 
     if (ext[PRISMA_NEXT_PREPARED]) {
-      const prepared = ext[PRISMA_NEXT_PREPARED] as PreparedFieldExtension;
-      const { typeName } = prepared;
       // Resolve plugin options once at schema-build time — `wrapResolve`
       // runs per field; the returned closure runs per request.
       const opts = readPluginOptions<AnyContract>(this.builder);
@@ -265,19 +252,6 @@ export class PothosPrismaNextPlugin<Types extends SchemaTypes> extends BasePlugi
       }
       const mapperOpts = mapperOptionsFromPluginOpts(opts);
       const contract = opts.contract;
-      // Resolve the return type's config once so the per-resolve
-      // normalize step has a stable handle to the object-level select
-      // manifest. `getTypeConfig` walks buildCache — cheap on first
-      // call, hashed on subsequent.
-      let returnTypeConfig: PothosTypeConfig | undefined;
-      try {
-        returnTypeConfig = this.buildCache.getTypeConfig(typeName);
-      } catch {
-        // typeName might be an interface or union — normalize is
-        // skipped in that case (object-level select isn't defined on
-        // those abstract types).
-        returnTypeConfig = undefined;
-      }
       return async (parent, args, context, info) => {
         const raw = (
           resolver as unknown as (
@@ -294,14 +268,13 @@ export class PothosPrismaNextPlugin<Types extends SchemaTypes> extends BasePlugi
 
         // Auto-wrap: if the resolver returned a Collection (duck-typed
         // via `.select` + `.all`), apply selection and materialize.
-        // Anything else (null, array, raw row) passes through to the
-        // row normalizer.
+        // Anything else (null, array, raw row) passes through unchanged.
         const materialized =
           result != null && !Array.isArray(result) && isOrmCollection(result)
             ? await materializeCollection(result, info, contract, context, mapperOpts)
             : result;
 
-        return normalizeRowsForType(materialized, returnTypeConfig, contract);
+        return materialized;
       };
     }
 
@@ -321,52 +294,30 @@ export class PothosPrismaNextPlugin<Types extends SchemaTypes> extends BasePlugi
       selectOpt !== undefined &&
       ((typeof selectOpt === 'object' && selectOpt !== null && !Array.isArray(selectOpt)) ||
         typeof selectOpt === 'function');
-    // `t.variant` routes through `pothosIndirectInclude` and carries no object `select` of its
-    // own, but the type it descends into may have one, whose entries land in that type's
-    // object-level combine slots. Without the wrap, `normalizeRowsForType` never lifts them.
-    //
-    // Only the pathless marker is a variant: `t.relatedConnection` sets one carrying `paths`, and
-    // it needs no wrap of its own -- giving it one would hand its resolver a cloned parent whose
-    // own properties differ from the row it was passed.
+    const parentTypeConfig = this.buildCache.getTypeConfig(fieldConfig.parentType);
+    const typeSelect = parentTypeConfig.extensions?.[PRISMA_NEXT_SELECT];
+    const modelName = parentTypeConfig.extensions?.[PRISMA_NEXT_MODEL] as string | undefined;
+    const contract = readPluginOptions<AnyContract>(this.builder)?.contract;
+    const modelRelations =
+      contract && modelName ? resolveContractModel(contract, modelName)?.relations : undefined;
+    const toOneRelations = Object.entries(modelRelations ?? {})
+      .filter(([, relation]) => relation.cardinality !== '1:N' && relation.cardinality !== 'N:M')
+      .map(([name]) => name);
+    const typeRelations =
+      typeSelect && !Array.isArray(typeSelect) && typeof typeSelect === 'object'
+        ? Object.keys(typeSelect).filter((key) => modelRelations?.[key] !== undefined)
+        : [];
+    const typeAlias = objectLevelFieldAlias(parentTypeConfig.name);
+    const hasTypeSelect = typeRelations.length > 0;
+    const hasFieldSelect = isObjectOrCallableSelect || !!ext[PRISMA_NEXT_FIELD_SELECT];
     const indirect = ext.pothosIndirectInclude as
-      | { path?: unknown[]; paths?: unknown[][] }
+      | { path?: unknown[]; paths?: unknown[] }
       | undefined;
-    const isVariantDescent =
-      indirect !== undefined && indirect.path === undefined && indirect.paths === undefined;
-
-    if (!isObjectOrCallableSelect && !ext[PRISMA_NEXT_FIELD_SELECT] && !isVariantDescent) {
+    const isSameRow = !!indirect && !indirect.path?.length && !indirect.paths?.length;
+    if (!hasTypeSelect && !hasFieldSelect && !isSameRow) {
       return resolver;
     }
     const baseResolver = resolver;
-    // Resolve the field's return type config once at schema-build so
-    // the per-resolve normalize step can apply object-level select
-    // entries from the returned type. Per-boundary local rewrap: each
-    // field returning rows normalizes them before downstream resolvers
-    // run.
-    const builderForCapture = this.builder;
-    const buildCacheForCapture = this.buildCache;
-    let returnTypeConfig: PothosTypeConfig | undefined;
-    try {
-      const fieldType = (
-        fieldConfig as unknown as {
-          type: {
-            kind?: string;
-            type?: { ref?: string; name?: string };
-            ref?: string;
-            name?: string;
-          };
-        }
-      ).type;
-      const inner = fieldType?.type ?? fieldType;
-      const refName =
-        (inner as { ref?: string; name?: string })?.name ?? (inner as { ref?: string })?.ref;
-      if (typeof refName === 'string') {
-        returnTypeConfig = buildCacheForCapture.getTypeConfig(refName);
-      }
-    } catch {
-      returnTypeConfig = undefined;
-    }
-    const contractForCapture = readPluginOptions<AnyContract>(builderForCapture)?.contract;
 
     return (parent, args, context, info) => {
       if (parent == null || typeof parent !== 'object') {
@@ -374,29 +325,64 @@ export class PothosPrismaNextPlugin<Types extends SchemaTypes> extends BasePlugi
       }
       // The prefix the adapter wrote the combine slot under. `:` is GraphQL-forbidden, so it
       // cannot collide with a user-defined alias or relation name.
-      const prefix = fieldAliasPrefix(info.fieldNodes[0]?.alias?.value ?? info.fieldName);
-      const p = parent as Record<string, unknown>;
+      const alias = info.fieldNodes[0]?.alias?.value ?? info.fieldName;
+      const scopes = childScopes(parent, alias);
+      const p = ((parent as { [sourceRow]?: object })[sourceRow] ?? parent) as Record<
+        string,
+        unknown
+      >;
       // Object.create(parent) preserves the prototype chain so variant
       // re-brands (which use Object.create to attach a type brand)
       // still surface their inherited row props via overlay. Adding a
       // top-level property on the overlay shadows that level only.
-      const overlay = Object.create(p) as Record<string, unknown>;
+      const overlay = normalizeParentForType(parent, typeRelations, typeAlias);
       // `for...in` over `p` walks the prototype chain so we still find combine slots when
       // `parent` is a variant wrapper from `rebrandForVariant` (which puts the row on the
       // prototype). It never yields a shadowed name twice, so no visited set is needed.
-      for (const key in p) {
+      for (const key in hasFieldSelect ? p : {}) {
         const slot = p[key];
         if (slot && typeof slot === 'object' && !Array.isArray(slot)) {
-          for (const k of Object.keys(slot)) {
-            if (k.startsWith(prefix)) {
-              const innerKey = k.slice(prefix.length);
-              overlay[innerKey] = (slot as Record<string, unknown>)[k];
-            }
+          liftSlots(overlay, slot, scopes);
+        }
+      }
+      // Scope model rows before other plugins transform the field's return shape.
+      // Errors success wrappers, for example, expose this same row via a data
+      // field even though their declared GraphQL return type is a union.
+      if (hasFieldSelect) {
+        for (const name of toOneRelations) {
+          const value = overlay[name];
+          if (value && typeof value === 'object' && !Array.isArray(value)) {
+            Object.defineProperty(overlay, name, {
+              value: scopedRow(value, scopes),
+              enumerable: true,
+              configurable: true,
+              writable: true,
+            });
           }
         }
       }
       const result = baseResolver(overlay, args, context, info);
-      return normalizeRowsForType(result, returnTypeConfig, contractForCapture);
+      const finish = (value: unknown) => {
+        if (!value || typeof value !== 'object' || value instanceof Error) {
+          return value;
+        }
+        if (Array.isArray(value)) {
+          // To-many branches own their rows; descendants use local namespaces.
+          return value.some(
+            (row) => row && typeof row === 'object' && (row as ScopedRow)[rowScopes],
+          )
+            ? value.map((row) => (row && typeof row === 'object' ? scopedRow(row, []) : row))
+            : value;
+        }
+        if (isSameRow) {
+          return scopedRow(value, scopes);
+        }
+        if (getNamedType(info.returnType).extensions?.[PRISMA_NEXT_MODEL]) {
+          return (value as ScopedRow)[rowScopes] === scopes ? value : scopedRow(value, scopes);
+        }
+        return value;
+      };
+      return isThenable(result) ? Promise.resolve(result).then(finish) : finish(result);
     };
   }
 }

--- a/packages/plugin-prisma-next/src/prisma-next-object-field-builder.ts
+++ b/packages/plugin-prisma-next/src/prisma-next-object-field-builder.ts
@@ -5,6 +5,7 @@ import {
   type FieldRef,
   type InferredFieldOptionKeys,
   type InputFieldMap,
+  isThenable,
   type NormalizeArgs,
   type PluginName,
   PothosSchemaError,
@@ -617,40 +618,41 @@ export class PrismaNextObjectFieldBuilder<
         refine != null ? (refine(rel, args, ctx) as MapperCollection) : rel;
       const resolvedDefault = resolveSizeOption(defaultSize, args, ctx) ?? fallbackDefault;
       const resolvedMax = resolveSizeOption(maxSize, args, ctx) ?? fallbackMax;
-      const rows: PrismaNextSpec = {
-        ...nested(
-          {
-            slot: 'rows',
-            columns: cursorCols,
-            // The user's `where` comes BEFORE cursor pagination so the cursor over-fetch
-            // (`take(N+1)`) runs on the matching set.
-            refine: (rel) =>
-              applyCursorPagination(
-                filter(rel),
-                cursorOpt,
-                args as import('@pothos/plugin-relay').DefaultConnectionArguments,
-                {
-                  ...(resolvedDefault !== undefined ? { defaultSize: resolvedDefault } : {}),
-                  ...(resolvedMax !== undefined ? { maxSize: resolvedMax } : {}),
-                },
-              ).collection,
-          },
-          pothosIndirectInclude,
-        ),
-        args: args as Record<string, unknown>,
-      };
-      // Synthetic count fires only when the client selected totalCount AND
-      // the user opted in via `totalCount: true`. Callable totalCount stays
-      // in the resolver — no extra DB round-trip in the spec.
-      const wantsTotalCount = totalCountFlag && selectedFieldNode(['totalCount']) !== null;
-
-      return {
-        relations: {
-          [relationName]: wantsTotalCount
-            ? [rows, { fn: (sub: MapperCollection) => ({ count: filter(sub).count() }) }]
-            : rows,
+      const selection = nested(
+        {
+          slot: 'rows',
+          columns: cursorCols,
+          // The user's `where` comes BEFORE cursor pagination so the cursor over-fetch
+          // (`take(N+1)`) runs on the matching set.
+          refine: (rel) =>
+            applyCursorPagination(
+              filter(rel),
+              cursorOpt,
+              args as import('@pothos/plugin-relay').DefaultConnectionArguments,
+              {
+                ...(resolvedDefault !== undefined ? { defaultSize: resolvedDefault } : {}),
+                ...(resolvedMax !== undefined ? { maxSize: resolvedMax } : {}),
+              },
+            ).collection,
         },
+        pothosIndirectInclude,
+      ) as PrismaNextSpec | PromiseLike<PrismaNextSpec>;
+      const finish = (selected: PrismaNextSpec): PrismaNextSpec => {
+        const rows = { ...selected, args: args as Record<string, unknown> };
+        // Synthetic count fires only when the client selected totalCount AND
+        // the user opted in via `totalCount: true`. Callable totalCount stays
+        // in the resolver — no extra DB round-trip in the spec.
+        const wantsTotalCount = totalCountFlag && selectedFieldNode(['totalCount']) !== null;
+
+        return {
+          relations: {
+            [relationName]: wantsTotalCount
+              ? [rows, { fn: (sub: MapperCollection) => ({ count: filter(sub).count() }) }]
+              : rows,
+          },
+        };
       };
+      return isThenable(selection) ? Promise.resolve(selection).then(finish) : finish(selection);
     };
 
     const connectionConfig = {

--- a/packages/plugin-prisma-next/src/utils/adapter.ts
+++ b/packages/plugin-prisma-next/src/utils/adapter.ts
@@ -7,7 +7,7 @@
  * `.include(rel, ...)` / `.combine({...})` calls on the resolver's collection.
  *
  * Every relation consumer gets its own combine slot (`<alias>:<slot>`, or
- * `:object:<Type>:<slot>` for a type-level select), so nothing ever conflicts: the adapter
+ * `:object:<Type>:<slot>` for a type-level select), while compatible to-one consumers share one include. The adapter
  * extends `Adapter` directly, answers its six members and implements no no-op — the four merge
  * rules are inherited. Rows are read back through the per-resolve overlay in the plugin index,
  * so the loader mappings the plan records are never looked up.
@@ -235,20 +235,19 @@ function addBranch(
   const args = spec.args ?? {};
   let branch = relation.branches.get(id);
 
-  if (!branch) {
-    // To-one relations can't carry multiple branches — the orm returns
-    // one row, so sibling aliases would each want their own refined view
-    // of the same row.
-    if (!relation.meta.isToMany && relation.branches.size > 0) {
-      throw new PothosValidationError(
-        `Relation "${name}" is to-one — only one branch allowed, got alias "${id}" plus ${[
-          ...relation.branches.keys(),
-        ]
-          .map((key) => `"${key}"`)
-          .join(', ')}.`,
-      );
+  // The ORM supports one include for a to-one relation. Keep every consumer's
+  // selection namespace, but only share the include when its query agrees.
+  if (!relation.meta.isToMany) {
+    for (const existing of relation.branches.values()) {
+      if (!deepEqual(existing.args, args) || !sameRefine(existing.refine, spec.refine)) {
+        throw new PothosValidationError(
+          `Relation "${name}" is to-one and has incompatible queries under aliases "${selectBranchAlias(existing.alias, existing.slot)}" and "${id}".`,
+        );
+      }
     }
+  }
 
+  if (!branch) {
     branch = {
       alias,
       slot,
@@ -439,8 +438,23 @@ function isDeclarativeRefineSpec(value: unknown): value is DeclarativeRefineSpec
  * model accessor; static `where` objects pass through to `.where()`
  * directly.
  */
+const declarativeRefines = new WeakMap<PrismaNextRefine, DeclarativeRefineSpec>();
+
+function sameRefine(a: PrismaNextRefine | undefined, b: PrismaNextRefine | undefined): boolean {
+  return (
+    a === b ||
+    !!(
+      a &&
+      b &&
+      declarativeRefines.has(a) &&
+      declarativeRefines.has(b) &&
+      deepEqual(declarativeRefines.get(a), declarativeRefines.get(b))
+    )
+  );
+}
+
 export function compileDeclarativeRefine(spec: DeclarativeRefineSpec): PrismaNextRefine {
-  return (rel) => {
+  const refine: PrismaNextRefine = (rel) => {
     let r = rel;
     if (spec.where !== undefined) {
       r = r.where(spec.where);
@@ -456,6 +470,8 @@ export function compileDeclarativeRefine(spec: DeclarativeRefineSpec): PrismaNex
     }
     return r;
   };
+  declarativeRefines.set(refine, spec);
+  return refine;
 }
 
 interface CompileOptions {
@@ -624,11 +640,17 @@ function compileFieldSelection(
   if (indirect && !indirect.path?.length && !indirect.paths?.length) {
     const forced = Array.isArray(raw) ? (raw as readonly string[]) : [];
 
-    return (_args, _ctx, nested) => {
+    return (_args, _ctx, nested, _selected, position) => {
       const selection = nested(true) as PrismaNextSpec | PromiseLike<PrismaNextSpec>;
-      return isThenable(selection)
-        ? Promise.resolve(selection).then((spec) => withColumns(spec, [...exposed, ...forced]))
-        : withColumns(selection, [...exposed, ...forced]);
+      const finish = (spec: PrismaNextSpec) =>
+        withColumns(
+          scopeChildConsumers({
+            ...spec,
+            alias: position.node.alias?.value ?? position.node.name.value,
+          }),
+          [...exposed, ...forced],
+        );
+      return isThenable(selection) ? Promise.resolve(selection).then(finish) : finish(selection);
     };
   }
 
@@ -721,20 +743,43 @@ function compileTypeSelection(
   type: GraphQLNamedType,
   model: PrismaNextModel | undefined,
 ): PrismaNextSpec | undefined {
-  const raw = type.extensions?.[PRISMA_NEXT_SELECT] as RawSelect | undefined;
-
-  if (!raw) {
+  if (!model) {
     return undefined;
   }
 
-  return compileSelect(raw, {
-    model,
-    owner: type.name,
-    label: 'prismaObject select',
-    alias: objectLevelFieldAlias(type.name),
-    // A type-level function entry runs with no field arguments.
-    fn: (value) => (sub, ctx) => value(sub, {}, ctx) as Record<string, unknown>,
-  });
+  const node = createPrismaNextNode(model);
+  const visited = new Set<GraphQLNamedType>();
+  let hasSelection = false;
+  const collect = (current: GraphQLNamedType) => {
+    if (visited.has(current)) {
+      return;
+    }
+    visited.add(current);
+    // Inherited fields retain their defining interface's resolver and slot namespace.
+    // Load those prerequisites even when the GraphQL return type is concrete.
+    if ('getInterfaces' in current) {
+      for (const iface of current.getInterfaces()) {
+        collect(iface);
+      }
+    }
+    const raw = current.extensions?.[PRISMA_NEXT_SELECT] as RawSelect | undefined;
+    if (!raw) {
+      return;
+    }
+    hasSelection = true;
+    const alias = objectLevelFieldAlias(current.name);
+    const spec = compileSelect(raw, {
+      model,
+      owner: current.name,
+      label: 'prismaObject select',
+      alias,
+      // A type-level function entry runs with no field arguments.
+      fn: (value) => (sub, ctx) => value(sub, {}, ctx) as Record<string, unknown>,
+    });
+    mergeSpec(node, spec, alias);
+  };
+  collect(type);
+  return hasSelection ? serializeNode(node) : undefined;
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -742,9 +787,9 @@ function compileTypeSelection(
 // ---------------------------------------------------------------------------------------------
 
 /**
- * Every relation consumer gets its own combine slot, so there is nothing to compare and nothing
- * to leave out: `canMergeQuery`, `firstConflict`, `mergeNode` and `canMergeNode` are inherited, and the package
- * answers "nothing ever conflicts" for them. The contract the models come from, and the compiled
+ * To-many consumers get separate combine slots; to-one consumers share a compatible query
+ * or fail validation while merging. There is no fallback loader: `canMergeQuery`, `firstConflict`, `mergeNode` and `canMergeNode` are inherited, and the package
+ * does not route conflicts to a fallback. The contract the models come from, and the compiled
  * selections cached against the schema's types and fields, are this object's own state.
  */
 export class PrismaNextAdapter extends Adapter<PrismaNextModel, PrismaNextSpec, PrismaNextNode> {
@@ -860,6 +905,26 @@ export function emit(
   return acc;
 }
 
+/**
+ * Sharing a to-one row must not also share its consumers' child queries. Scope
+ * the immediate child slots by their parent consumer; a further shared to-one
+ * include adds another level when it is emitted. A to-many include owns its
+ * rows, so its descendants keep their local namespaces.
+ */
+function scopeChildConsumers(branch: PrismaNextSpec): PrismaNextSpec {
+  if (!branch.relations) {
+    return branch;
+  }
+  const relations: NonNullable<PrismaNextSpec['relations']> = {};
+  for (const [name, entries] of Object.entries(branch.relations)) {
+    relations[name] = (Array.isArray(entries) ? entries : [entries]).map((entry) => {
+      const child = entry === true ? {} : typeof entry === 'function' ? { fn: entry } : entry;
+      return { ...child, alias: selectBranchAlias(branch.alias!, child.alias ?? branch.alias!) };
+    });
+  }
+  return { ...branch, relations };
+}
+
 // Single-consumer fast path: `.include(rel, cb => …)` direct — at most one branch and no
 // function-form entry. Several branches or any function-form entry goes through
 // `.combine({...})` for collision-free aliasing — prisma-next's planner falls back to
@@ -884,6 +949,16 @@ function emitRelation(
   const functions = list.filter(
     (entry): entry is PrismaNextFnEntry | PrismaNextSpecFn => !isBranch(entry) && entry !== true,
   );
+
+  if (!meta.isToMany && branches.length > 1 && functions.length === 0) {
+    const shared = createPrismaNextNode(meta.target);
+    for (const branch of branches) {
+      mergeSpec(shared, scopeChildConsumers(branch), branch.alias);
+    }
+    return parent.include(name, (rel) =>
+      emitBranch({ ...serializeNode(shared), refine: branches[0].refine }, rel, meta.target, ctx),
+    );
+  }
 
   if (branches.length <= 1 && functions.length === 0) {
     const branch = branches[0];

--- a/packages/plugin-prisma-next/src/utils/adapter.ts
+++ b/packages/plugin-prisma-next/src/utils/adapter.ts
@@ -624,7 +624,12 @@ function compileFieldSelection(
   if (indirect && !indirect.path?.length && !indirect.paths?.length) {
     const forced = Array.isArray(raw) ? (raw as readonly string[]) : [];
 
-    return (_args, _ctx, nested) => withColumns(nested(true), [...exposed, ...forced]);
+    return (_args, _ctx, nested) => {
+      const selection = nested(true) as PrismaNextSpec | PromiseLike<PrismaNextSpec>;
+      return isThenable(selection)
+        ? Promise.resolve(selection).then((spec) => withColumns(spec, [...exposed, ...forced]))
+        : withColumns(selection, [...exposed, ...forced]);
+    };
   }
 
   if (raw === undefined) {
@@ -635,26 +640,59 @@ function compileFieldSelection(
     value: RawSelect,
     args: PrismaNextArgs,
     nested: NestedSelection<PrismaNextSpec>,
-  ): PrismaNextSpec =>
-    withColumns(
-      compileSelect(value, {
-        model: parentModel,
-        owner,
-        label: 'select',
-        args,
-        // The nested selection is walked as the field's return type, so when that type is
-        // known to be backed by another model than the relation's, the entry is a bare include.
-        branch: (relation, query) =>
-          returnModel && returnModel !== relation.target ? (query ?? {}) : nested(query),
-        fn: (value) => (sub, fnCtx) =>
-          (value as PrismaNextSpecFn & ((s: unknown, a: unknown, c: unknown) => never))(
-            sub,
-            args,
-            fnCtx,
-          ) as Record<string, unknown>,
-      }),
-      exposed,
-    );
+  ): PrismaNextSpec | Promise<PrismaNextSpec> => {
+    const pending: Promise<void>[] = [];
+    const branches: PrismaNextSpec[] = [];
+    let index = 0;
+    let replay = false;
+    const build = () =>
+      withColumns(
+        compileSelect(value, {
+          model: parentModel,
+          owner,
+          label: 'select',
+          args,
+          // The nested selection is walked as the field's return type, so when that type is
+          // known to be backed by another model than the relation's, the entry is a bare include.
+          branch: (relation, query) => {
+            const slot = index++;
+            if (replay) {
+              return branches[slot];
+            }
+            const selection = (
+              returnModel && returnModel !== relation.target ? (query ?? {}) : nested(query)
+            ) as PrismaNextSpec | PromiseLike<PrismaNextSpec>;
+            if (isThenable(selection)) {
+              pending.push(
+                Promise.resolve(selection).then((spec) => {
+                  branches[slot] = spec;
+                }),
+              );
+              return {};
+            }
+            branches[slot] = selection;
+            return selection;
+          },
+          fn: (value) => (sub, fnCtx) =>
+            (value as PrismaNextSpecFn & ((s: unknown, a: unknown, c: unknown) => never))(
+              sub,
+              args,
+              fnCtx,
+            ) as Record<string, unknown>,
+        }),
+        exposed,
+      );
+    const spec = build();
+    // The compiler spreads each branch into its relation entry. Rebuild with settled
+    // branches so no promise is spread, without invoking nested selections a second time.
+    return pending.length === 0
+      ? spec
+      : Promise.all(pending).then(() => {
+          replay = true;
+          index = 0;
+          return build();
+        });
+  };
 
   if (typeof raw === 'function') {
     return (args, ctx, nested) => {

--- a/packages/plugin-prisma-next/src/utils/cursors.ts
+++ b/packages/plugin-prisma-next/src/utils/cursors.ts
@@ -5,8 +5,8 @@ import {
   encodeCursorChunk,
   encodeCursorTuple,
   PothosValidationError,
+  parseCursorConnectionArgs,
 } from '@pothos/core';
-import { parseCursorConnectionArgs } from '@pothos/plugin-relay';
 import { and, or } from '@prisma-next/sql-orm-client';
 import type { MapperCollection } from './adapter.js';
 

--- a/packages/plugin-prisma-next/src/utils/map-query.ts
+++ b/packages/plugin-prisma-next/src/utils/map-query.ts
@@ -33,10 +33,11 @@ export function applySelectionToCollection(
   context: unknown,
   options: ApplySelectionOptions = {},
 ): MapperCollection {
-  // The adapter records no loader mappings, so the walker never touches the context.
+  // Next passes the original context to callbacks and does not use loader mapping caches.
   const ctx = context as object;
   const initial = options.extraColumns?.length ? { columns: options.extraColumns } : undefined;
-  const plan = Plan.fromInfo(prismaNextAdapter(contract), {
+  const adapter = prismaNextAdapter(contract);
+  const plan = Plan.fromInfo(adapter, {
     context: ctx,
     info,
     typeName: options.typeName,
@@ -51,8 +52,10 @@ export function applySelectionToCollection(
     return emit(baseCollection, initial ?? {}, undefined, ctx);
   }
 
+  // Serialize the play directly: query() also publishes mappings to an object-context cache,
+  // but Next resolves selected rows through its own overlay.
   const finish = (settled: PrismaNextPlan) =>
-    emit(baseCollection, settled.query(), settled.model, ctx);
+    emit(baseCollection, adapter.toQuery(settled.play().root), settled.model, ctx);
 
   return isThenable(plan)
     ? (plan.then((settled) => finish(settled as PrismaNextPlan)) as unknown as MapperCollection)

--- a/packages/plugin-prisma-next/tests/adapter.test.ts
+++ b/packages/plugin-prisma-next/tests/adapter.test.ts
@@ -441,12 +441,11 @@ describe('relations', () => {
     expect(captured[0].ctx).toEqual({ tenantId: 'tenant-42' });
   });
 
-  it('refuses a second alias on a to-one relation', async () => {
-    await expect(
-      plan('{ users { posts { a: author { id } b: author { firstName } } } }'),
-    ).rejects.toThrow(
-      'Relation "author" is to-one — only one branch allowed, got alias "b:author" plus "a:author".',
-    );
+  it('shares one include for compatible to-one aliases', async () => {
+    expect(await plan('{ users { posts { a: author { id } b: author { firstName } } } }')).toEqual([
+      'select(id)',
+      'include(posts){ select(authorId) include(author){ select(firstName, id) } }',
+    ]);
   });
 
   it('unions one relation selected under two fragments into one slot', async () => {
@@ -544,7 +543,7 @@ describe('type-level selects and variants', () => {
   it('walks a t.variant on the same row with its forced columns and the variant type select', async () => {
     expect(await plan('{ users { id asAdmin { lastName posts { title } } } }')).toEqual([
       'select(email, firstName, id, lastName)',
-      'include(posts){ combine(:object:AdminUser:total=count[], posts:posts=[select(title)]) }',
+      'include(posts){ combine(asAdmin::object:AdminUser:total=count[], asAdmin:posts:posts=[select(title)]) }',
     ]);
   });
 
@@ -614,14 +613,14 @@ describe('entry options', () => {
       '{ users { asAdmin { asyncLastName } } }',
       [
         'select(email, firstName, id, lastName)',
-        'include(posts){ combine(:object:AdminUser:total=count[]) }',
+        'include(posts){ combine(asAdmin::object:AdminUser:total=count[]) }',
       ],
     ],
     [
       '{ users { asAdmin { posts { asyncTitle } } } }',
       [
         'select(email, firstName, id)',
-        'include(posts){ combine(:object:AdminUser:total=count[], posts:posts=[select(title)]) }',
+        'include(posts){ combine(asAdmin::object:AdminUser:total=count[], asAdmin:posts:posts=[select(title)]) }',
       ],
     ],
     [

--- a/packages/plugin-prisma-next/tests/adapter.test.ts
+++ b/packages/plugin-prisma-next/tests/adapter.test.ts
@@ -7,6 +7,7 @@
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import SchemaBuilder from '@pothos/core';
+import RelayPlugin from '@pothos/plugin-relay';
 import { execute } from '@pothos/test-utils';
 import {
   DirectiveLocation,
@@ -164,7 +165,8 @@ function createSchema({ asyncSelect = false } = {}) {
     PrismaNextContract: SampleContract;
     Context: { tenantId?: string };
   }>({
-    plugins: [prismaNextPlugin],
+    plugins: [RelayPlugin, prismaNextPlugin],
+    relay: {},
     prismaNext: { contract: sampleContract as never },
   });
 
@@ -181,6 +183,10 @@ function createSchema({ asyncSelect = false } = {}) {
     fields: (t) => ({
       id: t.exposeID('id'),
       title: t.exposeString('title'),
+      asyncTitle: t.string({
+        select: (async () => ['title']) as never,
+        resolve: () => 'async title',
+      }),
       // GraphQL field name `isPublished`, backing column `published` (an int in sqlite).
       isPublished: t.exposeInt('published'),
       author: t.relation('author'),
@@ -198,6 +204,10 @@ function createSchema({ asyncSelect = false } = {}) {
     fields: (t) => ({
       id: t.exposeID('id'),
       lastName: t.exposeString('lastName'),
+      asyncLastName: t.string({
+        select: (async () => ['lastName']) as never,
+        resolve: () => 'async last name',
+      }),
       posts: t.relation('posts'),
     }),
   });
@@ -215,6 +225,11 @@ function createSchema({ asyncSelect = false } = {}) {
       // No exposed column, no select — pure compute.
       plugin: t.string({ resolve: () => 'prisma-next' }),
       posts: t.relation('posts'),
+      postsConnection: t.relatedConnection('posts', {
+        cursor: 'id',
+        defaultSize: 2,
+        totalCount: true,
+      }),
       // Sibling aliases of the same relation with declarative refines.
       drafts: t.relation('posts', { query: { where: { published: 0 } } }),
       publishedPosts: t.relation('posts', { query: { where: { published: 1 } } }),
@@ -484,7 +499,8 @@ describe('counts and function-form entries', () => {
 
   it('throws a clear error for a select key that is neither column nor relation', async () => {
     const builder = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
-      plugins: [prismaNextPlugin],
+      plugins: [RelayPlugin, prismaNextPlugin],
+      relay: {},
       prismaNext: { contract: sampleContract as never },
     });
     let info: GraphQLResolveInfo | undefined;
@@ -588,6 +604,37 @@ describe('entry options', () => {
     ).toEqual(['select(id, lastName)']);
   });
 
+  it.each([
+    ['{ users { posts { asyncTitle } } }', ['select(id)', 'include(posts){ select(title) }']],
+    [
+      '{ users { drafts { asyncTitle } } }',
+      ['select(id)', 'include(posts){ where({"published":0}) select(title) }'],
+    ],
+    [
+      '{ users { asAdmin { asyncLastName } } }',
+      [
+        'select(email, firstName, id, lastName)',
+        'include(posts){ combine(:object:AdminUser:total=count[]) }',
+      ],
+    ],
+    [
+      '{ users { asAdmin { posts { asyncTitle } } } }',
+      [
+        'select(email, firstName, id)',
+        'include(posts){ combine(:object:AdminUser:total=count[], posts:posts=[select(title)]) }',
+      ],
+    ],
+    [
+      '{ users { postsConnection { totalCount edges { node { asyncTitle } } } } }',
+      [
+        'select(id)',
+        'include(posts){ combine(postsConnection:count=count[], postsConnection:rows=[orderBy(fn) take(3) select(id, title)]) }',
+      ],
+    ],
+  ])('awaits nested async selections in %s', async (source, expected) => {
+    expect(await plan(source)).toEqual(expected);
+  });
+
   it('awaits an async select callback', async () => {
     const { infoFor: asyncInfo } = createSchema({ asyncSelect: true });
     const info = await asyncInfo('{ users { postsPage { id } } }');
@@ -609,7 +656,8 @@ describe('entry options', () => {
 /** The schema with a `@defer` directive declared, so deferred fragments can be written. */
 function createDeferSchema() {
   const builder = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
-    plugins: [prismaNextPlugin],
+    plugins: [RelayPlugin, prismaNextPlugin],
+    relay: {},
     prismaNext: { contract: sampleContract as never },
   });
   let info: GraphQLResolveInfo | undefined;

--- a/packages/plugin-prisma-next/tests/adapter.test.ts
+++ b/packages/plugin-prisma-next/tests/adapter.test.ts
@@ -697,3 +697,63 @@ function createDeferSchema() {
     },
   };
 }
+
+describe('execution context', () => {
+  it.each([
+    undefined,
+    null,
+    'tenant-42',
+    42,
+  ])('preserves context %s and synchronous selection in the direct helper', async (context) => {
+    captured.length = 0;
+    const info = await infoFor('{ users { filteredPosts(published: 1) { id } } }');
+    const result = applySelectionToCollection(
+      new RecordingCollection(),
+      info,
+      sampleContract as never,
+      context,
+    );
+
+    expect(result).not.toBeInstanceOf(Promise);
+    expect(render(result)).toEqual([
+      'select(id)',
+      'include(posts){ where({"published":1}) select(id) }',
+    ]);
+    expect(captured).toEqual([{ args: { published: 1 }, ctx: context }]);
+  });
+
+  it('executes a prismaField without contextValue', async () => {
+    const builder = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
+      plugins: [prismaNextPlugin],
+      prismaNext: { contract: sampleContract },
+    });
+    const User = builder.prismaObject('User', {
+      fields: (t) => ({ id: t.exposeID('id') }),
+    });
+    const collection = {
+      select() {
+        return this;
+      },
+      include() {
+        return this;
+      },
+      where() {
+        return this;
+      },
+      all: async () => [{ id: 'u1' }],
+    };
+    builder.queryType({
+      fields: (t) => ({
+        users: t.prismaField({ type: [User], resolve: () => collection as never }),
+      }),
+    });
+
+    const result = await execute({
+      schema: builder.toSchema(),
+      document: parse('{ users { id } }'),
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ users: [{ id: 'u1' }] });
+  });
+});

--- a/packages/plugin-prisma-next/tests/interface-selections.test.ts
+++ b/packages/plugin-prisma-next/tests/interface-selections.test.ts
@@ -1,0 +1,90 @@
+import SchemaBuilder from '@pothos/core';
+import { execute, parse } from 'graphql';
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import prismaNextPlugin, {
+  applySelectionToCollection,
+  type RelationRefinementCollection,
+} from '../src';
+import {
+  createTestRuntime,
+  type SampleContract,
+  type TestRuntimeContext,
+} from './fixtures/runtime';
+
+type Posts = RelationRefinementCollection<
+  PothosSchemaTypes.ExtendDefaultTypes<{ PrismaNextContract: SampleContract }>,
+  'User',
+  'posts'
+>;
+
+let ctx: TestRuntimeContext;
+beforeAll(async () => {
+  ctx = await createTestRuntime();
+});
+afterAll(async () => {
+  await ctx?.cleanup();
+});
+
+it('loads inherited interface selections through concrete and interface roots', async () => {
+  const builder = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
+    plugins: [prismaNextPlugin],
+    prismaNext: { contract: ctx.contract },
+  });
+  const base = builder.prismaInterface('User', {
+    name: 'UserTotals',
+    select: { posts: (sub: Posts) => ({ total: sub.count() }) },
+    fields: (t) => ({
+      total: t.int({ resolve: (parent) => (parent as unknown as { total: number }).total }),
+    }),
+  });
+  const published = builder.prismaInterface('User', {
+    name: 'UserPublishedTotals',
+    interfaces: [base] as never,
+    select: { posts: (sub: Posts) => ({ published: sub.where({ published: 1 }).count() }) },
+    fields: (t) => ({
+      published: t.int({
+        resolve: (parent) => (parent as unknown as { published: number }).published,
+      }),
+    }),
+  });
+  const user = builder.prismaObject('User', {
+    interfaces: [base, published] as never,
+    isTypeOf: () => true,
+    select: { posts: true },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      ownTotal: t.int({ resolve: (parent) => parent.posts.length }),
+    }),
+  });
+  builder.queryType({
+    fields: (t) => ({
+      users: t.prismaField({ type: [user], resolve: () => ctx.ormClient.User }),
+      viaInterface: t.field({
+        type: [published],
+        resolve: async (_parent, _args, context, info) => {
+          const collection = await applySelectionToCollection(
+            ctx.ormClient.User as never,
+            info,
+            ctx.contract,
+            context,
+          );
+          return (await (collection as unknown as typeof ctx.ormClient.User).all()) as never;
+        },
+      }),
+    }),
+  });
+  const result = await execute({
+    schema: builder.toSchema(),
+    contextValue: {},
+    document: parse(`{
+      users { id total published ownTotal }
+      viaInterface { total published ... on User { id ownTotal } }
+    }`),
+  });
+  expect(result.errors).toBeUndefined();
+  const users = [
+    { id: 'u-alice', total: 2, published: 1, ownTotal: 2 },
+    { id: 'u-bob', total: 2, published: 1, ownTotal: 2 },
+  ];
+  expect(result.data).toEqual({ users, viaInterface: users });
+});

--- a/packages/plugin-prisma-next/tests/normalization-runtime.test.ts
+++ b/packages/plugin-prisma-next/tests/normalization-runtime.test.ts
@@ -1,0 +1,201 @@
+import SchemaBuilder from '@pothos/core';
+import relayPlugin from '@pothos/plugin-relay';
+import { execute, parse } from 'graphql';
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import prismaNextPlugin, { type RelationRefinementCollection } from '../src';
+import {
+  createTestRuntime,
+  type SampleContract,
+  type TestRuntimeContext,
+} from './fixtures/runtime';
+
+let ctx: TestRuntimeContext;
+beforeAll(async () => {
+  ctx = await createTestRuntime();
+});
+afterAll(async () => {
+  await ctx?.cleanup();
+});
+
+it('preserves filtered aliases alongside object-level relation rows', async () => {
+  const b = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
+    plugins: [prismaNextPlugin],
+    prismaNext: { contract: ctx.contract },
+  });
+  b.prismaObject('User', {
+    select: { posts: true },
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      total: t.int({ resolve: (p) => p.posts.length }),
+      latest: t.relation('posts', { query: { orderBy: (p) => p.createdAt.desc(), take: 1 } }),
+      posts: t.relation('posts', {
+        query: { where: { published: 1 }, orderBy: (p) => p.id.desc(), take: 1 },
+      }),
+    }),
+  });
+  b.prismaObject('Post', { fields: (t) => ({ id: t.exposeID('id') }) });
+  b.queryType({
+    fields: (t) => ({
+      users: t.prismaField({ type: ['User'], resolve: (() => ctx.ormClient.User) as never }),
+    }),
+  });
+  const result = await execute({
+    schema: b.toSchema(),
+    contextValue: {},
+    document: parse('{ users { id total latest { id } a: posts { id } b: posts { id } } }'),
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    users: [
+      {
+        id: 'u-alice',
+        total: 2,
+        latest: [{ id: 'p-draft1' }],
+        a: [{ id: 'p-hello' }],
+        b: [{ id: 'p-hello' }],
+      },
+      {
+        id: 'u-bob',
+        total: 2,
+        latest: [{ id: 'p-bob-draft' }],
+        a: [{ id: 'p-bob1' }],
+        b: [{ id: 'p-bob1' }],
+      },
+    ],
+  });
+});
+
+it('normalizes computed counts across connection, nested relation and node loading boundaries', async () => {
+  const b = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
+    plugins: [prismaNextPlugin, relayPlugin],
+    relay: {},
+    prismaNext: { contract: ctx.contract },
+  });
+  b.prismaNode('User', {
+    isTypeOf: () => true,
+    id: { field: 'id' },
+    collection: ctx.ormClient.User,
+    select: { posts: (sub) => ({ total: sub.count() }) },
+    fields: (t) => ({
+      total: t.int({ resolve: (p) => (p as typeof p & { total: number }).total }),
+      postsPage: t.relatedConnection('posts', {
+        cursor: 'id',
+        where: { published: 1 },
+        totalCount: true,
+      }),
+    }),
+  });
+  b.prismaObject('Post', {
+    select: {
+      comments: (
+        sub: RelationRefinementCollection<
+          PothosSchemaTypes.ExtendDefaultTypes<{ PrismaNextContract: SampleContract }>,
+          'Post',
+          'comments'
+        >,
+      ) => ({ commentsTotal: sub.count() }),
+    },
+    fields: (t) => ({
+      author: t.relation('author'),
+      commentsTotal: t.int({ resolve: (p) => p.commentsTotal }),
+    }),
+  });
+  b.queryType({
+    fields: (t) => ({
+      users: t.prismaField({ type: ['User'], resolve: (() => ctx.ormClient.User) as never }),
+      posts: t.prismaField({ type: ['Post'], resolve: (() => ctx.ormClient.Post) as never }),
+      page: t.prismaConnection({
+        type: 'User',
+        cursor: 'id',
+        totalCount: true,
+        resolve: (() => ctx.ormClient.User) as never,
+      }),
+    }),
+  });
+  const id = Buffer.from('User:u-alice').toString('base64');
+  const result = await execute({
+    schema: b.toSchema(),
+    contextValue: {},
+    document: parse(
+      `{ users { total postsPage(first: 1) { totalCount edges { node { commentsTotal } } } } posts { author { total } } page(first: 1) { totalCount edges { node { total } } } node(id: "${id}") { ... on User { total } } }`,
+    ),
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    users: [
+      { total: 2, postsPage: { totalCount: 1, edges: [{ node: { commentsTotal: 2 } }] } },
+      { total: 2, postsPage: { totalCount: 1, edges: [{ node: { commentsTotal: 0 } }] } },
+    ],
+    posts: Array.from({ length: 4 }, () => ({ author: { total: 2 } })),
+    page: { totalCount: 2, edges: [{ node: { total: 2 } }] },
+    node: { total: 2 },
+  });
+});
+
+it('keeps frozen shared rows intact and ordinary resolvers synchronous', () => {
+  const b = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
+    plugins: [prismaNextPlugin],
+    prismaNext: { contract: ctx.contract },
+  });
+  const rows = Object.freeze([{ id: 'p-hello' }, { id: 'p-draft1' }]);
+  const slots = Object.freeze({
+    ':object:User:posts': rows,
+    ':object:UserVariant:posts': rows.slice(0, 1),
+    'chosen:posts': rows.slice(0, 1),
+  });
+  const parent = Object.freeze({ id: 'u-alice', posts: slots });
+  const variant = b.prismaObject('User', {
+    name: 'UserVariant',
+    select: { posts: true },
+    fields: (t) => ({ total: t.int({ resolve: (p) => p.posts.length }) }),
+  });
+  const user = b.prismaObject('User', {
+    select: { posts: true },
+    fields: (t) => ({
+      total: t.int({ resolve: (p) => p.posts.length }),
+      posts: t.relation('posts'),
+      variant: t.variant(variant),
+    }),
+  });
+  b.prismaObject('Post', { fields: (t) => ({ id: t.exposeID('id') }) });
+  b.queryType({
+    fields: (t) => ({ user: t.field({ type: user, resolve: () => parent as never }) }),
+  });
+  const result = execute({
+    schema: b.toSchema(),
+    contextValue: {},
+    document: parse('{ user { total chosen: posts { id } variant { total } } }'),
+  });
+  expect(result).not.toBeInstanceOf(Promise);
+  expect(result).toEqual({
+    data: { user: { total: 2, chosen: [{ id: 'p-hello' }], variant: { total: 1 } } },
+  });
+  expect(parent.posts).toBe(slots);
+  expect(Object.keys(parent)).toEqual(['id', 'posts']);
+});
+
+it.each([
+  ['id'] as const,
+  { id: true } as const,
+])('preserves row identity for scalar-only type selects %j', (select) => {
+  const parent = { id: 'u-alice' };
+  const labels = new WeakMap([[parent, 'cached label']]);
+  const b = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
+    plugins: [prismaNextPlugin],
+    prismaNext: { contract: ctx.contract },
+  });
+  const user = b.prismaObject('User', {
+    select,
+    fields: (t) => ({ label: t.string({ resolve: (p) => labels.get(p) }) }),
+  });
+  b.queryType({
+    fields: (t) => ({ user: t.field({ type: user, resolve: () => parent as never }) }),
+  });
+  const result = execute({
+    schema: b.toSchema(),
+    contextValue: {},
+    document: parse('{ user { label } }'),
+  });
+  expect(result).not.toBeInstanceOf(Promise);
+  expect(result).toEqual({ data: { user: { label: 'cached label' } } });
+});

--- a/packages/plugin-prisma-next/tests/optional-plugins.test.ts
+++ b/packages/plugin-prisma-next/tests/optional-plugins.test.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { expect, it } from 'vitest';
+
+it('imports the built package without optional Pothos plugins', () => {
+  // Exercise the published CommonJS entrypoint in a separate process, even though the
+  // workspace has every optional plugin installed. CI builds packages before their tests.
+  const entry = fileURLToPath(new URL('../lib/index.js', import.meta.url));
+  const output = execFileSync(
+    process.execPath,
+    [
+      '-e',
+      `
+    const Module = require('node:module');
+    const load = Module._load;
+    Module._load = function(name, ...args) {
+      if (name === '@pothos/plugin-relay' || name === '@pothos/plugin-with-input') {
+        throw new Error('Optional plugin imported: ' + name);
+      }
+      return load.call(this, name, ...args);
+    };
+    const plugin = require(process.argv[1]);
+    if (plugin.default !== 'prismaNext') throw new Error('Missing plugin export');
+    process.stdout.write('ok');
+  `,
+      entry,
+    ],
+    { encoding: 'utf8' },
+  );
+  expect(output).toBe('ok');
+});

--- a/packages/plugin-prisma-next/tests/regressions.test.ts
+++ b/packages/plugin-prisma-next/tests/regressions.test.ts
@@ -430,6 +430,7 @@ describe('refs cache + connection-options short-circuit + plugin assorted', () =
     const schema = builder.toSchema();
     const info = {
       parentType: schema.getType('User'),
+      path: { prev: undefined, key: 'whatever', typename: 'Query' },
       fieldNodes: [
         {
           kind: 'Field',

--- a/packages/plugin-prisma-next/tests/regressions.test.ts
+++ b/packages/plugin-prisma-next/tests/regressions.test.ts
@@ -1,4 +1,5 @@
 import SchemaBuilder from '@pothos/core';
+import RelayPlugin from '@pothos/plugin-relay';
 import { GraphQLInt, GraphQLObjectType, printSchema } from 'graphql';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import prismaNextPlugin, {
@@ -469,7 +470,7 @@ describe('refs cache + connection-options short-circuit + plugin assorted', () =
     // same suffix value.
     const make = () => {
       const b = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
-        plugins: [prismaNextPlugin],
+        plugins: [prismaNextPlugin, RelayPlugin],
         prismaNext: { contract: ctx.contract },
       });
       b.prismaObject('Post', { fields: (t) => ({ id: t.exposeID('id') }) });
@@ -598,7 +599,7 @@ describe('prismaInterface → prismaObject model propagation', () => {
 describe('prismaNode — user isTypeOf merged with brand check', () => {
   it('honors a user-supplied isTypeOf while still keeping the brand fallback', () => {
     const builder = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
-      plugins: [prismaNextPlugin, require('@pothos/plugin-relay').default],
+      plugins: [prismaNextPlugin, RelayPlugin],
       relay: { clientMutationId: 'omit', cursorType: 'String' },
       prismaNext: { contract: ctx.contract },
     } as never);
@@ -634,7 +635,7 @@ describe('prismaNode — user isTypeOf merged with brand check', () => {
     // on a truthy Promise<false>. The merge must detect the Promise
     // return and chain through .then so the brand check still runs.
     const builder = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
-      plugins: [prismaNextPlugin, require('@pothos/plugin-relay').default],
+      plugins: [prismaNextPlugin, RelayPlugin],
       relay: { clientMutationId: 'omit', cursorType: 'String' },
       prismaNext: { contract: ctx.contract },
     } as never);

--- a/packages/plugin-prisma-next/tests/scope-boundaries.test.ts
+++ b/packages/plugin-prisma-next/tests/scope-boundaries.test.ts
@@ -1,0 +1,199 @@
+import SchemaBuilder from '@pothos/core';
+import ErrorsPlugin from '@pothos/plugin-errors';
+import { execute, parse } from 'graphql';
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import prismaNextPlugin from '../src';
+import {
+  createTestRuntime,
+  type SampleContract,
+  type TestRuntimeContext,
+} from './fixtures/runtime';
+
+let ctx: TestRuntimeContext;
+beforeAll(async () => {
+  ctx = await createTestRuntime();
+});
+afterAll(async () => {
+  await ctx?.cleanup();
+});
+
+function schema(directResult = false, dataName = 'data', staticFilters = false) {
+  const builder = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
+    plugins: [ErrorsPlugin, prismaNextPlugin],
+    prismaNext: { contract: ctx.contract },
+  });
+  const userView = builder.prismaObject('User', {
+    name: 'UserView',
+    fields: (t) => ({
+      posts: t.relation('posts', {
+        args: { published: t.arg.int() },
+        query: ({ published }) =>
+          staticFilters
+            ? { where: { published: 0 } }
+            : published == null
+              ? {}
+              : { where: { published } },
+      }),
+    }),
+  });
+  builder.prismaObject('User', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      firstName: t.exposeString('firstName'),
+      view: t.variant(userView),
+      postCount: t.field({
+        type: 'Int',
+        args: { published: t.arg.int({ required: true }) },
+        select: {
+          posts: (
+            sub: { where: (filter: unknown) => { count: () => unknown } },
+            args: { published: number },
+          ) => ({ posts: sub.where({ published: args.published }).count() }),
+        },
+        resolve: ((parent: { posts: number }) => parent.posts) as never,
+      } as never),
+      posts: t.relation('posts', {
+        args: { published: t.arg.int() },
+        query: ({ published }) =>
+          staticFilters
+            ? { where: { published: 1 } }
+            : published == null
+              ? {}
+              : { where: { published } },
+      }),
+    }),
+  });
+  builder.prismaObject('Post', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      author: t.relation('author', {
+        errors: { types: [], directResult, dataField: { name: dataName } },
+      }),
+      alice: t.relation('author', { query: { where: { firstName: 'Alice' } } }),
+      bob: t.relation('author', { query: { where: { firstName: 'Bob' } } }),
+    }),
+  });
+  builder.prismaObject('Comment', { fields: (t) => ({ post: t.relation('post') }) });
+  builder.queryType({
+    fields: (t) => ({
+      comments: t.prismaField({
+        type: ['Comment'],
+        resolve: () => ctx.ormClient.Comment.where({ id: 'c-1' }),
+      }),
+      posts: t.prismaField({
+        type: ['Post'],
+        resolve: () => ctx.ormClient.Post.where({ id: 'p-hello' }),
+      }),
+    }),
+  });
+  return builder.toSchema();
+}
+
+it.each([
+  false,
+  true,
+])('errors directResult=%s plus list reset and nested aliases', async (direct) => {
+  const wrap = (body: string) =>
+    direct ? `... on User { ${body} }` : `... on PostAuthorSuccess { payload:data { ${body} } }`;
+  const inner = wrap('posts(published:1){id}');
+  const outer = wrap(`posts { x:author {${inner}} y:author {${wrap('posts(published:0){id}')}} }`);
+  const result = await execute({
+    schema: schema(direct),
+    contextValue: {},
+    document: parse(`{posts { a:author {${outer}} b:author {${wrap('posts(published:0){id}')}} }}`),
+  });
+  expect(result.errors).toBeUndefined();
+  const rows = [
+    {
+      x: direct ? { posts: [{ id: 'p-hello' }] } : { payload: { posts: [{ id: 'p-hello' }] } },
+      y: direct ? { posts: [{ id: 'p-draft1' }] } : { payload: { posts: [{ id: 'p-draft1' }] } },
+    },
+  ];
+  expect(result.data).toEqual({
+    posts: [
+      {
+        a: direct ? { posts: [...rows, ...rows] } : { payload: { posts: [...rows, ...rows] } },
+        b: direct ? { posts: [{ id: 'p-draft1' }] } : { payload: { posts: [{ id: 'p-draft1' }] } },
+      },
+    ],
+  });
+});
+it('renamed errors dataField retains scope', async () => {
+  const result = await execute({
+    schema: schema(false, 'value'),
+    contextValue: {},
+    document: parse(
+      '{posts {a:author {... on PostAuthorSuccess {v:value {posts(published:1){id}}}} b:author {... on PostAuthorSuccess {v:value {posts(published:0){id}}}}}}',
+    ),
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    posts: [
+      { a: { v: { posts: [{ id: 'p-hello' }] } }, b: { v: { posts: [{ id: 'p-draft1' }] } } },
+    ],
+  });
+});
+
+it('same-row variants preserve separate child arguments', async () => {
+  const result = await execute({
+    schema: schema(),
+    contextValue: {},
+    document: parse(`{
+    posts { alice { a: view { posts(published: 1) { id } } b: view { posts(published: 0) { id } } } }
+  }`),
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    posts: [
+      {
+        alice: {
+          a: { posts: [{ id: 'p-hello' }] },
+          b: { posts: [{ id: 'p-draft1' }] },
+        },
+      },
+    ],
+  });
+});
+
+it('same-row variants preserve separate static refinements from the base type', async () => {
+  const result = await execute({
+    schema: schema(false, 'data', true),
+    contextValue: {},
+    document: parse(`{
+    posts { alice { posts { id } view { posts { id } } } }
+  }`),
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    posts: [
+      {
+        alice: {
+          posts: [{ id: 'p-hello' }],
+          view: { posts: [{ id: 'p-draft1' }] },
+        },
+      },
+    ],
+  });
+});
+
+it('scopes same-row variants beneath errors-wrapped to-one aliases', async () => {
+  const result = await execute({
+    schema: schema(),
+    contextValue: {},
+    document: parse(`{
+    posts {
+      a: author { ... on PostAuthorSuccess { data { a: view { posts(published: 1) { id } } b: view { posts(published: 0) { id } } } } }
+      b: author { ... on PostAuthorSuccess { data { view { posts(published: 0) { id } } } } }
+    }
+  }`),
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    posts: [
+      {
+        a: { data: { a: { posts: [{ id: 'p-hello' }] }, b: { posts: [{ id: 'p-draft1' }] } } },
+        b: { data: { view: { posts: [{ id: 'p-draft1' }] } } },
+      },
+    ],
+  });
+});

--- a/packages/plugin-prisma-next/tests/to-one-aliases.test.ts
+++ b/packages/plugin-prisma-next/tests/to-one-aliases.test.ts
@@ -1,0 +1,298 @@
+import SchemaBuilder from '@pothos/core';
+import { execute, parse } from 'graphql';
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import prismaNextPlugin from '../src';
+import {
+  createTestRuntime,
+  type SampleContract,
+  type TestRuntimeContext,
+} from './fixtures/runtime';
+
+let ctx: TestRuntimeContext;
+beforeAll(async () => {
+  ctx = await createTestRuntime();
+});
+afterAll(async () => {
+  await ctx?.cleanup();
+});
+
+function schema() {
+  const builder = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
+    plugins: [prismaNextPlugin],
+    prismaNext: { contract: ctx.contract },
+  });
+  const userView = builder.prismaObject('User', {
+    name: 'UserView',
+    fields: (t) => ({
+      posts: t.relation('posts', {
+        args: { published: t.arg.int() },
+        query: ({ published }) => (published == null ? {} : { where: { published } }),
+      }),
+    }),
+  });
+  builder.prismaObject('User', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      firstName: t.exposeString('firstName'),
+      view: t.variant(userView),
+      postCount: t.field({
+        type: 'Int',
+        args: { published: t.arg.int({ required: true }) },
+        select: {
+          posts: (
+            sub: { where: (filter: unknown) => { count: () => unknown } },
+            args: { published: number },
+          ) => ({ posts: sub.where({ published: args.published }).count() }),
+        },
+        resolve: ((parent: { posts: number }) => parent.posts) as never,
+      } as never),
+      posts: t.relation('posts', {
+        args: { published: t.arg.int() },
+        query: ({ published }) => (published == null ? {} : { where: { published } }),
+      }),
+    }),
+  });
+  builder.prismaObject('Post', {
+    fields: (t) => ({
+      id: t.exposeID('id'),
+      author: t.relation('author'),
+      alice: t.relation('author', { query: { where: { firstName: 'Alice' } } }),
+      bob: t.relation('author', { query: { where: { firstName: 'Bob' } } }),
+    }),
+  });
+  builder.prismaObject('Comment', { fields: (t) => ({ post: t.relation('post') }) });
+  builder.queryType({
+    fields: (t) => ({
+      comments: t.prismaField({
+        type: ['Comment'],
+        resolve: () => ctx.ormClient.Comment.where({ id: 'c-1' }),
+      }),
+      posts: t.prismaField({
+        type: ['Post'],
+        resolve: () => ctx.ormClient.Post.where({ id: 'p-hello' }),
+      }),
+    }),
+  });
+  return builder.toSchema();
+}
+
+it('shares a to-one include across aliases with distinct nested selections', async () => {
+  const result = await execute({
+    schema: schema(),
+    document: parse(`{
+    posts { a: author { id } b: author { firstName posts { id } } }
+  }`),
+    contextValue: {},
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    posts: [
+      {
+        a: { id: 'u-alice' },
+        b: { firstName: 'Alice', posts: [{ id: 'p-hello' }, { id: 'p-draft1' }] },
+      },
+    ],
+  });
+});
+
+it('shares equivalent declarative refinements', async () => {
+  const result = await execute({
+    schema: schema(),
+    document: parse(`{
+    posts { a: alice { id } b: alice { firstName } }
+  }`),
+    contextValue: {},
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({ posts: [{ a: { id: 'u-alice' }, b: { firstName: 'Alice' } }] });
+});
+
+it('rejects conflicting to-one refinements instead of using one consumer query', async () => {
+  const result = await execute({
+    schema: schema(),
+    document: parse(`{
+    posts { alice { id } bob { firstName } }
+  }`),
+    contextValue: {},
+  });
+  expect(result.errors?.[0].message).toMatch(/to-one.*incompatible/);
+});
+
+it('preserves type-level relation selections for two views of one to-one row', async () => {
+  const builder = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
+    plugins: [prismaNextPlugin],
+    prismaNext: { contract: ctx.contract },
+  });
+  const titles = (published: number) =>
+    builder.prismaObject('User', {
+      name: published ? 'PublishedAuthor' : 'DraftAuthor',
+      select: { posts: { where: { published } } },
+      fields: (t) => ({
+        titles: t.string({
+          resolve: (row) =>
+            (row as { posts: { title: string }[] }).posts.map((post) => post.title).join(','),
+        }),
+      }),
+    });
+  const published = titles(1);
+  const drafts = titles(0);
+  builder.prismaObject('Post', {
+    fields: (t) => ({
+      publishedAuthor: t.relation('author', { type: published }),
+      draftAuthor: t.relation('author', { type: drafts }),
+    }),
+  });
+  builder.queryType({
+    fields: (t) => ({
+      posts: t.prismaField({
+        type: ['Post'],
+        resolve: () => ctx.ormClient.Post.where({ id: 'p-hello' }),
+      }),
+    }),
+  });
+  const result = await execute({
+    schema: builder.toSchema(),
+    document: parse(`{
+    posts { publishedAuthor { titles } draftAuthor { titles } }
+  }`),
+    contextValue: {},
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    posts: [
+      {
+        publishedAuthor: { titles: 'Hello, Pothos' },
+        draftAuthor: { titles: 'Draft #1' },
+      },
+    ],
+  });
+});
+
+it('keeps identical child aliases independent beneath shared to-one consumers', async () => {
+  const result = await execute({
+    schema: schema(),
+    contextValue: {},
+    document: parse(`{
+    posts {
+      a: author { posts(published: 1) { id } }
+      b: author { posts(published: 0) { id } }
+    }
+  }`),
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    posts: [
+      {
+        a: { posts: [{ id: 'p-hello' }] },
+        b: { posts: [{ id: 'p-draft1' }] },
+      },
+    ],
+  });
+});
+
+it('keeps scoped child aliases independent through further shared to-one relations', async () => {
+  const result = await execute({
+    schema: schema(),
+    contextValue: {},
+    document: parse(`{
+    posts {
+      a: author { posts { a: author { posts(published: 1) { id } } b: author { posts(published: 0) { id } } } }
+      b: author { posts(published: 0) { id } }
+    }
+  }`),
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    posts: [
+      {
+        a: {
+          posts: [0, 1].map(() => ({
+            a: { posts: [{ id: 'p-hello' }] },
+            b: { posts: [{ id: 'p-draft1' }] },
+          })),
+        },
+        b: { posts: [{ id: 'p-draft1' }] },
+      },
+    ],
+  });
+});
+
+it('routes child aliases through same-row variant wrappers', async () => {
+  const result = await execute({
+    schema: schema(),
+    contextValue: {},
+    document: parse(`{
+    posts {
+      a: author { view { posts(published: 1) { id } } }
+      b: author { view { posts(published: 0) { id } } }
+    }
+  }`),
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    posts: [
+      {
+        a: { view: { posts: [{ id: 'p-hello' }] } },
+        b: { view: { posts: [{ id: 'p-draft1' }] } },
+      },
+    ],
+  });
+});
+
+it('keeps function-form child consumers independent beneath shared to-one aliases', async () => {
+  const result = await execute({
+    schema: schema(),
+    contextValue: {},
+    document: parse(`{
+    posts { a: author { postCount(published: 1) } b: author { postCount(published: 9) } }
+  }`),
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({ posts: [{ a: { postCount: 1 }, b: { postCount: 0 } }] });
+});
+
+it('carries explicit scopes across consecutive to-one includes', async () => {
+  const result = await execute({
+    schema: schema(),
+    contextValue: {},
+    document: parse(`{
+    comments {
+      a: post { author { posts(published: 1) { id } } }
+      b: post { author { posts(published: 0) { id } } }
+    }
+  }`),
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    comments: [
+      {
+        a: { author: { posts: [{ id: 'p-hello' }] } },
+        b: { author: { posts: [{ id: 'p-draft1' }] } },
+      },
+    ],
+  });
+});
+
+it('uses local child namespaces after a single-consumer to-one include', async () => {
+  const result = await execute({
+    schema: schema(),
+    contextValue: {},
+    document: parse(`{
+    comments { post {
+      a: author { posts(published: 1) { id } }
+      b: author { posts(published: 0) { id } }
+    } }
+  }`),
+  });
+  expect(result.errors).toBeUndefined();
+  expect(result.data).toEqual({
+    comments: [
+      {
+        post: {
+          a: { posts: [{ id: 'p-hello' }] },
+          b: { posts: [{ id: 'p-draft1' }] },
+        },
+      },
+    ],
+  });
+});

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -4,6 +4,7 @@ import {
   type MaybePromise,
   type Merge,
   PothosValidationError,
+  parseCursorConnectionArgs,
   type SchemaTypes,
 } from '@pothos/core';
 import type { ArrayConnectionShape, DefaultConnectionArguments } from '../types.js';
@@ -197,39 +198,7 @@ export function resolveArrayConnection<T>(
   };
 }
 
-export function parseCursorConnectionArgs(options: ResolveOffsetConnectionOptions) {
-  const { before, after, first, last } = options.args;
-
-  const defaultSize = options.defaultSize ?? DEFAULT_SIZE;
-  const maxSize = options.maxSize ?? DEFAULT_MAX_SIZE;
-
-  if (first != null && first < 0) {
-    throw new PothosValidationError('Argument "first" must be a non-negative integer');
-  }
-
-  if (last != null && last < 0) {
-    throw new PothosValidationError('Argument "last" must be a non-negative integer');
-  }
-
-  // `first`/`last` are checked for presence rather than truthiness so that a page size of 0
-  // (which the validation above allows) is treated as a requested page size, and not as an
-  // omitted argument.
-  const hasFirst = first != null;
-  const hasLast = last != null;
-
-  const limit = Math.min(first ?? last ?? defaultSize, maxSize) + 1;
-  const inverted = after ? hasLast && !hasFirst : (!!before && !hasFirst) || (!hasFirst && hasLast);
-
-  return {
-    before: before ?? undefined,
-    after: after ?? undefined,
-    limit,
-    expectedSize: limit - 1,
-    inverted,
-    hasPreviousPage: (resultSize: number) => (inverted ? resultSize >= limit : !!after),
-    hasNextPage: (resultSize: number) => (inverted ? !!before : resultSize >= limit),
-  };
-}
+export { parseCursorConnectionArgs } from '@pothos/core';
 
 type NodeType<T> = T extends (infer N)[] | Promise<(infer N)[] | null> | null ? N : never;
 

--- a/website/components/plugins/plugins.ts
+++ b/website/components/plugins/plugins.ts
@@ -51,7 +51,7 @@ export const PLUGIN_CATEGORIES: Record<
   },
 };
 
-export const PLUGINS: PluginEntry[] = [
+const allPlugins: PluginEntry[] = [
   // ── Data ──────────────────────────────────────────────────────────
   {
     slug: 'prisma',
@@ -217,6 +217,9 @@ export const PLUGINS: PluginEntry[] = [
     order: 2,
   },
 ];
+
+// Keep the unreleased plugin's catalog entry for when its docs are published.
+export const PLUGINS = allPlugins.filter((plugin) => plugin.slug !== 'prisma-next');
 
 /** Canonical docs URL for a plugin's page. */
 export function pluginDocsHref(slug: string): string {

--- a/website/source.config.ts
+++ b/website/source.config.ts
@@ -10,7 +10,10 @@ import { remarkMultiRegion } from './lib/remark-multi-region';
 
 export const { docs, meta } = defineDocs({
   dir: 'content/docs',
+  meta: { files: ['**/*.json', '!plugins/prisma-next/**'] },
   docs: {
+    // Keep the unreleased plugin's content in git without publishing its pages.
+    files: ['**/*.{md,mdx}', '!plugins/prisma-next/**'],
     postprocess: {
       includeProcessedMarkdown: true,
     },


### PR DESCRIPTION
Fix Prisma Next correctness findings from the full review of #1679 against main. Targets `feat/plugin-prisma-next-selection-mapper`; shared mapper and Drizzle fixes remain on #1684.

- Await nested selections in relations, declarative refinements, variants, and connections while preserving synchronous planning. Preserve execution for omitted and primitive GraphQL contexts.
- Keep type-level and field-level relation slots separate with immutable resolver overlays. Apply type prerequisites to connection and nested rows, and include inherited interface prerequisites in planning.
- Share compatible to-one includes while retaining separate child consumer namespaces. Preserve scopes through errors-plugin wrappers, nested lists, and same-row variants so aliases cannot silently use another consumer's filter.
- Use core's cursor argument parser without a runtime dependency on optional Relay. Include the shared parser extraction commit here and in #1684 so this branch is independently buildable before stack propagation. Relay retains its existing export.
- Add database regressions for normalization, aliases, interface inheritance, and scope boundaries; correct fixtures that relied on Relay's implicit import. Add an isolated optional-peer import regression and synchronize the README and architecture notes.

Validation:

- Clean assembled stack: all repository package tests passed, the final Prisma Next rerun passed all 278 cases (243 runtime and 35 type cases).
- Repository build (35 tasks), all package and website type checks, Biome, and diff whitespace checks passed.
- Independent final review against main reproduced and verified the fixes; 12 additional external SQLite probes passed for scope, interface, null, async, and errors-plugin compositions.
- Packed core/mapper/Next imports passed without Relay or with-input in both CJS and ESM, including Node 22 and 24 smoke checks.

No new changeset: this ships with the existing stack. The full CI platform/Node matrix and Slush's infrastructure-backed suite have not been run locally.
