### PR TITLE
docs: correct core API reference contracts

### DIFF
--- a/website/content/docs/api/arg-builder.mdx
+++ b/website/content/docs/api/arg-builder.mdx
@@ -3,6 +3,10 @@ title: ArgBuilder
 description: API docs for Pothos ArgBuilder
 ---
 
+This reference describes the options for an argument. For examples, see [Arguments](../guide/args).
+
+The option types below are summaries; Pothos infers their concrete types from your schema.
+
 ## `arg(options)`
 
 - `options`: \[`FieldOptions`\]
@@ -11,19 +15,23 @@ description: API docs for Pothos ArgBuilder
 
 ```typescript
 type FieldOptions = {
-  type: ReturnType;
-  required?: boolean;
+  type: InputType;
+  required?: boolean | { list: boolean; items: boolean };
+  defaultValue?: DefaultValue;
   description?: string;
   deprecationReason?: string;
+  extensions?: Readonly<Record<string, unknown>>;
 };
 ```
 
 - `type`: [Type Parameter](./arg-builder#type-parameter)
-- `required`: boolean, defaults to `false`, unless overwritten in SchemaBuilder see
+- `required`: defaults to `false`, unless overwritten in SchemaBuilder see
 
   [Changing Default Nullability](../guide/changing-default-nullability).
 
 - `description`: string
+- `deprecationReason`: marks the input as deprecated.
+- `extensions`: metadata for tools and plugins.
 - `defaultValue`: default value for field, type based on `type` option.
 
 ### Type Parameter
@@ -33,9 +41,14 @@ A Type Parameter for a Field can be any `InputTypeRef` returned by one of the
 enum used to define a graphql enum type, or a string that corresponds to one of the keys of the
 `Scalars` object defined in `SchemaTypes`.
 
+For lists, wrap the type in an array, for example `['ID']`. A boolean `required` controls
+the list itself; items are required by default. Use `{ list: false, items: false }` to allow both
+an omitted or null list and null items. Input object names declared in `SchemaTypes.Inputs`
+can also be used as strings.
+
 ## helpers
 
-A set of helpers for creating scalar fields. This work the same as ArgBuilder, but omit the `type`
+A set of helpers for creating scalar fields. These work the same as ArgBuilder, but omit the `type`
 field from options.
 
 ### Scalars
@@ -50,4 +63,10 @@ field from options.
 - `arg.booleanList(options)`
 - `arg.intList(options)`
 - `arg.floatList(options)`
-- `arg.listRef(type, options)`
+
+
+### `arg.listRef(type, options?)`
+
+Creates a list type reference, including nested lists. `options.required` controls the items
+and defaults to `true`; the field or argument options control the outer list. See
+[Arguments](../guide/args) for a nested-list example.

--- a/website/content/docs/api/field-builder.mdx
+++ b/website/content/docs/api/field-builder.mdx
@@ -3,6 +3,9 @@ title: FieldBuilder
 description: API docs for Pothos FieldBuilder
 ---
 
+The field builder is the `t` passed to a `fields` callback. See [Fields](../guide/fields)
+for examples. The option types below summarize an API whose concrete types are inferred from your schema.
+
 ## `field(options)`
 
 - `options`: `FieldOptions`
@@ -13,20 +16,17 @@ description: API docs for Pothos FieldBuilder
 type FieldOptions = {
   type: ReturnType;
   args?: Args;
-  nullable?: boolean;
+  nullable?: boolean | { list: boolean; items: boolean };
   description?: string;
   deprecationReason?: string;
-  resolve: (parent, args, context, info): ResolveValue;
+  resolve: (parent, args, context, info) => ResolveValue;
+  extensions?: Readonly<Record<string, unknown>>;
 };
 ```
 
 - `type`: [Type Parameter](./field-builder#type-parameter)
-- `args`: a map of arg name to arg values. Arg values can be created using an
-  [`InputFieldBuilder`](./input-field-builder)
-
-  \(`fieldBuilder.arg`\) or using `schemaBuilder.args`
-
-- `nullable`: boolean, defaults to `true`, unless overwritten in SchemaBuilder see
+- `args`: a map of argument names to refs, created with [`t.arg`](./arg-builder) or `builder.args`.
+- `nullable`: defaults to `true`, unless overwritten in SchemaBuilder see
   [Changing Default Nullability](../guide/changing-default-nullability).
 - `description`: string
 - `deprecationReason`: string
@@ -39,7 +39,9 @@ A Type Parameter for a Field can be any `TypeRef` returned by one of the
 interface type, a ts enum used to define a graphql enum type, or a string that corresponds to one of
 the keys of the `Objects`, `Interfaces`, or `Scalars` objects defined in `SchemaTypes`.
 
-For List fields, the Type Parameter should be one of the above wrapped in an array eg `['User']`.
+For list fields, wrap the type in an array, for example `['User']`. A boolean `nullable`
+controls the list itself; items are non-null by default. Use `{ list: true, items: true }` to allow
+both a null list and null items.
 
 ### Resolver
 
@@ -48,19 +50,17 @@ A function to resolve the value of this field.
 #### Return type
 
 Field resolvers should return a value \(or promise\) that matches the expected type for this field.
-For `Scalars`, `Objects`, and `Interfaces` this type is the corresponding type defined
-`SchemaTypes`. For Unions, the type may be any of the corresponding shapes of members of the union.
-For Enums, the value is dependent on the implementation of the enum. See `Enum` guide for more
+For scalars, this is their output shape. For objects and interfaces, it is the backing shape
+carried by a ref, class, or `SchemaTypes` entry. For Unions, the type may be any of the corresponding shapes of members of the union.
+For Enums, the value is dependent on the implementation of the enum. See the [Enums](../guide/enums) guide for more
 details.
 
 #### Args
 
-- `parent`: Parent will be a value of the backing model for the current type specified in
-
-  `SchemaTypes`.
+- `parent`: the backing value of the current type. Root fields receive the root value, typed by `SchemaTypes.Root`.
 
 - `args`: an object matching the shape of the args option for the current field
-- `context`: The type `Context` type defined in `SchemaTypes`.
+- `context`: The `Context` type defined in `SchemaTypes`.
 - `info`: a GraphQLResolveInfo object see
 
   [https://graphql.org/graphql-js/type/\#graphqlobjecttype](https://graphql.org/graphql-js/type/#graphqlobjecttype)
@@ -69,7 +69,7 @@ details.
 
 ## helpers
 
-A set of helpers for creating scalar fields. This work the same as
+A set of helpers for creating scalar fields. These work the same as
 [`field`](./field-builder#fieldoptions), but omit the `type` field from options.
 
 ### Scalars
@@ -84,13 +84,20 @@ A set of helpers for creating scalar fields. This work the same as
 - `booleanList(options)`
 - `intList(options)`
 - `floatList(options)`
-- `listRef(type, options)`
+
+
+### `listRef(type, options?)`
+
+Creates a list type reference, including nested lists. `options.nullable` controls the items
+and defaults to `false`; the field options control the outer list.
 
 ### expose
 
 A set of helpers to expose fields from the backing model. The `name` arg can be any field from the
 backing model that matches the type being exposed. Options are the same as
-[`field`](./field-builder#fieldoptions), but `type` and `resolve` are omitted.
+[`field`](./field-builder#fieldoptions), but `type`, `resolve`, and `args` are omitted.
+
+The general `expose(name, { type, ...options })` helper also supports object, enum, and custom scalar properties.
 
 - `exposeString(name, options)`
 - `exposeID(name, options)`

--- a/website/content/docs/api/input-field-builder.mdx
+++ b/website/content/docs/api/input-field-builder.mdx
@@ -3,6 +3,10 @@ title: InputFieldBuilder
 description: API docs for Pothos InputFieldBuilder
 ---
 
+This reference describes the options for an input field. For examples, see [Input Objects](../guide/inputs).
+
+The option types below are summaries; Pothos infers their concrete types from your schema.
+
 ## `field(options)`
 
 - `options`: \[`FieldOptions`\]
@@ -11,18 +15,22 @@ description: API docs for Pothos InputFieldBuilder
 
 ```typescript
 type FieldOptions = {
-  type: ReturnType;
-  required?: boolean;
+  type: InputType;
+  required?: boolean | { list: boolean; items: boolean };
+  defaultValue?: DefaultValue;
   description?: string;
   deprecationReason?: string;
+  extensions?: Readonly<Record<string, unknown>>;
 };
 ```
 
 - `type`: [Type Parameter](./input-field-builder#type-parameter)
-- `required`: boolean, defaults to `false`, unless overwritten in SchemaBuilder. See
+- `required`: defaults to `false`, unless overwritten in SchemaBuilder. See
   [Changing Default Nullability](../guide/changing-default-nullability).
 
 - `description`: string
+- `deprecationReason`: marks the input as deprecated.
+- `extensions`: metadata for tools and plugins.
 - `defaultValue`: default value for field, type based on `type` option.
 
 ### Type Parameter
@@ -32,9 +40,14 @@ A Type Parameter for a Field can be any `InputTypeRef` returned by one of the
 enum used to define a graphql enum type, or a string that corresponds to one of the keys of the
 `Scalars` object defined in [`SchemaTypes`](./schema-builder#schematypes).
 
+For lists, wrap the type in an array, for example `['ID']`. A boolean `required` controls
+the list itself; items are required by default. Use `{ list: false, items: false }` to allow both
+an omitted or null list and null items. Input object names declared in `SchemaTypes.Inputs`
+can also be used as strings.
+
 ## helpers
 
-A set of helpers for creating scalar fields. This work the same as `field`, but omit the `type`
+A set of helpers for creating scalar fields. These work the same as `field`, but omit the `type`
 field from options.
 
 ### Scalars
@@ -49,4 +62,10 @@ field from options.
 - `booleanList(options)`
 - `intList(options)`
 - `floatList(options)`
-- `listRef(type, options)`
+
+
+### `listRef(type, options?)`
+
+Creates a list type reference, including nested lists. `options.required` controls the items
+and defaults to `true`; the field or argument options control the outer list. See
+[Arguments](../guide/args) for a nested-list example.

--- a/website/content/docs/api/schema-builder.mdx
+++ b/website/content/docs/api/schema-builder.mdx
@@ -5,7 +5,9 @@ description: API docs for Pothos SchemaBuilder
 ---
 
 SchemaBuilder is the core class of Pothos. It can be used to build types, and merge them into a
-graphql.js Schema.
+graphql.js Schema. The signatures below summarize the API; placeholder types such as
+`FieldsFunction` stand for types inferred from your schema. See the
+[Schema Builder guide](../guide/schema-builder) for configuration examples.
 
 ## `constructor<SchemaTypes>(options)`
 
@@ -15,9 +17,13 @@ graphql.js Schema.
 ### `SchemaTypes`
 
 ```typescript
-type SchemaTypes {
+type SchemaTypes = {
   // Shape of the context arg in your resolvers
   Context?: object;
+  // Shape of the root value passed to root field resolvers
+  Root?: object;
+  // Select v3 compatibility defaults when needed
+  Defaults?: 'v3' | 'v4';
   // A map of Object type names to their backing models.
   Objects?: object;
   // A map of Input type names to their backing models.
@@ -42,10 +48,17 @@ type SchemaTypes {
 ### SchemaBuilderOptions
 
 ```typescript
-type SchemaBuilderOptions = {};
+type SchemaBuilderOptions = {
+  plugins?: PluginName[];
+  defaultFieldNullability?: boolean;
+  defaultInputFieldRequiredness?: boolean;
+  defaults?: 'v3' | 'v4';
+};
 ```
 
-By default there are no options for SchemaBuilder, but plugins may contribute additional options
+Plugins may contribute additional options. When changing a default, set both the corresponding
+`SchemaTypes` entry and runtime option. Fields are nullable and inputs optional by default in v4.
+See [Changing Default Nullability](../guide/changing-default-nullability).
 
 ## `queryType(options, fields?)`
 
@@ -60,7 +73,7 @@ creates the `Query` with a set of Query fields
 ```typescript
 type QueryTypeOptions = {
   description?: string;
-  fields: FieldsFunction;
+  fields?: FieldsFunction;
 };
 ```
 
@@ -96,7 +109,7 @@ creates the `Mutation` with a set of Mutation fields
 ```typescript
 type MutationTypeOptions = {
   description?: string;
-  fields: FieldsFunction;
+  fields?: FieldsFunction;
 };
 ```
 
@@ -132,7 +145,7 @@ creates the `Subscription` with a set of Subscription fields
 ```typescript
 type SubscriptionTypeOptions = {
   description?: string;
-  fields: FieldsFunction;
+  fields?: FieldsFunction;
 };
 ```
 
@@ -169,9 +182,9 @@ add a single field to the `Subscription` type.
 ```typescript
 type ObjectTypeOptions = {
   description?: string;
-  fields: FieldsFunction;
-  interfaces?: Interfaces;
-  isTypeOf: (obj: InterfaceShape) => boolean;
+  fields?: FieldsFunction;
+  interfaces?: Interfaces | (() => Interfaces);
+  isTypeOf?: (obj: unknown, context, info) => boolean | Promise<boolean>;
   name?: string;
 };
 ```
@@ -183,7 +196,7 @@ type ObjectTypeOptions = {
 - `isTypeOf`: Recommended when implementing interfaces. This is a method that will be used when
   determining if a value of an implemented interface is of the current type.
 
-- `interfaces`: an array of interfaces implemented by this interface type. Items in this array
+- `interfaces`: an array of interfaces implemented by this type. Items in this array
   should be an interface param. See `param` argument of `interfaceType`
 
 - `name`: name of GraphQL type. Required when param is a class
@@ -211,7 +224,7 @@ add a single field to the object type.
 
 ## `objectRef<T>(name)`
 
-Creates a Ref object represent an object that has not been implemented. This can be useful for
+Creates a Ref object representing an object that has not been implemented. This can be useful for
 building certain types of plugins, or when building a modular schema where you don't want to define
 all types in SchemaTypes, or import the actual implementation of each object type you use.
 
@@ -232,8 +245,10 @@ all types in SchemaTypes, or import the actual implementation of each object typ
 ```typescript
 type InterfaceTypeOptions = {
   description?: string;
-  fields: FieldsFunction;
-  interfaces?: Interfaces;
+  resolveType?: (parent: InterfaceShape, context, info, abstractType) =>
+    MaybePromise<ObjectParam | string | null | undefined>;
+  fields?: FieldsFunction;
+  interfaces?: Interfaces | (() => Interfaces);
   name?: string;
 };
 ```
@@ -242,10 +257,13 @@ type InterfaceTypeOptions = {
 - `fields`: a function that receives a [`FieldBuilder`](./field-builder), and returns an object of
   field names to field refs. See [`FieldBuilder`](./field-builder) for more details.
 
-- `interfaces`: an array of interfaces implemented by this interface type. Items in this array
+- `interfaces`: an array of interfaces implemented by this type. Items in this array
   should be an interface param. See `param` argument of `interfaceType`
 
 - `name`: name of GraphQL type. Required when param is a class
+
+`resolveType` returns an implementing object ref, registered class, or GraphQL type name.
+If omitted, GraphQL uses `__typename` or object `isTypeOf` checks. See [Interfaces](../guide/interfaces).
 
 ## `interfaceFields(param, fields)`
 
@@ -270,7 +288,7 @@ add a single field to the interface type.
 
 ## `interfaceRef<T>(name)`
 
-Creates a Ref object represent an interface that has not been implemented. This can be useful for
+Creates a Ref object representing an interface that has not been implemented. This can be useful for
 building certain types of plugins, or when building a modular schema where you don't want to define
 all types in SchemaTypes, or import the actual implementation of each interface type you use.
 
@@ -288,7 +306,8 @@ all types in SchemaTypes, or import the actual implementation of each interface 
 type UnionTypeOptions = {
   description?: string;
   types: Member[] | (() => Member[]);
-  resolveType: (parent: UnionShape, context) => MaybePromise<GraphQLObjectType | TypeName>;
+  resolveType?: (parent: UnionShape, context, info, abstractType) =>
+    MaybePromise<Member | string | null | undefined>;
 };
 ```
 
@@ -297,8 +316,9 @@ type UnionTypeOptions = {
   params. See `param` argument in `builder.objectType`.
 
 - `resolveType`: A function called when resolving the type of a union value. `parent` will be a
-  union of the backing models of the types provided in `types`. This function should return the name
-  of one of the union member types.
+  union of the backing models of the types provided in `types`. Return a member ref, its registered
+  class, or its GraphQL type name. If omitted, GraphQL uses
+  `__typename` or member `isTypeOf` checks. See [Unions](../guide/unions).
 
 ## `enumType(param, options)`
 
@@ -308,7 +328,7 @@ type UnionTypeOptions = {
 ### `EnumTypeOptions`
 
 ```typescript
-type UnionTypeOptions = {
+type EnumTypeOptions = {
   description?: string;
   values?: Values;
   name?: string;
@@ -321,28 +341,40 @@ type UnionTypeOptions = {
 
 - `name`: required when param is an enum
 
-## `addScalarType(name, scalar, options)`
+## `addScalarType(name, scalar, options?)`
 
-- `name`: A key of the `Interface` property in `SchemaTypes`
-- `scalar`: A `GraphQLScalar`
+- `name`: A key of the `Scalars` property in `SchemaTypes`
+- `scalar`: A `GraphQLScalarType`
+- `options`: optional scalar options that override the supplied scalar configuration.
 
 ## `scalarType(name, options)`
 
-- `name`: A key of the `Interface` property in `SchemaTypes`
+- `name`: A key of the `Scalars` property in `SchemaTypes`
 - `options`: `ScalarTypeOptions`
 
 ### ScalarTypeOptions
 
 ```typescript
-description?: string;
-// Serializes an internal value to include in a response.
-serialize: GraphQLScalarSerializer<OutputShape>;
-// Parses an externally provided value to use as an input.
-parseValue?: GraphQLScalarValueParser<InputShape>;
-// Parses an externally provided literal value to use as an input.
-parseLiteral?: GraphQLScalarLiteralParser<InputShape>;
-extensions?: Readonly<Record<string, unknown>>;
+type ScalarTypeOptions = {
+  description?: string;
+  // Serializes an internal value to include in a response.
+  serialize?: (value: OutputShape) => unknown;
+  // Parses an externally provided value to use as an input.
+  parseValue?: GraphQLScalarValueParser<InputShape>;
+  // Parses an externally provided literal value to use as an input.
+  parseLiteral?: GraphQLScalarLiteralParser<InputShape>;
+  // GraphQL.js 17+ coercion hooks
+  coerceOutputValue?: (value: OutputShape) => unknown;
+  coerceInputValue?: GraphQLScalarValueParser<InputShape>;
+  coerceInputLiteral?: (node: ConstValueNode) => InputShape | null | undefined;
+  valueToLiteral?: (value: unknown) => ConstValueNode | undefined;
+  extensions?: Readonly<Record<string, unknown>>;
+};
 ```
+
+For portable scalar definitions, provide `serialize`, `parseValue`, and `parseLiteral`.
+GraphQL.js 17 also supports `coerceOutputValue`, `coerceInputValue`, `coerceInputLiteral`, and
+`valueToLiteral`. These hooks have version-specific requirements; see [Scalars](../guide/scalars).
 
 ## `inputType(param, options)`
 
@@ -354,19 +386,24 @@ extensions?: Readonly<Record<string, unknown>>;
 ```typescript
 type InputTypeOptions = {
   description?: string;
-  fields: InputShape;
+  fields: InputFieldsFunction;
+  isOneOf?: boolean;
 };
 ```
 
 - `description`: A description of the current type
 - `fields`: a function that receives an `InputFieldBuilder`, and returns an object of field names to
-  field definitions. See [`InputFieldBuilder`](./input-field-builder) for more details. If `name` is
-  a key of the `Input` property in `SchemaTypes`, shape will show type errors for any fields that do
+  field definitions. See [`InputFieldBuilder`](./input-field-builder) for more details. If `param` is
+  a key of the `Inputs` property in `SchemaTypes`, shape will show type errors for any fields that do
   not match the types provided in `SchemaTypes`.
+
+- `isOneOf`: defines a OneOf input object on supported GraphQL.js versions. See
+  [Input Objects](../guide/inputs). A OneOf input accepts exactly one non-null field; its fields
+  must be optional and have no defaults. Use a GraphQL.js version with OneOf support.
 
 ## `inputRef<T>(name)`
 
-Creates a Ref object represent an input object that has not been implemented. This can be useful for
+Creates a Ref object representing an input object that has not been implemented. This can be useful for
 defining recursive input types, for building certain types of plugins, or when building a modular
 schema where you don't want to define all types in SchemaTypes, or import the actual implementation
 of each input type you use.
@@ -381,10 +418,17 @@ Creates an arguments object which can be used as the `args` option in a field de
 - `fields`: a function that receives an [`ArgBuilder`](./arg-builder), and returns an object of
   field names to field definitions. See [`ArgBuilder`](./arg-builder) for more details.
 
-## `toSchema(types)`
+## `toSchema(options?)`
 
-Takes an array of types created by [`SchemaBuilder`](./schema-builder#schemabuilder) and returns a
-[`GraphQLSchema`](https://graphql.org/graphql-js/type/#graphqlschema)
+Builds a `GraphQLSchema` from the types registered on the builder. The optional object accepts:
+
+- `directives`: custom `GraphQLDirective` instances to include in the schema.
+- `extensions`: schema metadata.
+- `sortSchema`: defaults to `true`; set to `false` to skip lexicographic sorting.
+- `astNode`: a schema definition AST node.
+
+Plugins may contribute build-time options. Calling `toSchema` again creates a new schema and
+new plugin instances.
 
 ## `SchemaBuilder.allowPluginReRegistration`
 

--- a/website/content/docs/design.mdx
+++ b/website/content/docs/design.mdx
@@ -13,10 +13,13 @@ reference by name \(as a string\). Having all type information in a single objec
 at times, but with large schemas, can become unwieldy.
 
 To support a number of additional use cases, including Unions and Enums, large schemas, and plugins
-that use extract type information from other sources \(eg the Prisma, or the simple-objects
-plugin\), Pothos has another way of passing around type information. This system is based in `Ref`
-objects that contain the type information it represents. Every builder method for creating a type or
+that extract type information from other sources \(eg the Prisma, or the simple-objects
+plugin\), Pothos has another way of passing around type information. This system uses `Ref`
+objects whose TypeScript types carry the backing shapes they represent. Every builder method for creating a type or
 a field returns a `Ref` object.
 
 Using Ref objects allows us to separate the type information from the implementation, and allows for
-a more modular design.
+a more modular design. For example, `builder.objectRef<{ id: string }>('User')` declares
+the backing shape before fields are defined with `implement`. The ref carries that shape at compile
+time and identifies the GraphQL type at runtime; it does not validate resolver values at runtime.
+See [Objects](./guide/objects) and [Circular References](./guide/circular-references) for examples.


### PR DESCRIPTION
Correct stale builder, field, argument, and input signatures, including toSchema options, abstract-type resolution, defaults, nested lists, scalar hooks, and OneOf inputs. Clarify the Design page’s distinction between backing types and runtime identifiers. Signatures are explicitly API summaries rather than standalone programs.

Validation: Contracts audited against current core implementation/types; runtime nested-list SDL, null inner elements, argument defaults, sortSchema:false and schema extensions. OneOf and scalar hooks checked against current source/tests.

Independent Standards and Spec/correctness reviews passed. The integrated docs stack passes MDX generation and the production website build.
