### PR TITLE
docs: teach Objects with a complete objectRef example

### DIFF
--- a/website/content/docs/guide/objects.mdx
+++ b/website/content/docs/guide/objects.mdx
@@ -152,20 +152,37 @@ You can also pass a ref to `builder.objectType(GiraffeRef, { ... })` with the sa
 
 If your app already represents its data with classes, prefer using those classes as backing models.
 Pass the class to `builder.objectType`: its instance type becomes the backing model, and the class
-itself can be used as a field's `type`. For example, with an existing `GiraffeModel` class:
+itself can be used as a field's `type`:
 
 ```typescript
-builder.objectType(GiraffeModel, {
+class Giraffe {
+  constructor(
+    public name: string,
+    public birthday: Date,
+    public heightInMeters: number,
+  ) {}
+}
+
+builder.objectType(Giraffe, {
   name: 'Giraffe',
   fields: (t) => ({
     name: t.exposeString('name'),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    giraffe: t.field({
+      type: Giraffe,
+      resolve: () => new Giraffe('James', new Date(Date.UTC(2012, 11, 12)), 5.2),
+    }),
   }),
 });
 ```
 
 The `name` option supplies the GraphQL type name. When resolving an
 [interface](./interfaces) or [union](./unions), you can also use an explicit
-`isTypeOf: (value) => value instanceof GiraffeModel` option to identify instances of the class.
+`isTypeOf: (value) => value instanceof Giraffe` option to identify instances of the class.
 
 ### Using SchemaTypes
 

--- a/website/content/docs/guide/objects.mdx
+++ b/website/content/docs/guide/objects.mdx
@@ -1,18 +1,14 @@
 ---
 title: Objects
-description: Guide for defining Object types in Pothos
+description: Define GraphQL object types from your application's data.
 ---
 
-This will walk you through creating your first object types, some concepts in this guide will be
-explained further in later guides.
+This guide builds a `Giraffe` object type from a TypeScript interface, adds fields, and returns it
+from a query. The same approach works with types from a database client or another part of your app.
 
 ### Defining an Object type
 
-When adding a new type to your schema, you'll need to figure out how the data behind this type will be
-represented. Pothos entirely decouples your data from your GraphQL schema, and has many different
-ways to implement Objects in your schema.
-
-In this guide, we will be implementing a `Giraffe` object type:
+We will use this interface to describe the data our resolvers return:
 
 ```typescript
 interface Giraffe {
@@ -22,69 +18,43 @@ interface Giraffe {
 }
 ```
 
-The easiest way to create a new Object based on an existing Typescript type is with the `objectRef`
-method:
+Pothos calls this the **backing model**. The GraphQL object type defines the fields clients can
+query, while the backing model describes the data available to resolve those fields.
 
-```typescript
-const builder = new SchemaBuilder({});
-const GiraffeRef = builder.objectRef<Giraffe>('Giraffe');
-```
-
-This will create a new `ObjectRef` that can be used to reference the `Giraffe` type in other parts
-of the schema. By passing in the Giraffe interface, we give the `ObjectRef` the information it needs
-to ensure that fields we add to the Giraffe type are type-safe, and that any fields that reference
-the Giraffe type return the expected data.
-
-Next, we can add an implementation for the `Giraffe` type:
-
-```typescript
-const GiraffeRef = builder.objectRef<Giraffe>('Giraffe');
-
-GiraffeRef.implement({
-  description: 'Long necks, cool patterns, taller than you.',
-  fields: (t) => ({}),
-});
-```
-
-In the implementation, we can add a description (optional) and a function to define the fields
-available to query on the Giraffe type.
+`builder.objectRef<Giraffe>('Giraffe')` creates a reference with the GraphQL name `Giraffe` and the
+backing model from the interface. We can pass this reference as the `type` of a field that returns
+a giraffe.
 
 ### Add some fields
 
-The `fields` function receives a `FieldBuilder` instance that can be used to define the fields for
-your type. The `FieldBuilder` will be covered in more detail in the [fields guide](./fields).
+The ref's `implement` method takes the options for the object type, including its `fields` function
+and an optional `description`. The `fields` function receives a field builder, usually named `t`.
+Each entry in the object it returns defines one GraphQL field.
+
+Here is the complete schema. Save it as `schema.ts`:
 
 ```typescript
-GiraffeRef.implement(Giraffe, {
+import SchemaBuilder from '@pothos/core';
+
+interface Giraffe {
+  name: string;
+  birthday: Date;
+  heightInMeters: number;
+}
+
+const builder = new SchemaBuilder({});
+
+const GiraffeRef = builder.objectRef<Giraffe>('Giraffe').implement({
+  description: 'A giraffe in the zoo.',
   fields: (t) => ({
     name: t.exposeString('name'),
     height: t.exposeFloat('heightInMeters'),
-    age: t.int({
-      resolve: (parent) => {
-        // Do some date math to get an approximate age from a birthday
-        const ageDifMs = Date.now() - parent.birthday.getTime();
-        const ageDate = new Date(ageDifMs); // milliseconds from epoch
-        return Math.abs(ageDate.getUTCFullYear() - 1970);
-      },
+    birthYear: t.int({
+      resolve: (giraffe) => giraffe.birthday.getUTCFullYear(),
     }),
   }),
 });
-```
 
-You'll notice that we haven't added any additional typescript definitions when defining our fields.
-Pothos will use the type provided to `objectRef` to ensure that the fields we add to the Giraffe
-type are type-safe. This type is only used to ensure that the implementation is type-safe, but
-Pothos will never automatically expose properties from the underlying data without an explicit field
-definition.
-
-In the example above, we have examples of "exposing" data from the underlying type, as well as a field
-that requires some additional logic to resolve.
-
-## Add a query
-
-We can create a root `Query` object with a field that returns a giraffe using `builder.queryType`
-
-```typescript
 builder.queryType({
   fields: (t) => ({
     giraffe: t.field({
@@ -97,139 +67,150 @@ builder.queryType({
     }),
   }),
 });
+
+export const schema = builder.toSchema();
 ```
 
-We can use the `ObjectRef` created earlier as the `type` option when defining fields that return the
-Giraffe type.
+`t.exposeString('name')` reads the `name` property from the backing model. The `height` field uses
+`t.exposeFloat('heightInMeters')`, so the GraphQL field and the property it reads have different names.
+
+For `birthYear`, we write a resolver that computes an integer from the giraffe's birthday. Pothos
+infers the resolver's first argument as `Giraffe` from the ref. We can add computed fields like this
+without adding properties to the backing model.
+
+Only the fields we define appear in the GraphQL schema. In this example, clients can query `name`,
+`height`, and `birthYear`; the `birthday` property is available to resolvers. The
+[fields guide](./fields) covers field options, lists, and nullability.
+
+## Add a query
+
+The `builder.queryType` call above defines a `giraffe` field on the root `Query` type. Its `type`
+is `GiraffeRef`, so Pothos checks that its resolver returns data matching the `Giraffe` interface.
+When a client queries the giraffe's fields, that returned object becomes the first argument to each
+field's resolver.
+
+The same ref can be used for fields on other object types. Use `type: [GiraffeRef]` for a field that
+returns a list of giraffes. The [root types guide](./queries-mutations-and-subscriptions) covers
+queries, mutations, and subscriptions.
 
 ### Create a server
 
-Pothos schemas build into a plain schema that uses types from the `graphql` package. This means it
-should be compatible with most of the popular GraphQL server implementations for node. In this guide
-we will use `graphql-yoga` but you can use whatever server you want.
+`builder.toSchema()` builds a standard `GraphQLSchema`. To serve it with `graphql-yoga`, install
+`graphql-yoga` and save this as `server.ts` alongside `schema.ts`:
 
 ```typescript
-import { createServer } from 'http';
+import { createServer } from 'node:http';
 import { createYoga } from 'graphql-yoga';
+import { schema } from './schema';
 
-const yoga = createYoga({
-  schema: builder.toSchema(),
-  context: (ctx) => ({
-    user: { id: Number.parseInt(ctx.request.headers.get('x-user-id') ?? '1', 10) },
-  }),
-});
+const yoga = createYoga({ schema });
 
-export const server = createServer(yoga);
+const server = createServer(yoga);
 server.listen(3000);
 ```
 
 ### Query your data
 
-1. Run your server (either with `ts-node`) by compiling your code and running it with node.
-2. Open [http://0.0.0.0:3000/graphql](http://0.0.0.0:3000/graphql) to open the playground and query
-   your API:
+Run `npx tsx server.ts`, then open [http://localhost:3000/graphql](http://localhost:3000/graphql)
+and run this query:
 
 ```graphql
 query {
   giraffe {
     name
-    age
+    birthYear
     height
+  }
+}
+```
+
+The result is:
+
+```json
+{
+  "data": {
+    "giraffe": {
+      "name": "James",
+      "birthYear": 2012,
+      "height": 5.2
+    }
   }
 }
 ```
 
 ## Different ways to define Object types
 
-There are many different ways that you can provide type information to Pothos about what the
-underlying data in your graph will be. Depending on how the rest of your application is structured
-you can pick the approach that works best for you, or use a combination of different styles.
+This guide uses object refs with a TypeScript interface. You can also use an existing class or
+register backing models by name on the builder. These forms can be used together in the same schema.
 
 ### Using Refs
 
-ObjectRefs (the method shown above) is the most flexible solution, and makes it easy to integrate
-pothos with data sources that have their own Typescript types.
-
-Object refs can be created using `builder.objectRef`, and then implemented by calling the
-`implement` method on the ref, or by passing the ref to `builder.objectType`:
+The example chains `objectRef` and `implement` in one expression. If TypeScript has trouble
+inferring mutually referential types, assign each ref before calling `implement`:
 
 ```typescript
-const GiraffeRef = builder.objectRef<GiraffeType>('Giraffe').implement({
-  description: 'Long necks, cool patterns, taller than you.',
-  fields: (t) => ({}),
+const GiraffeRef = builder.objectRef<Giraffe>('Giraffe');
+
+GiraffeRef.implement({
+  fields: (t) => ({
+    name: t.exposeString('name'),
+  }),
 });
 ```
 
-import { Callout } from 'fumadocs-ui/components/callout';
-
-<Callout type="warn">
-  When using objectRefs with circular dependencies, ensure that the `implement` method is called as
-  a separate statement, or typescript may complain about circular references:
-</Callout>
+You can also pass the ref to `builder.objectType(GiraffeRef, { ... })` with the same options.
+See [circular references](./circular-references) for recursive types and module dependencies.
 
 ### Using classes
 
-If your data is already represented as a class, Pothos supports using the classes themselves as
-ObjectRefs. This allows you to define a type-safe schema with minimal typescript definitions.
+If your app already represents its data with classes, you can pass a class to `builder.objectType`.
+The class's instance type becomes the backing model, and the class itself can be used as a field's
+`type`. For example, with an existing `GiraffeModel` class:
 
 ```typescript
-export class Giraffe {
-  name: string;
-  birthday: Date;
-  heightInMeters: number;
-
-  constructor(name: string, birthday: Date, heightInMeters: number) {
-    this.name = name;
-    this.birthday = birthday;
-    this.heightInMeters = heightInMeters;
-  }
-}
-
-builder.objectType(Giraffe, {
-  // Name is required when using a class as an ObjectRef
+builder.objectType(GiraffeModel, {
   name: 'Giraffe',
-  description: 'Long necks, cool patterns, taller than you.',
-  fields: (t) => ({}),
-});
-
-builder.queryFields((t) => ({
-  giraffe: t.field({
-    type: Giraffe,
-    resolve: () => new Giraffe('James', new Date(Date.UTC(2012, 11, 12)), 5.2),
+  fields: (t) => ({
+    name: t.exposeString('name'),
   }),
-}));
+});
 ```
+
+The `name` option supplies the GraphQL type name. When resolving an
+[interface](./interfaces) or [union](./unions), you can also use an explicit
+`isTypeOf: (value) => value instanceof GiraffeModel` option to identify instances of the class.
 
 ### Using SchemaTypes
 
-You can also provide type mappings when you create the [SchemaBuilder](./schema-builder), which
-allows you to reference the types by name throughout your schema (as a string).
+To reference an object type by a string name, register its backing model in the builder's `Objects`
+generic. This alternative uses the `Giraffe` interface from above:
 
 ```typescript
-const builder = new SchemaBuilder<{ Objects: { Giraffe: GiraffeType } }>({});
+const builder = new SchemaBuilder<{
+  Objects: { Giraffe: Giraffe };
+}>({});
 
 builder.objectType('Giraffe', {
-  description: 'Long necks, cool patterns, taller than you.',
-  fields: (t) => ({}),
+  fields: (t) => ({
+    name: t.exposeString('name'),
+  }),
 });
 
-builder.queryFields((t) => ({
-  giraffe: t.field({
-    type: 'Giraffe',
-    resolve: () => ({
-      name: 'James',
-      birthday: new Date(Date.UTC(2012, 11, 12)),
-      heightInMeters: 5.2,
+builder.queryType({
+  fields: (t) => ({
+    giraffe: t.field({
+      type: 'Giraffe',
+      resolve: () => ({
+        name: 'James',
+        birthday: new Date(Date.UTC(2012, 11, 12)),
+        heightInMeters: 5.2,
+      }),
     }),
   }),
-}));
+});
 ```
 
-This is ideal when you want to list out all the types for your schema in one place, or you have
-interfaces/types that define your data rather than classes, and means you won't have to import
-anything when referencing the object type in other parts of the schema.
-
-The type signature for [SchemaBuilder](../api/schema-builder) is described in more detail
-[later](../api/schema-builder), for now, it is enough to know that the `Objects` type provided to
-the schema builder allows you to map the names of object types to type definitions that describe the
-data for those types.
+This keeps the mapping from names to backing models in one place, so other modules can reference
+`'Giraffe'` without importing a ref. The generic provides TypeScript information;
+`builder.objectType` registers the type's implementation. The [SchemaBuilder guide](./schema-builder)
+covers the builder's other type settings.

--- a/website/content/docs/guide/objects.mdx
+++ b/website/content/docs/guide/objects.mdx
@@ -3,35 +3,11 @@ title: Objects
 description: Define GraphQL object types from your application's data.
 ---
 
-This guide builds a `Giraffe` object type from a TypeScript interface, adds fields, and returns it
-from a query. The same approach works with types from a database client or another part of your app.
+We'll define a GraphQL type for a giraffe, using a TypeScript interface to describe its data.
 
 ### Defining an Object type
 
-We will use this interface to describe the data our resolvers return:
-
-```typescript
-interface Giraffe {
-  name: string;
-  birthday: Date;
-  heightInMeters: number;
-}
-```
-
-Pothos calls this the **backing model**. The GraphQL object type defines the fields clients can
-query, while the backing model describes the data available to resolve those fields.
-
-`builder.objectRef<Giraffe>('Giraffe')` creates a reference with the GraphQL name `Giraffe` and the
-backing model from the interface. We can pass this reference as the `type` of a field that returns
-a giraffe.
-
-### Add some fields
-
-The ref's `implement` method takes the options for the object type, including its `fields` function
-and an optional `description`. The `fields` function receives a field builder, usually named `t`.
-Each entry in the object it returns defines one GraphQL field.
-
-Here is the complete schema. Save it as `schema.ts`:
+Create `schema.ts` with a builder and a reference for the `Giraffe` type:
 
 ```typescript
 import SchemaBuilder from '@pothos/core';
@@ -43,8 +19,20 @@ interface Giraffe {
 }
 
 const builder = new SchemaBuilder({});
+const GiraffeRef = builder.objectRef<Giraffe>('Giraffe');
+```
 
-const GiraffeRef = builder.objectRef<Giraffe>('Giraffe').implement({
+The interface describes the **backing model**: the data returned by resolvers for this type.
+`objectRef` associates that model with the GraphQL name `Giraffe`. We can use the ref when defining
+fields that return a giraffe.
+
+### Add some fields
+
+Next, call `implement` to define the object's fields. It accepts the options for the object type,
+including an optional description:
+
+```typescript
+GiraffeRef.implement({
   description: 'A giraffe in the zoo.',
   fields: (t) => ({
     name: t.exposeString('name'),
@@ -54,7 +42,25 @@ const GiraffeRef = builder.objectRef<Giraffe>('Giraffe').implement({
     }),
   }),
 });
+```
 
+The `fields` function receives a field builder, usually named `t`. Here, `t.exposeString('name')`
+reads the `name` property from the backing model. The `height` field reads `heightInMeters`, giving
+that property a different name in the GraphQL schema.
+
+For `birthYear`, we write a resolver that computes an integer from the giraffe's birthday. Pothos
+infers the resolver's first argument as `Giraffe` from the ref.
+
+The backing model and GraphQL fields can have different shapes. Clients can query `name`, `height`,
+and `birthYear`; `birthday` is available to resolvers but isn't exposed as a field. We can add
+computed fields without adding properties to the backing model. The [fields guide](./fields)
+covers more field options.
+
+## Add a query
+
+Add a field to the root `Query` type that returns a giraffe, then build the schema:
+
+```typescript
 builder.queryType({
   fields: (t) => ({
     giraffe: t.field({
@@ -71,27 +77,9 @@ builder.queryType({
 export const schema = builder.toSchema();
 ```
 
-`t.exposeString('name')` reads the `name` property from the backing model. The `height` field uses
-`t.exposeFloat('heightInMeters')`, so the GraphQL field and the property it reads have different names.
-
-For `birthYear`, we write a resolver that computes an integer from the giraffe's birthday. Pothos
-infers the resolver's first argument as `Giraffe` from the ref. We can add computed fields like this
-without adding properties to the backing model.
-
-Only the fields we define appear in the GraphQL schema. In this example, clients can query `name`,
-`height`, and `birthYear`; the `birthday` property is available to resolvers. The
-[fields guide](./fields) covers field options, lists, and nullability.
-
-## Add a query
-
-The `builder.queryType` call above defines a `giraffe` field on the root `Query` type. Its `type`
-is `GiraffeRef`, so Pothos checks that its resolver returns data matching the `Giraffe` interface.
-When a client queries the giraffe's fields, that returned object becomes the first argument to each
-field's resolver.
-
-The same ref can be used for fields on other object types. Use `type: [GiraffeRef]` for a field that
-returns a list of giraffes. The [root types guide](./queries-mutations-and-subscriptions) covers
-queries, mutations, and subscriptions.
+The `type: GiraffeRef` option tells Pothos to check that the resolver returns data matching the
+`Giraffe` interface. That returned object becomes the first argument to the resolvers for `name`,
+`height`, and `birthYear`.
 
 ### Create a server
 
@@ -145,21 +133,20 @@ register backing models by name on the builder. These forms can be used together
 
 ### Using Refs
 
-The example chains `objectRef` and `implement` in one expression. If TypeScript has trouble
-inferring mutually referential types, assign each ref before calling `implement`:
+You can create and implement a ref in one expression:
 
 ```typescript
-const GiraffeRef = builder.objectRef<Giraffe>('Giraffe');
-
-GiraffeRef.implement({
+const GiraffeRef = builder.objectRef<Giraffe>('Giraffe').implement({
   fields: (t) => ({
     name: t.exposeString('name'),
   }),
 });
 ```
 
-You can also pass the ref to `builder.objectType(GiraffeRef, { ... })` with the same options.
-See [circular references](./circular-references) for recursive types and module dependencies.
+For types that reference each other, TypeScript may need ref creation and `implement` to be separate
+statements, as in the walkthrough above. See [circular references](./circular-references) for details.
+
+You can also pass a ref to `builder.objectType(GiraffeRef, { ... })` with the same options.
 
 ### Using classes
 
@@ -195,22 +182,8 @@ builder.objectType('Giraffe', {
     name: t.exposeString('name'),
   }),
 });
-
-builder.queryType({
-  fields: (t) => ({
-    giraffe: t.field({
-      type: 'Giraffe',
-      resolve: () => ({
-        name: 'James',
-        birthday: new Date(Date.UTC(2012, 11, 12)),
-        heightInMeters: 5.2,
-      }),
-    }),
-  }),
-});
 ```
 
-This keeps the mapping from names to backing models in one place, so other modules can reference
-`'Giraffe'` without importing a ref. The generic provides TypeScript information;
-`builder.objectType` registers the type's implementation. The [SchemaBuilder guide](./schema-builder)
-covers the builder's other type settings.
+Fields can now use `type: 'Giraffe'` without importing a ref. The mapping from GraphQL names to
+backing models stays in one place. The [SchemaBuilder guide](./schema-builder) covers the builder's
+other type settings.

--- a/website/content/docs/guide/objects.mdx
+++ b/website/content/docs/guide/objects.mdx
@@ -148,6 +148,46 @@ statements, as in the walkthrough above. See [circular references](./circular-re
 
 You can also pass a ref to `builder.objectType(GiraffeRef, { ... })` with the same options.
 
+### Using SchemaTypes
+
+You can declare backing models in `SchemaTypes` and pass it to `SchemaBuilder`. This lets you
+reference object types by their GraphQL names instead of importing refs. Using the `Giraffe`
+interface from above:
+
+```typescript
+interface SchemaTypes {
+  Objects: {
+    Giraffe: Giraffe;
+  };
+}
+
+const builder = new SchemaBuilder<SchemaTypes>({});
+
+builder.objectType('Giraffe', {
+  fields: (t) => ({
+    name: t.exposeString('name'),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    giraffe: t.field({
+      type: 'Giraffe',
+      resolve: () => ({
+        name: 'James',
+        birthday: new Date(Date.UTC(2012, 11, 12)),
+        heightInMeters: 5.2,
+      }),
+    }),
+  }),
+});
+```
+
+The `Objects` mapping tells Pothos which backing model belongs to each name. Here, it types the
+`Giraffe` field resolvers and checks the object returned by the `giraffe` query. You still define
+the GraphQL fields with `builder.objectType`; declaring a backing model doesn't expose its properties.
+The [SchemaBuilder guide](./schema-builder) covers the other type settings.
+
 ### Using classes
 
 If your app already represents its data with classes, you can pass a class to `builder.objectType`.
@@ -166,24 +206,3 @@ builder.objectType(GiraffeModel, {
 The `name` option supplies the GraphQL type name. When resolving an
 [interface](./interfaces) or [union](./unions), you can also use an explicit
 `isTypeOf: (value) => value instanceof GiraffeModel` option to identify instances of the class.
-
-### Using SchemaTypes
-
-To reference an object type by a string name, register its backing model in the builder's `Objects`
-generic. This alternative uses the `Giraffe` interface from above:
-
-```typescript
-const builder = new SchemaBuilder<{
-  Objects: { Giraffe: Giraffe };
-}>({});
-
-builder.objectType('Giraffe', {
-  fields: (t) => ({
-    name: t.exposeString('name'),
-  }),
-});
-```
-
-Fields can now use `type: 'Giraffe'` without importing a ref. The mapping from GraphQL names to
-backing models stays in one place. The [SchemaBuilder guide](./schema-builder) covers the builder's
-other type settings.

--- a/website/content/docs/guide/objects.mdx
+++ b/website/content/docs/guide/objects.mdx
@@ -148,6 +148,25 @@ statements, as in the walkthrough above. See [circular references](./circular-re
 
 You can also pass a ref to `builder.objectType(GiraffeRef, { ... })` with the same options.
 
+### Using classes
+
+If your app already represents its data with classes, prefer using those classes as backing models.
+Pass the class to `builder.objectType`: its instance type becomes the backing model, and the class
+itself can be used as a field's `type`. For example, with an existing `GiraffeModel` class:
+
+```typescript
+builder.objectType(GiraffeModel, {
+  name: 'Giraffe',
+  fields: (t) => ({
+    name: t.exposeString('name'),
+  }),
+});
+```
+
+The `name` option supplies the GraphQL type name. When resolving an
+[interface](./interfaces) or [union](./unions), you can also use an explicit
+`isTypeOf: (value) => value instanceof GiraffeModel` option to identify instances of the class.
+
 ### Using SchemaTypes
 
 You can declare backing models in `SchemaTypes` and pass it to `SchemaBuilder`. This lets you
@@ -187,22 +206,3 @@ The `Objects` mapping tells Pothos which backing model belongs to each name. Her
 `Giraffe` field resolvers and checks the object returned by the `giraffe` query. You still define
 the GraphQL fields with `builder.objectType`; declaring a backing model doesn't expose its properties.
 The [SchemaBuilder guide](./schema-builder) covers the other type settings.
-
-### Using classes
-
-If your app already represents its data with classes, you can pass a class to `builder.objectType`.
-The class's instance type becomes the backing model, and the class itself can be used as a field's
-`type`. For example, with an existing `GiraffeModel` class:
-
-```typescript
-builder.objectType(GiraffeModel, {
-  name: 'Giraffe',
-  fields: (t) => ({
-    name: t.exposeString('name'),
-  }),
-});
-```
-
-The `name` option supplies the GraphQL type name. When resolving an
-[interface](./interfaces) or [union](./unions), you can also use an explicit
-`isTypeOf: (value) => value instanceof GiraffeModel` option to identify instances of the class.


### PR DESCRIPTION
The Objects guide now builds a schema in three steps using plain TypeScript data and `objectRef`, followed by a query and its response. It shows exposed properties and a computed field, then covers existing classes and a complete `SchemaTypes.Objects` declaration and query using string type names. Existing application classes are recommended as backing models.

Validation: strict checking of the extracted snippets, execution of the documented query, and a production website build (160 pages). Editorial and technical review findings have been addressed.

Stack: follows #1687; next is #1690.


