### PR TITLE
docs: clarify historical migration guidance

### DIFF
--- a/website/content/docs/migrations/index.mdx
+++ b/website/content/docs/migrations/index.mdx
@@ -9,9 +9,8 @@ description: List of Pothos migration guides
 
 # Migration to Pothos from other GraphQL libraries
 
-Official migration tools are currently a work in progress, and we are hoping to make incremental
-migration from a number of common setups much easier in the near future. For now there are a few
-tools that may be helpful while the official tooling for migrations is being developed.
+The following tools can help migrate an existing schema. Review their generated code and adapt
+the resolvers and application integration to your project.
 
 - [Nexus to Pothos codemod](https://github.com/villesau/nexus-to-pothos-codemod)
 

--- a/website/content/docs/migrations/v2.mdx
+++ b/website/content/docs/migrations/v2.mdx
@@ -46,8 +46,8 @@ const builder = new SchemaBuilder({
 ### Plugin Order
 
 The old plugin API did not make strong guarantees about the order in which plugin hooks would be
-executed. Plugins are now always triggered in reverse order. The most critical plugins \(like
-`auth-scope`\) should appear first in the list of plugins. This ensures that any modifications made
+executed. Config hooks and resolver wrappers are applied in reverse order; `beforeBuild` runs in list order. The most critical plugins \(like
+`scope-auth`\) should appear first in the list of plugins. This ensures that any modifications made
 by other plugins are applied first, and lets the more important plugins be at the top of the call
 stack when resolving fields.
 

--- a/website/content/docs/migrations/v4.mdx
+++ b/website/content/docs/migrations/v4.mdx
@@ -15,7 +15,7 @@ The `4.0` release of Pothos is largely focused on updating 4 things:
 4. Updating internal types to support some previously challenging plugin patterns
 
 While the internals of Pothos have almost entirely been re-written, the public API surface should
-have a minimal changes for most users. The first 2 sets of changes will cover the majority of
+have minimal changes for most users. The first 2 sets of changes will cover the majority of
 changes relevant to the majority of applications. To make the upgrade as simple as
 possible, some options were added to maintain the defaults and option names from `3.x` which are
 described in the simple upgrade section below.
@@ -42,8 +42,8 @@ const builder = new SchemaBuilder<{
 This will restore all the defaults and config options from previous Pothos versions for both core
 and plugins.
 
-If you are using `@pothos/plugin-validation`, it has been renamed to `@pothos/plugin-zod`, and a new
-validation plugin will be released in the future.
+If you are using `@pothos/plugin-validation`, it has been renamed to `@pothos/plugin-zod`, as part of the v4 release. The name
+`@pothos/plugin-validation` now refers to the [Standard Schema validation plugin](../plugins/validation).
 
 ```diff
 - import ValidationPlugin from '@pothos/plugin-validation';
@@ -267,7 +267,7 @@ consistent with options for other plugins. The `authScopes` option has been move
 
 ### Renamed options
 
-The base validation plugin options have moved from `validationOptions` to `validation` to be more
+The base validation plugin options have moved from `validationOptions` to `zod` to be more
 consistent with options for other plugins.
 
 ```diff


### PR DESCRIPTION
Correct the v4 validationOptions-to-zod rename and explain that the validation package name now belongs to the Standard Schema plugin. Correct lifecycle wording and remove an unsupported promise of imminent migration tooling while preserving version-specific history.

Validation: Compared current and historical migration pages with compatibility types and plugin implementation. Historical package versions and third-party migration tools were not executed.

Independent Standards and Spec/correctness reviews passed. The integrated docs stack passes MDX generation and the production website build.
