### PR TITLE
docs: make root type examples executable

### DIFF
--- a/website/content/docs/guide/queries-mutations-and-subscriptions.mdx
+++ b/website/content/docs/guide/queries-mutations-and-subscriptions.mdx
@@ -3,50 +3,46 @@ title: Queries, Mutations and Subscriptions
 description: Guide for adding queries, mutations and subscriptions to your schema
 ---
 
-There are a few different ways to add queries to your schema. The simplest way is to define a
-`Query` type with your query fields using the `builder.queryType()` method.
+Queries, mutations, and subscriptions are fields on the schema's root types. Each root type has
+methods for defining the type, adding one field, and adding several fields.
+
+## Queries
+
+Use `builder.queryType()` to define the `Query` type. This example returns plain backing data through
+an [object reference](./objects):
 
 ```typescript
-builder.queryType({
-  fields: (t) => ({
-    // Add query for a simple scalar type
-    hello: t.string({
-      resolve: () => 'hello, world!',
-    }),
-    // Add a query for an object type
-    giraffe: t.field({
-      type: Giraffe,
-      resolve: () => ({
-        name: 'James',
-      }),
-    }),
-    // Add a query for a list of objects
-    giraffes: t.field({
-      type: [Giraffe],
-      resolve: () => [
-        {
-          name: 'James',
-        },
-      ],
-    }),
-  }),
-});
+import SchemaBuilder from '@pothos/core';
 
-const Giraffe = builder.objectRef<{ name: string }>('Giraffe');
+type Giraffe = { name: string };
 
-Giraffe.implement({
+const builder = new SchemaBuilder({});
+const giraffes: Giraffe[] = [{ name: 'James' }];
+
+const GiraffeRef = builder.objectRef<Giraffe>('Giraffe').implement({
   fields: (t) => ({
     name: t.exposeString('name'),
   }),
 });
+
+builder.queryType({
+  fields: (t) => ({
+    hello: t.string({
+      resolve: () => 'hello, world!',
+    }),
+    giraffes: t.field({
+      type: [GiraffeRef],
+      resolve: () => giraffes,
+    }),
+  }),
+});
 ```
 
-You can only use `builder.queryType()` once in your schema, because it is responsible for defining
-the `Query` type itself. If you want to split up your queries and add query fields individually, you
-can use the `builder.queryField()` method to add individual query fields to the `Query` type.
+Define the `Query` type once. To split its fields across files, use `builder.queryField()` or
+`builder.queryFields()`. The following is an alternative to the `builder.queryType()` call above,
+using the same builder, object reference, and data:
 
 ```typescript
-// You will still need to define the `Query` type somewhere in your schema to add individual query fields
 builder.queryType({});
 
 builder.queryField('hello', (t) =>
@@ -55,87 +51,91 @@ builder.queryField('hello', (t) =>
   }),
 );
 
-builder.queryField('giraffe', (t) =>
-  t.field({
-    type: Giraffe,
-    resolve: () => ({
-      name: 'James',
-    }),
-  }),
-);
-```
-
-If you want to add multiple query fields at once, you can use the `builder.queryFields()` method.
-
-```typescript
 builder.queryFields((t) => ({
-  hello: t.string({
-    resolve: () => 'hello, world!',
-  }),
-  giraffe: t.field({
-    type: Giraffe,
-    resolve: () => ({
-      name: 'James',
-    }),
+  giraffes: t.field({
+    type: [GiraffeRef],
+    resolve: () => giraffes,
   }),
 }));
 ```
 
-# Mutations
+## Mutations
 
-Mutations work just like queries, and you can use the `builder.mutationType()`,
-`builder.mutationField()`, and `builder.mutationFields()` methods to add mutations to your schema.
+Use `builder.mutationType()`, `builder.mutationField()`, and `builder.mutationFields()` in the same
+way. Continuing the query example, this mutation adds a giraffe to the array returned by `giraffes`:
 
 ```typescript
-builder.mutationType({
-  fields: (t) => ({
-    // Add mutation that returns a simple boolean
-    post: t.boolean({
-      args: {
-        message: t.arg.string(),
-      },
-      resolve: async (root, args) => {
-        // Do something with the message
-        const success = await messageClient.postMessage(args.message);
-
-        return success;
-      },
-    }),
-  }),
-});
+builder.mutationType({});
 
 builder.mutationField('createGiraffe', (t) =>
   t.field({
-    type: Giraffe,
+    type: GiraffeRef,
     args: {
-      name: t.arg.string(),
+      name: t.arg.string({ required: true }),
     },
-    resolve: async (root, args) => {
-      const giraffe = {
-        name: args.name,
-      };
-
-      await db.giraffes.create(giraffe);
-
+    resolve: (_parent, args) => {
+      const giraffe = { name: args.name };
+      giraffes.push(giraffe);
       return giraffe;
     },
   }),
 );
-```
-# Subscriptions
 
-Subscriptions too work just like queries and mutations where you can use the `builder.subscriptionType()`,
-`builder.subscriptionField()`, and `builder.subscriptionFields()` methods to add subscriptions to your
-schema.
+const schema = builder.toSchema();
+```
+
+The required argument provides a `string` for the backing model's `name`. This example stores data
+in memory; an application can perform its database write in the resolver instead.
+
+```graphql
+mutation {
+  createGiraffe(name: "Morgan") {
+    name
+  }
+}
+```
+
+A subsequent `{ giraffes { name } }` query returns both James and Morgan.
+
+## Subscriptions
+
+Use `builder.subscriptionType()`, `builder.subscriptionField()`, and `builder.subscriptionFields()`
+to define subscription fields. Each field has a `subscribe` function that returns an async iterable
+of events, and a `resolve` function that converts each event into the field's result.
+
+This separate example defines the context contract for a counter and its event provider. Supply a
+shared counter and provider through your server's context so the mutation publishes to the same
+stream that subscriptions consume. The provider's `subscribe()` method must register the listener
+when called and release it when the returned iterator is closed.
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
+
+type Context = {
+  count: { value: number };
+  counterEvents: {
+    publish: (value: number) => void;
+    subscribe: () => AsyncIterable<number>;
+  };
+};
+
+const builder = new SchemaBuilder<{ Context: Context }>({});
+
+builder.queryType({
+  fields: (t) => ({
+    count: t.int({
+      resolve: (_parent, _args, context) => context.count.value,
+    }),
+  }),
+});
+
 builder.mutationType({
   fields: (t) => ({
     incrementCount: t.int({
-      resolve: (_parent, _args, ctx) => {
-        ctx.count.value += 1;
-        ctx.pubSub.publish('COUNT_INCREMENT', ctx.count.value);
-        return ctx.count.value;
+      resolve: (_parent, _args, context) => {
+        context.count.value += 1;
+        context.counterEvents.publish(context.count.value);
+        return context.count.value;
       },
     }),
   }),
@@ -144,16 +144,35 @@ builder.mutationType({
 builder.subscriptionType({
   fields: (t) => ({
     incrementedCount: t.int({
-      subscribe: (_parent, _args, ctx) => ctx.pubSub.subscribe('COUNT_INCREMENT'),
+      subscribe: (_parent, _args, context) => context.counterEvents.subscribe(),
       resolve: (count) => count,
     }),
   }),
 });
+
+const schema = builder.toSchema();
 ```
+
+Start a subscription before calling the mutation to receive its event:
+
+```graphql
+subscription {
+  incrementedCount
+}
+```
+
+```graphql
+mutation {
+  incrementCount
+}
+```
+
+With an initial count of `0`, the mutation returns `1` and the subscription emits
+`{ "data": { "incrementedCount": 1 } }`. Configure a subscription transport in your GraphQL server
+to deliver these results to clients.
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
 <Callout type="warn">
-  Ensure that the `subscribe` function is always defined before the `resolve` function,
-  otherwise you may run into issues with the resolver arguments not being typed correctly.
+  Define `subscribe` before `resolve` so TypeScript can infer the resolver's event type.
 </Callout>


### PR DESCRIPTION
The root-types guide's mutations referenced undefined clients and passed optional names into required backing data. Use a complete in-memory query/mutation example whose write is visible to a subsequent query, and clearly distinguish the alternative query registration methods.

Keep subscription registration methods and provide a separate typed context contract for the counter/event provider. Explain shared state, listener lifecycle, and the server transport needed to deliver events.

Validation:
- Exact displayed examples and query-registration alternative pass strict typechecking against current core source.
- Runtime assertions cover queries, mutation persistence, and required argument rejection.
- Real GraphQL subscribe execution verifies event delivery, shared counter state, and listener cleanup using an event-provider fixture.
- Full-stack MDX generation and production website build passed (160 pages).
- Independent Standards and Spec/correctness reviews: no findings.

Docs only, stacked on the Input Objects guide update.
