### PR TITLE
docs: clarify input object refs and recursive values

### DIFF
--- a/website/content/docs/guide/inputs.mdx
+++ b/website/content/docs/guide/inputs.mdx
@@ -3,9 +3,44 @@ title: Input Objects
 description: Guide for defining Input Object types in Pothos
 ---
 
-## Creating Input objects
+Input objects group related argument values. Define one with `builder.inputType`, then use the
+returned ref as an argument type. Pothos infers the input shape from its fields.
 
-Input objects can be created using `builder.inputType`.
+## Creating input objects
+
+The examples through “Recursive inputs” build on the same schema. Start with a backing model and
+an object ref for the mutation result:
+
+```typescript
+import SchemaBuilder from '@pothos/core';
+
+type Giraffe = {
+  name: string;
+  birthdate: string;
+  height: number;
+};
+
+const builder = new SchemaBuilder({});
+const giraffes: Giraffe[] = [];
+
+const GiraffeRef = builder.objectRef<Giraffe>('Giraffe').implement({
+  fields: (t) => ({
+    name: t.exposeString('name'),
+    birthdate: t.exposeString('birthdate'),
+    height: t.exposeFloat('height'),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    giraffes: t.field({ type: [GiraffeRef], resolve: () => giraffes }),
+  }),
+});
+```
+
+Input objects and output objects are separate GraphQL types, even when they have the same fields.
+Here, `GiraffeInput` describes the argument and `Giraffe` describes the result. The array stores the
+created giraffes in memory for this example.
 
 ```typescript
 const GiraffeInput = builder.inputType('GiraffeInput', {
@@ -19,89 +54,143 @@ const GiraffeInput = builder.inputType('GiraffeInput', {
 builder.mutationType({
   fields: (t) => ({
     createGiraffe: t.field({
-      type: Giraffe,
+      type: GiraffeRef,
       args: {
         input: t.arg({ type: GiraffeInput, required: true }),
       },
-      resolve: (root, args) =>
-        new Giraffe(args.input.name, new Date(args.input.birthdate), args.input.height),
+      resolve: (_root, { input }) => {
+        giraffes.push(input);
+        return input;
+      },
     }),
   }),
 });
 ```
 
+`required: true` on the argument requires an input object. Each input field has its own
+requiredness; here all three fields must also be provided and cannot be `null`.
+
+```graphql
+mutation {
+  createGiraffe(input: { name: "Gina", birthdate: "2020-03-15", height: 4.8 }) {
+    name
+    height
+  }
+}
+```
+
+```json
+{ "data": { "createGiraffe": { "name": "Gina", "height": 4.8 } } }
+```
+
 ## Recursive inputs
 
-Types for recursive inputs get slightly more complicated to implement because their types can't
-easily be inferred. Referencing other input types works without any additional logic, as long as
-there is no circular reference to the original type.
+Input objects can reference other input refs directly. For circular references, declare the input
+shape explicitly with `builder.inputRef` so TypeScript does not have to infer it through the cycle.
+Create the ref before implementing its fields.
 
-To build input types with recursive references you can use `builder.inputRef` along with a type or
-interface that describes the fields of your input object. The builder will still ensure all the
-types are correct, but needs type definitions to help infer the correct values.
+Add this input and mutation field to the builder above:
 
 ```typescript
 interface RecursiveGiraffeInputShape {
   name: string;
   birthdate: string;
   height: number;
-  friends?: RecursiveGiraffeInputShape[];
+  friends?: RecursiveGiraffeInputShape[] | null;
 }
 
-const RecursiveGiraffeInput = builder
-  .inputRef<RecursiveGiraffeInputShape>('RecursiveGiraffeInput')
-  .implement({
-    fields: (t) => ({
-      name: t.string({ required: true }),
-      birthdate: t.string({ required: true }),
-      height: t.float({ required: true }),
-      friends: t.field({
-        type: [RecursiveGiraffeInput],
-      }),
-    }),
-  });
+const RecursiveGiraffeInput = builder.inputRef<RecursiveGiraffeInputShape>(
+  'RecursiveGiraffeInput',
+);
 
-builder.mutationType({
+RecursiveGiraffeInput.implement({
   fields: (t) => ({
-    createGiraffeWithFriends: t.field({
-      type: [Giraffe],
-      args: {
-        input: t.arg({ type: RecursiveGiraffeInput, required: true }),
-      },
-      resolve: (root, args) => {
-        const friends = (args.input.friends || []).map(
-          (friend) =>
-            new Giraffe(args.input.name, new Date(args.input.birthdate), args.input.height),
-        );
-
-        return [
-          new Giraffe(args.input.name, new Date(args.input.birthdate), args.input.height),
-          ...friends,
-        ];
-      },
+    name: t.string({ required: true }),
+    birthdate: t.string({ required: true }),
+    height: t.float({ required: true }),
+    friends: t.field({
+      type: [RecursiveGiraffeInput],
+      required: { list: false, items: true },
     }),
   }),
 });
+
+function createGiraffes(input: RecursiveGiraffeInputShape): Giraffe[] {
+  const giraffe: Giraffe = {
+    name: input.name,
+    birthdate: input.birthdate,
+    height: input.height,
+  };
+
+  return [giraffe, ...(input.friends ?? []).flatMap(createGiraffes)];
+}
+
+builder.mutationField('createGiraffeWithFriends', (t) =>
+  t.field({
+    type: [GiraffeRef],
+    args: {
+      input: t.arg({ type: RecursiveGiraffeInput, required: true }),
+    },
+    resolve: (_root, { input }) => {
+      const created = createGiraffes(input);
+      giraffes.push(...created);
+      return created;
+    },
+  }),
+);
+
+const schema = builder.toSchema();
 ```
 
-## Additional way to define Input types
+The `friends` list can be omitted or set to `null`, but its items cannot be `null`. The TypeScript
+shape includes both optionality and `null` to match those values. The resolver uses each friend's
+own fields and follows nested `friends` lists, returning the parent before its descendants.
 
-If you're unable to use the builder ref directly by assigning it to a variable as depicted above,
-you can provide an `Inputs` type to the `SchemaBuilder`.
+```graphql
+mutation {
+  createGiraffeWithFriends(input: {
+    name: "Gina", birthdate: "2020-03-15", height: 4.8
+    friends: [{
+      name: "George", birthdate: "2021-06-01", height: 4.5
+      friends: [{ name: "Gemma", birthdate: "2022-08-10", height: 3.9 }]
+    }]
+  }) {
+    name
+    height
+  }
+}
+```
 
-This is useful in a scenario where you have multiple schema builders.
+```json
+{
+  "data": {
+    "createGiraffeWithFriends": [
+      { "name": "Gina", "height": 4.8 },
+      { "name": "George", "height": 4.5 },
+      { "name": "Gemma", "height": 3.9 }
+    ]
+  }
+}
+```
+
+## Declaring inputs in SchemaTypes
+
+Alternatively, register input shapes in the builder's `Inputs` map to reference them by name.
+To use this approach for `createGiraffe`, keep the import and `Giraffe` backing model from the first
+example and replace its builder declaration with:
 
 ```typescript
 const builder = new SchemaBuilder<{
   Inputs: {
-    GiraffeInput: {
-      name: string;
-      birthdate: string;
-      height: number;
-    };
+    GiraffeInput: Giraffe;
   };
 }>({});
+```
 
+Keep the `giraffes` array, `GiraffeRef`, and query definition. Replace the `GiraffeInput` ref
+declaration with this definition; registering a shape alone does not create the GraphQL input type.
+
+```typescript
 builder.inputType('GiraffeInput', {
   fields: (t) => ({
     name: t.string({ required: true }),
@@ -109,17 +198,14 @@ builder.inputType('GiraffeInput', {
     height: t.float({ required: true }),
   }),
 });
-
-builder.mutationType({
-  fields: (t) => ({
-    createGiraffe: t.field({
-      type: Giraffe,
-      args: {
-        input: t.arg({ type: 'GiraffeInput', required: true }),
-      },
-      resolve: (root, args) =>
-        new Giraffe(args.input.name, new Date(args.input.birthdate), args.input.height),
-    }),
-  }),
-});
 ```
+
+In the `createGiraffe` mutation, replace the `input` argument's `t.arg(...)` expression with:
+
+```typescript
+t.arg({ type: 'GiraffeInput', required: true })
+```
+
+Keep the rest of that mutation unchanged and call `builder.toSchema()` after defining it. The first
+mutation and result on this page also work with this schema; the recursive example is independent
+of this alternative.


### PR DESCRIPTION
The recursive input example created each friend from the parent's values and ignored deeper descendants. Use each input's own fields and traverse nested friends, with a displayed mutation/result that demonstrates the difference.

Introduce a complete plain-data/object-ref example, explain argument versus input-field requiredness, and preserve inputRef and SchemaTypes alternatives. The optional friends list explicitly accepts omission or null while rejecting null items.

Validation:
- Exact displayed snippets and SchemaTypes substitutions pass strict typechecking against current core source.
- Runtime assertions cover both displayed operations/results, distinct nested descendant values, omitted/null/empty lists, required inputs, rejected null items, stored query results, and the SchemaTypes alternative.
- Full-stack MDX generation and production website build passed (160 pages).
- Independent Standards and Spec/correctness reviews: no findings.

Docs only, stacked on the Arguments guide update.
