### PR TITLE
Restore private flag for Prisma Next package

### DIFF
--- a/packages/plugin-prisma-next/package.json
+++ b/packages/plugin-prisma-next/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@pothos/plugin-prisma-next",
   "version": "0.0.0",
+  "private": true,
   "description": "Pothos integration for the Prisma ORM 8 SQL collection client",
   "main": "./lib/index.js",
   "types": "./dts/index.d.ts",


### PR DESCRIPTION
Restore `private: true` on `@pothos/plugin-prisma-next` to prevent publication. Validation: parsed the manifest and confirmed the flag is true; git diff --check passes.