### PR TITLE
docs: fix invalid Fields guide examples

### DIFF
--- a/website/content/docs/guide/fields.mdx
+++ b/website/content/docs/guide/fields.mdx
@@ -60,6 +60,12 @@ const builder = new SchemaBuilder<{
   Objects: { Giraffe: { name: string } };
 }>({});
 
+builder.objectType('Giraffe', {
+  fields: (t) => ({
+    name: t.exposeString('name'),
+  }),
+});
+
 builder.queryType({
   fields: (t) => ({
     giraffe: t.field({
@@ -77,28 +83,19 @@ builder method that created them in the `type` parameter. For types created usin
 \([Objects](./objects) or [Interfaces](./interfaces)\) or [Enums](./enums) created using a typescript
 enum, you can also use the `class` or `enum` that was used to define them.
 
+Here we add an enum field to the `Giraffe` type defined above:
+
 ```typescript
 const LengthUnit = builder.enumType('LengthUnit', {
   values: { Feet: {}, Meters: {} },
 });
 
-builder.objectType('Giraffe', {
-  fields: (t) => ({
-    preferredNeckLengthUnit: t.field({
-      type: LengthUnit,
-      resolve: () => 'Feet' as const,
-    }),
+builder.objectField('Giraffe', 'preferredNeckLengthUnit', (t) =>
+  t.field({
+    type: LengthUnit,
+    resolve: () => 'Feet',
   }),
-});
-
-builder.queryType({
-  fields: (t) => ({
-    giraffe: t.field({
-      type: 'Giraffe',
-      resolve: () => ({ name: 'Gina' }),
-    }),
-  }),
-});
+);
 ```
 
 ## Lists

--- a/website/content/docs/guide/fields.mdx
+++ b/website/content/docs/guide/fields.mdx
@@ -61,12 +61,12 @@ const builder = new SchemaBuilder<{
 }>({});
 
 builder.queryType({
-  fields: t => ({
+  fields: (t) => ({
     giraffe: t.field({
-      description: 'A giraffe'
+      description: 'A giraffe',
       type: 'Giraffe',
       resolve: () => ({ name: 'Gina' }),
-    }),:
+    }),
   }),
 });
 ```
@@ -86,7 +86,7 @@ builder.objectType('Giraffe', {
   fields: (t) => ({
     preferredNeckLengthUnit: t.field({
       type: LengthUnit,
-      resolve: () => 'Feet',
+      resolve: () => 'Feet' as const,
     }),
   }),
 });
@@ -107,16 +107,16 @@ To create a list field, you can wrap the type in an array
 
 ```typescript
 builder.queryType({
-  fields: t => ({
+  fields: (t) => ({
     giraffes: t.field({
-      description: 'multiple giraffes'
+      description: 'multiple giraffes',
       type: ['Giraffe'],
       resolve: () => [{ name: 'Gina' }, { name: 'James' }],
     }),
     giraffeNames: t.field({
       type: ['String'],
       resolve: () => ['Gina', 'James'],
-    })
+    }),
   }),
 });
 ```
@@ -133,16 +133,16 @@ builder.queryType({
     nonNullableField: t.field({
       type: 'String',
       nullable: false,
-      resolve: () => null,
+      resolve: () => 'Gina',
     }),
     nonNullableString: t.string({
       nullable: false,
-      resolve: () => null,
+      resolve: () => 'Gina',
     }),
     nonNullableList: t.field({
       type: ['String'],
       nullable: false,
-      resolve: () => null,
+      resolve: () => ['Gina', 'James'],
     }),
     sparseList: t.field({
       type: ['String'],
@@ -207,7 +207,7 @@ builder.queryType({
       },
       resolve: (root, args) => {
         if (args.name !== 'Gina') {
-          throw new NotFoundError(`Unknown Giraffe ${name}`);
+          throw new Error(`Unknown Giraffe ${args.name}`);
         }
 
         return { name: 'Gina' };
@@ -229,19 +229,19 @@ where the type is defined\).
 ```typescript
 builder.queryFields((t) => ({
   giraffe: t.field({
-    type: Giraffe,
-    resolve: () => new Giraffe('James', new Date(Date.UTC(2012, 11, 12)), 5.2),
+    type: 'Giraffe',
+    resolve: () => ({ name: 'James' }),
   }),
 }));
 
-builder.objectField(Giraffe, 'ageInDogYears', (t) =>
+builder.objectField('Giraffe', 'nameLength', (t) =>
   t.int({
-    resolve: (parent) => parent.age * 7,
+    resolve: (parent) => parent.name.length,
   }),
 );
 ```
 
-To see all the methods available for defining fields see the [SchemaBuilder API](./schema-builder)
+To see all the methods available for defining fields see the [SchemaBuilder API](../api/schema-builder)
 
 ## Nested Lists
 


### PR DESCRIPTION
Repair syntax errors, non-null fields that returned null, an undefined model class, the unknown-giraffe error, and the SchemaBuilder API link in the Fields guide. The enum example now extends the previously defined object and returns an ordinary literal without a cast.

Validation: 11 GraphQL assertions and the production website build pass. Strict snippet checking still exposes the pre-existing enum literal inference error, tracked separately in #1692. Editorial and technical review findings have been addressed.

Stack: based on `main`; next is #1688. This PR contains only docs changes.

