### PR TITLE
docs: clarify enum names and backing values

### DIFF
--- a/website/content/docs/guide/enums.mdx
+++ b/website/content/docs/guide/enums.mdx
@@ -1,74 +1,122 @@
 ---
 title: Enums
-description: Guide for defining Enum types in Pothos
+description: Define enum values and use them in fields and arguments.
 ---
 
-Enums can be defined a number of different ways:
+A GraphQL enum defines a fixed set of named values. `builder.enumType` returns a reference you can
+use as a field or argument type.
 
-1. Using typescript enums
+## Defining an enum
+
+An array of strings uses the same values in GraphQL and in your resolvers:
 
 ```typescript
-export enum Diet {
-  HERBIVOROUS,
-  CARNIVOROUS,
-  OMNIVORIOUS,
+import SchemaBuilder from '@pothos/core';
+
+const builder = new SchemaBuilder({});
+
+const LengthUnit = builder.enumType('LengthUnit', {
+  values: ['Feet', 'Meters'],
+});
+
+builder.queryType({
+  fields: (t) => ({
+    height: t.float({
+      args: {
+        unit: t.arg({ type: LengthUnit, required: true, defaultValue: 'Meters' }),
+      },
+      resolve: (_parent, { unit }) => (unit === 'Meters' ? 5 : 5 * 3.281),
+    }),
+    unit: t.field({
+      type: LengthUnit,
+      args: { value: t.arg({ type: LengthUnit, required: true }) },
+      resolve: (_parent, { value }) => value,
+    }),
+  }),
+});
+
+export const schema = builder.toSchema();
+```
+
+Pothos infers the inline array as the literal values `'Feet' | 'Meters'`. If you define the array
+in a separate variable, use `as const` to retain those literal types.
+
+```graphql
+{
+  height
+  feet: height(unit: Feet)
+  unit(value: Meters)
 }
-
-builder.enumType(Diet, {
-  name: 'Diet',
-});
 ```
 
-2. Using an array of strings
-
-```typescript
-export const LengthUnit = builder.enumType('LengthUnit', {
-  values: ['Feet', 'Meters'] as const,
-});
+```json
+{
+  "data": {
+    "height": 5,
+    "feet": 16.405,
+    "unit": "Meters"
+  }
+}
 ```
 
-Note that we use `as const` to allow ts to properly type our enum values.
+Enum literals in a query are unquoted names. When passing an enum in JSON variables, use a string
+such as `"Meters"`.
 
-3. Using a values object:
+## Descriptions and internal values
+
+Use a values object to describe or deprecate individual values, or to map GraphQL names to different
+values in your application:
 
 ```typescript
-export const GiraffeSpecies = builder.enumType('GiraffeSpecies', {
+const GiraffeSpecies = builder.enumType('GiraffeSpecies', {
   values: {
     Southern: {
       description: 'Also known as two-horned giraffe',
       value: 'giraffa',
     },
-    Masai: {
-      value: 'tippelskirchi',
-    },
-    Reticulated: {
-      value: 'reticulata',
-    },
-    Northern: {
-      value: 'camelopardalis',
-    },
-  } as const,
+    Masai: { value: 'tippelskirchi' },
+    Reticulated: { value: 'reticulata' },
+    Northern: { value: 'camelopardalis' },
+    Unknown: { deprecationReason: 'Use a nullable species field instead.' },
+  },
 });
 ```
 
-Again we use `as const` here to allow the enum values to be correctly inferred. The `as const`
-can also be added to the values instead, or omitted if the `values` are already defined using a
-variable that typescript can type correctly.
+The keys are GraphQL names. An argument containing `Northern` reaches the resolver as
+`'camelopardalis'`; returning `'camelopardalis'` from a `GiraffeSpecies` field produces `"Northern"`
+in the response. If `value` is omitted, the key is also the internal value. Deprecating a value
+leaves it usable by clients.
 
-Using a values object like this enables defining additional options like a description for each
-enum value.
+## TypeScript enums
 
-Using a values object also allows the name of the enum value to be different from the typescript
-value used internally in your resolvers.
+If your application already uses a TypeScript enum, register it directly:
 
-The keys (eg `Southern`) are used as the name of the enum value in your GraphQL schema, and the
-`value` (eg. `'giraffa'`) property is used as the value you will receive in the arguments for
-your resolvers, or the value you need to return from your resolvers. This is similar to how
-typescript enum values can be assigned string or numeric values.
+```typescript
+enum Diet {
+  HERBIVOROUS,
+  CARNIVOROUS,
+  OMNIVOROUS,
+}
 
-4. Using an object with `as const`
+builder.enumType(Diet, { name: 'Diet' });
 
-```ts
+builder.queryField('diet', (t) =>
+  t.field({
+    type: Diet,
+    resolve: () => Diet.HERBIVOROUS,
+  }),
+);
+```
+
+The enum's keys become GraphQL value names. Resolvers receive and return the TypeScript enum's
+values, including numeric values in this example. You can use either the TypeScript enum itself
+or the reference returned by `enumType` as the field or argument type.
+
+## Objects with `as const`
+
+You can also derive enum values from an existing object:
+
+```typescript
 const VehicleType = {
   sedan: 'SEDAN',
   suv: 'SUV',
@@ -83,62 +131,21 @@ const VehicleTypeEnum = builder.enumType('VehicleType', {
 });
 ```
 
-Modern TypeScript may prefer using objects with as const over enums to align with JavaScript
-standards. This approach essentially mirrors the "array of strings" method. You can use
-`Object.toEntries` and `Object.fromEntries` to convert to Object values form described
-above.
+Here the GraphQL names are `sedan`, `suv`, `truck`, and `motorcycle`, while resolvers use `SEDAN`,
+`SUV`, `TRUCK`, and `MOTORCYCLE`. To use the object's values for both names and internal values,
+replace the enum definition with:
 
-For more detailed information, you can refer to the TypeScript handbook on
-[Objects vs Enums](https://www.typescriptlang.org/docs/handbook/enums.html#objects-vs-enums).
-
-Alternatively, using `Object.keys` or `Object.values` will allow you to produce an enum that uses
-just the keys or values of the object for both the internal typescript and name in the GraphQL
-schema.
-
-```ts
-const VehicleType = {
-  sedan: 'SEDAN',
-  suv: 'SUV',
-  truck: 'TRUCK',
-  motorcycle: 'MOTORCYCLE',
-} as const;
-
+```typescript
 const VehicleTypeEnum = builder.enumType('VehicleType', {
   values: Object.values(VehicleType),
 });
-// Or
+```
+
+To use the keys for both, use `Object.keys(VehicleType)`. TypeScript types `Object.keys` as
+`string[]`, so the following assertion preserves the known keys of this local object:
+
+```typescript
 const VehicleTypeEnum = builder.enumType('VehicleType', {
   values: Object.keys(VehicleType) as (keyof typeof VehicleType)[],
 });
-```
-
-## Using Enum Types
-
-Enums can be referenced either by the `Ref` that was returned by calling `builder.enumType` or by
-using the typescript enum. They can be used either as arguments, or as field return types:
-
-```typescript
-builder.objectFields('Giraffe', (t) => ({
-  height: t.float({
-    args: {
-      unit: t.arg({
-        type: LengthUnit,
-        required: true,
-        defaultValue: 'Meters',
-      }),
-    },
-    resolve: (parent, args) =>
-      args.unit === 'Meters' ? parent.heightInMeters : parent.heightInMeters * 3.281,
-  }),
-  diet: t.field({
-    description:
-      'While Giraffes are herbivores, they do eat the bones of dead animals to get extra calcium',
-    type: Diet,
-    resolve: () => Diet.HERBIVOROUS,
-  }),
-  species: t.field({
-    type: GiraffeSpecies,
-    resolve: () => 'camelopardalis' as const,
-  }),
-}));
 ```


### PR DESCRIPTION
Show enum input/output behavior and distinguish GraphQL names from resolver values. Keep inline arrays, TypeScript enums, explicit values, and const-object alternatives; fix stale examples without a resolver type assertion.

Validation: Exact displayed TypeScript snippets and executed enum queries on GraphQL16 and17; mapped values, variables, unknown-value rejection, TypeScript enum output, and all const-object representations.

Independent Standards and Spec/correctness reviews passed. The integrated docs stack passes MDX generation and the production website build.
