### PR TITLE
docs(drizzle): correct node and connection helper examples

### DIFF
--- a/packages/plugin-drizzle/README.md
+++ b/packages/plugin-drizzle/README.md
@@ -1,32 +1,94 @@
-# Drizzle Plugin
+# Drizzle Plugin for Pothos
 
-## Installing
+> **Note:**
+  This plugin uses drizzle's [relational query builder v2](https://orm.drizzle.team/docs/rqb-v2),
+  which ships in `drizzle-orm` 1.0. That release is still a release candidate, and npm's `latest`
+  tag is the 0.x line, so install drizzle with the `rc` tag. Its API can still change before 1.0 is
+  final.
+
+  If you are upgrading from an older version of this plugin, read drizzle's [relations v1 to v2
+  guide](https://orm.drizzle.team/docs/relations-v1-v2), then this package's changelog for the
+  Pothos specific changes.
+
+
+The Drizzle plugin defines GraphQL types from your tables and plans database queries from GraphQL
+selections. It loads relations and integrates with Relay nodes and connections.
+
+## Getting started
+
+Install the plugin and add it to your builder, as described in [Setup](https://pothos-graphql.dev/docs/plugins/drizzle/setup):
 
 ```package-install
 npm install --save @pothos/plugin-drizzle drizzle-orm@rc
 ```
 
-The drizzle plugin is built on top of drizzles relational query builder, and requires that you
-define and configure all the relevant relations in your drizzle schema. See
-https://orm.drizzle.team/docs/relations-v2 for detailed documentation on the relations API.
-
-Once you have configured your drizzle schema, you can initialize your Pothos
-SchemaBuilder with the drizzle plugin:
+Define an object type for a table, expose the columns you want in your API, and add the relations
+you want clients to query. This example uses the builder, database client, and `userId` context
+from Setup, with a users table related to posts:
 
 ```ts
-import { drizzle } from 'drizzle-orm/...';
+const User = builder.drizzleObject('users', {
+  name: 'User',
+  fields: (t) => ({
+    firstName: t.exposeString('firstName'),
+    lastName: t.exposeString('lastName'),
+    posts: t.relation('posts'),
+  }),
+});
+
+builder.drizzleObject('posts', {
+  name: 'Post',
+  fields: (t) => ({ title: t.exposeString('title') }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    me: t.drizzleField({
+      type: 'users',
+      nullable: true,
+      resolve: (query, root, args, ctx) =>
+        db.query.users.findFirst(query({ where: { id: ctx.userId } })),
+    }),
+  }),
+});
+```
+
+Querying `me { firstName posts { title } }` loads the user and their posts in a single query
+through drizzles relational query builder.
+
+## Setup
+
+### Installing
+
+```package-install
+npm install --save @pothos/plugin-drizzle drizzle-orm@rc
+```
+
+The Drizzle plugin uses the relational query builder. Define the tables and relations your schema
+will query; see Drizzle’s [relations API](https://orm.drizzle.team/docs/relations-v2).
+
+Once you have configured your drizzle schema, you can initialize your Pothos
+SchemaBuilder with the drizzle plugin. This example uses SQLite through `@libsql/client`;
+install that driver and use the `relations` exported by your application. For another database,
+use its Drizzle driver and matching `getTableConfig` import:
+
+```ts
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
 // Import the appropriate getTableConfig for your dialect
 import { getTableConfig } from 'drizzle-orm/sqlite-core';
 import SchemaBuilder from '@pothos/core';
 import DrizzlePlugin from '@pothos/plugin-drizzle';
 import { relations } from './db/relations';
 
+const client = createClient({ url: 'file:./dev.db' });
 const db = drizzle({ client, relations });
 
-type DrizzleRelations = typeof relations
+type DrizzleRelations = typeof relations;
 
 export interface PothosTypes {
   DrizzleRelations: DrizzleRelations;
+  Context: { userId: number };
 }
 
 const builder = new SchemaBuilder<PothosTypes>({
@@ -39,13 +101,17 @@ const builder = new SchemaBuilder<PothosTypes>({
 });
 ```
 
-### Integration with other plugins
+The examples use an authenticated request context with `userId: number`. Supply it through your
+GraphQL server; see [Context](https://pothos-graphql.dev/docs/guide/context).
+
+#### Integration with other plugins
 
 The drizzle plugin has integrations with several other plugins. While the `with-input` and `relay`
 plugins are not required, many examples will assume these plugins have been installed:
 
 ```ts
-import { drizzle } from 'drizzle-orm/...';
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
 import SchemaBuilder from '@pothos/core';
 import DrizzlePlugin from '@pothos/plugin-drizzle';
 import RelayPlugin from '@pothos/plugin-relay';
@@ -53,10 +119,12 @@ import WithInputPlugin from '@pothos/plugin-with-input';
 import { getTableConfig } from 'drizzle-orm/sqlite-core';
 import { relations } from './db/relations';
 
+const client = createClient({ url: 'file:./dev.db' });
 const db = drizzle({ client, relations });
 
 export interface PothosTypes {
   DrizzleRelations: typeof relations;
+  Context: { userId: number };
 }
 
 const builder = new SchemaBuilder<PothosTypes>({
@@ -69,7 +137,7 @@ const builder = new SchemaBuilder<PothosTypes>({
 });
 ```
 
-### Plugin options
+#### Plugin options
 
 - `client`: the drizzle client, or a function returning one from the request context.
 - `getTableConfig`: the `getTableConfig` of your dialect, used to read primary keys and unique
@@ -83,13 +151,18 @@ const builder = new SchemaBuilder<PothosTypes>({
   by default, and the fragment's fields are loaded through [fallback queries](https://pothos-graphql.dev/docs/plugins/drizzle/relations#fallback-queries)
   when it resolves. Set this to `false` to plan deferred selections with the rest of the query.
 
-## Defining Objects
+## Drizzle Objects
+
+Use the builder and database client from [Setup](https://pothos-graphql.dev/docs/plugins/drizzle/setup). The examples below use a `users` table
+with an integer `id` and string `firstName` and `lastName` columns.
+
+### Defining Objects
 
 The `builder.drizzleObject` method can be used to define GraphQL Object types based on a drizzle
 table:
 
 ```ts
-const UserRef = builder.drizzleObject('users', {
+const User = builder.drizzleObject('users', {
   name: 'User',
   fields: (t) => ({
     firstName: t.exposeString('firstName'),
@@ -99,16 +172,16 @@ const UserRef = builder.drizzleObject('users', {
 ```
 
 You will be able to "expose" any column in the table, and GraphQL fields do not need to match the
-names of the columns in your database. The returned `UserRef` can be used like any other `ObjectRef`
+names of the columns in your database. The returned `User` can be used like any other `ObjectRef`
 in Pothos.
 
-## Custom fields
+### Custom fields
 
 You will often want to define fields in your API that do not correspond to a specific database
-column. To do this, you can define fields with a resolver like any other Pothos object type:
+column. For example, replace the object definition above with a computed full name:
 
 ```ts
-const UserRef = builder.drizzleObject('users', {
+const User = builder.drizzleObject('users', {
   name: 'User',
   fields: (t) => ({
     fullName: t.string({
@@ -118,80 +191,69 @@ const UserRef = builder.drizzleObject('users', {
 });
 ```
 
-## Type selections
+### Drizzle Fields
 
-In the above example, you can see that by default we have access to all columns of our table. For
-tables with many columns, it can be more efficient to only select the needed columns. You can
-configure the selected columns, and relations by passing a `select` option when defining the type:
+Drizzle objects and relations allow you to define parts of your schema backed by your drizzle
+schema, but don't provide a clear entry point into this Graph of data. To make your drizzle objects
+queryable, we will need to add fields that return our drizzle objects. This can be done using the
+`t.drizzleField` method. This can be used to define fields on the root `Query` type, or any other
+object type in your schema:
 
 ```ts
-const UserRef = builder.drizzleObject('users', {
-  name: 'User',
-  select: {
-    columns: {
-      firstName: true,
-      lastName: true,
-    },
-    with: {
-      profile: true,
-    },
-    extras: {
-      lowercaseName: (users, sql) => sql<string>`lower(${users.firstName})`
-    },
-  },
+builder.queryType({
   fields: (t) => ({
-    fullName: t.string({
-      resolve: (user, args, ctx, info) => `${user.firstName} ${user.lastName}`,
+    user: t.drizzleField({
+      type: 'users',
+      nullable: true,
+      args: {
+        id: t.arg.id({ required: true }),
+      },
+      resolve: (query, root, args, ctx) =>
+        db.query.users.findFirst(
+          query({
+            where: {
+              id: Number.parseInt(args.id, 10),
+            },
+          }),
+        ),
     }),
-    bio: t.string({
-      resolve: (user) => user.profile.bio,
-    }),
-    email: t.string({
-      resolve: (user) => `${user.lowercaseName}@example.com`,
+    users: t.drizzleField({
+      type: ['users'],
+      resolve: (query, root, args, ctx) => db.query.users.findMany(query()),
     }),
   }),
 });
 ```
 
-Any selections added to the type will be available to consume in all resolvers. Columns that are not
-selected can still be exposed as before.
+The `resolve` function of a `drizzleField` receives a `query` function. Call it and pass its result
+to a Drizzle `findFirst` or `findMany` query. The `query` function optionally accepts any
+arguments that are normally passed into the query, and will merge these options with the selection
+used to resolve data for the nested GraphQL selections.
 
-## Field selections
+#### `drizzleFieldWithInput`
 
-The previous example allows you to control what gets selected by default, but you often want to only
-select the columns that are required to fulfill a specific field. You can do this by adding the
-appropriate selections on each field:
+With the [with-input plugin](https://pothos-graphql.dev/docs/plugins/with-input),
+`t.drizzleFieldWithInput` combines `t.drizzleField` with `t.fieldWithInput`. The `input` fields
+become an input object argument, and the resolver still receives the `query` function as its first
+argument. This replaces the `user` field above:
 
 ```ts
-const UserRef = builder.drizzleObject('users', {
-  name: 'User',
-  select: {},
-  fields: (t) => ({
-    fullName: t.string({
-      select: {
-        columns: { firstName: true, lastName: true },
-      },
-      resolve: (user, args, ctx, info) => `${user.firstName} ${user.lastName}`,
-    }),
-    bio: t.string({
-      select: {
-        with: { profile: true },
-      },
-      resolve: (user) => user.profile.bio,
-    }),
-    email: t.string({
-      select: {
-        extras: {
-          lowercaseName: (users, sql) => sql<string>`lower(${users.firstName})`
-        },
-      },
-      resolve: (user) => `${user.lowercaseName}@example.com`,
-    }),
+builder.queryFields((t) => ({
+  user: t.drizzleFieldWithInput({
+    type: 'users',
+    nullable: true,
+    input: {
+      id: t.input.id({ required: true }),
+    },
+    resolve: (query, root, args, ctx) =>
+      db.query.users.findFirst(query({ where: { id: Number.parseInt(args.input.id, 10) } })),
   }),
-});
+}));
 ```
 
 ## Relations
+
+### Relations
 
 Drizzles relational query builder allows you to define the relationships between your tables. The
 `t.relation` method makes it easy to add fields to your GraphQL API that implement those
@@ -226,7 +288,7 @@ builder.drizzleObject('users', {
 The relation will automatically define GraphQL fields of the appropriate type based on the relation
 defined in your drizzle schema.
 
-## Relation queries
+### Relation queries
 
 For some cases, exposing relations as fields without any customization works great, but in some
 cases you may want to apply some filtering or ordering to your relations. This can be done by
@@ -276,9 +338,9 @@ describes where in the GraphQL query the relation is being loaded:
   on), and `isList` (whether the field returns a list).
 
 You can read more about the relation query builder api
-[here](https://orm.drizzle.team/docs/rqb#querying)
+[here](https://orm.drizzle.team/docs/rqb-v2)
 
-## Fallback queries
+### Fallback queries
 
 A field whose data is not on the row it resolves from is loaded with a fallback query. This happens
 when:
@@ -296,72 +358,735 @@ not return a row for a parent, because it was deleted since it was loaded, or ne
 table, that field rejects with `Model users(1) not found`, where the value in parentheses is the
 key that was looked up.
 
-## Drizzle Fields
+### Related field
 
-Drizzle objects and relations allow you to define parts of your schema backed by your drizzle
-schema, but don't provide a clear entry point into this Graph of data. To make your drizzle objects
-queryable, we will need to add fields that return our drizzle objects. This can be done using the
-`t.drizzleField` method. This can be used to define fields on the root `Query` type, or any other
-object type in your schema:
+The `t.relatedField` method allows you to define a field based on a relation that uses custom
+selections, including aggregations like counts. This is useful when you want to expose derived data
+from a relation without loading the full related records.
+
+#### Count aggregations
+
+One common use case is adding a count field that efficiently counts related records:
 
 ```ts
-builder.queryType({
+import { count } from 'drizzle-orm';
+
+builder.drizzleNode('users', {
+  name: 'User',
+  id: { column: (user) => user.id },
   fields: (t) => ({
-    post: t.drizzleField({
-      type: 'posts',
-      args: {
-        id: t.arg.id({ required: true }),
-      },
-      resolve: (query, root, args, ctx) =>
-        db.query.posts.findFirst(
-          query({
-            where: {
-              id: Number.parseInt(args.id, 10),
-            },
-          }),
-        ),
-    }),
-    posts: t.drizzleField({
-      type: ['posts'],
-      resolve: (query, root, args, ctx) => db.query.posts.findMany(query()),
+    firstName: t.exposeString('firstName'),
+    // Add a count of related posts
+    postsCount: t.relatedField('posts', {
+      type: 'Int',
+      // buildFilter creates the correct WHERE clause for the relation
+      select: (buildFilter) => ({
+        extras: {
+          postsCount: (parent) => db.$count(posts, buildFilter(parent)),
+        },
+      }),
+      resolve: (user) => user.postsCount,
     }),
   }),
 });
 ```
 
-The `resolve` function of a `drizzleField` will be passed a `query` function that MUST be called and
-passed to a drizzle `findOne` or `findMany` query. The `query` function optionally accepts any
-arguments that are normally passed into the query, and will merge these options with the selection
-used to resolve data for the nested GraphQL selections.
+The `buildFilter` function passed to `select` generates the appropriate SQL filter based on the
+relation definition.  This is no different than using `t.field`, but the `buildFilter` helper makes
+it easier to filter for the related records.
 
-### `drizzleFieldWithInput`
+`t.relatedField` also accepts the normal field options (`description`, `deprecationReason`,
+`extensions`, and options added by other plugins like `authScopes`). Its `resolve` may be async,
+and receives the resolve `info` as its fourth argument.
 
-With the [with-input plugin](https://pothos-graphql.dev/docs/plugins/with-input),
-`t.drizzleFieldWithInput` combines `t.drizzleField` with `t.fieldWithInput`. The `input` fields
-become an input object argument, and the resolver still receives the `query` function as its first
-argument:
+#### SQLite many-to-many filters
+
+On SQLite, `buildFilter` can look up related target identities through the junction join when the
+target has a non-null unique key. PostgreSQL retains an `EXISTS` predicate to avoid an additional
+target join.
+
+For a custom `RAW` scope in a Drizzle relation definition, use the table supplied to the callback:
+
+```ts
+where: {
+  RAW: (target) => sql`${target.published} = true`,
+},
+```
+
+This lets Drizzle use the target's alias inside the lookup. A static SQL scope referencing the
+original target table, such as ``RAW: sql`${posts.published} = true` ``, is passed through unchanged
+and can still force SQLite to scan the target table. The same applies to a callback that ignores
+its table argument and references `posts` directly. Object filters such as
+`where: { published: true }` also use the supplied alias.
+
+### Related count
+
+For the common case of counting related records, there's a simpler `t.relatedCount` method that handles
+all the boilerplate for you:
+
+```ts
+builder.drizzleNode('users', {
+  name: 'User',
+  id: { column: (user) => user.id },
+  fields: (t) => ({
+    firstName: t.exposeString('firstName'),
+    // Simple count of all related comments
+    commentsCount: t.relatedCount('comments'),
+    // Count with a where filter
+    publishedPostsCount: t.relatedCount('posts', {
+      where: eq(posts.published, true),
+    }),
+  }),
+});
+```
+
+The `where` option accepts either a static SQL filter or a function that receives the field arguments
+and context:
+
+```ts
+publishedPostsCount: t.relatedCount('posts', {
+  args: {
+    category: t.arg.string(),
+  },
+  where: (args, ctx) => args.category
+    ? and(eq(posts.published, true), eq(posts.category, args.category))
+    : eq(posts.published, true),
+});
+```
+
+For a many-to-many relation (one defined with `.through(...)`), `t.relatedCount` counts distinct
+related rows, so a row reachable through two junction rows counts once. A `t.relatedConnection`'s
+`totalCount` counts the rows the connection pages over instead, which is one per junction row,
+since that is what the relational query builder returns for the relation.
+
+## Selections
+
+### Type selections
+
+By default, a `drizzleObject` gives its resolvers access to all columns of the table. For tables
+with many columns, it can be more efficient to only select the needed columns. You can configure the
+selected columns, and relations by passing a `select` option when defining the type:
+
+```ts
+const User = builder.drizzleObject('users', {
+  name: 'User',
+  select: {
+    columns: {
+      firstName: true,
+      lastName: true,
+    },
+    with: {
+      profile: true,
+    },
+    extras: {
+      lowercaseName: (users, { sql }) => sql<string>`lower(${users.firstName})`
+    },
+  },
+  fields: (t) => ({
+    fullName: t.string({
+      resolve: (user, args, ctx, info) => `${user.firstName} ${user.lastName}`,
+    }),
+    bio: t.string({
+      nullable: true,
+      resolve: (user) => user.profile?.bio,
+    }),
+    lowercaseName: t.string({
+      resolve: (user) => user.lowercaseName,
+    }),
+  }),
+});
+```
+
+Any selections added to the type will be available to consume in all resolvers. Columns that are not
+selected can still be exposed as before.
+
+### Field selections
+
+The previous example allows you to control what gets selected by default, but you often want to only
+select the columns that are required to fulfill a specific field. You can do this by adding the
+appropriate selections on each field. Replace the preceding User definition with:
+
+```ts
+const User = builder.drizzleObject('users', {
+  name: 'User',
+  select: {},
+  fields: (t) => ({
+    fullName: t.string({
+      select: {
+        columns: { firstName: true, lastName: true },
+      },
+      resolve: (user, args, ctx, info) => `${user.firstName} ${user.lastName}`,
+    }),
+    bio: t.string({
+      nullable: true,
+      select: {
+        with: { profile: true },
+      },
+      resolve: (user) => user.profile?.bio,
+    }),
+    lowercaseName: t.string({
+      select: {
+        extras: {
+          lowercaseName: (users, { sql }) => sql<string>`lower(${users.firstName})`
+        },
+      },
+      resolve: (user) => user.lowercaseName,
+    }),
+  }),
+});
+```
+
+## Connections
+
+Use the [builder setup with Relay](https://pothos-graphql.dev/docs/plugins/drizzle/setup#integration-with-other-plugins) and register the users
+and posts object types. Examples defining the same field or helper are alternatives.
+
+### Related connections
+
+To implement a relation as a connection, you can use `t.relatedConnection` instead of `t.relation`:
+
+```ts
+builder.drizzleNode('users', {
+  name: 'User',
+  id: { column: (user) => user.id },
+  fields: (t) => ({
+    posts: t.relatedConnection('posts'),
+  }),
+});
+```
+
+This will automatically define the `Connection`, and `Edge` types, and their respective fields. To
+customize the Connection and Edge types, options for these types can be passed as additional
+arguments to `t.relatedConnection`, just like `t.connection` from the relay plugin. See the
+[relay plugin docs](https://pothos-graphql.dev/docs/plugins/relay) for more details.
+
+You can also define a `query` like with `t.relation`. The only difference with `t.relatedConnection`
+is that the `orderBy` format is slightly changed.
+
+To comply with the relay spec and efficiently support backwards pagination, some queries need to be
+performed in reverse order, which requires inverting the orderBy clause. To do this automatically,
+the `t.relatedConnection` method accepts orderBy as an object keyed by column name with `'asc'` or
+`'desc'` values, like `{ createdAt: 'desc' }`, rather than using the `asc(column)` and
+`desc(column)` helpers from drizzle. orderBy can also be returned as a single column, or an array of
+columns when ordering by multiple columns, which orders ascending.
+
+Ordering defaults to using the table `primaryKey`, and the orderBy columns will also be used to
+derive the connections cursor.
+
+```ts
+builder.drizzleNode('users', {
+  name: 'User',
+  id: { column: (user) => user.id },
+  fields: (t) => ({
+    posts: t.relatedConnection('posts', {
+      query: () => ({
+        where: {
+          published: true,
+        },
+        orderBy: {
+          id: 'desc',
+        },
+      }),
+    }),
+  }),
+});
+```
+
+#### Connection totalCount
+
+You can add a `totalCount` field to your connection by setting the `totalCount` option to `true`:
+
+```ts
+builder.drizzleNode('users', {
+  name: 'User',
+  id: { column: (user) => user.id },
+  fields: (t) => ({
+    posts: t.relatedConnection('posts', {
+      totalCount: true,
+      query: () => ({
+        where: {
+          published: true,
+        },
+        orderBy: {
+          id: 'desc',
+        },
+      }),
+    }),
+  }),
+});
+```
+
+This will automatically add a `totalCount` field to the connection type. The count query is only
+executed when the `totalCount` field is actually requested in the GraphQL query, and it's included
+as a subquery in the main database query for efficiency.
+
+```graphql
+query {
+  user(id: "...") {
+    posts(first: 10) {
+      totalCount
+      edges {
+        node {
+          id
+          title
+        }
+      }
+    }
+  }
+}
+```
+
+The count applies the `where` returned by the field's `query`, so it counts the same rows the
+connection paginates (only published posts in the example above). To count every related row
+regardless of the filter, set `filterConnectionTotalCount: false` in the `drizzle` plugin options:
+
+```ts
+const builder = new SchemaBuilder<PothosTypes>({
+  plugins: [RelayPlugin, DrizzlePlugin],
+  drizzle: {
+    client: db,
+    getTableConfig,
+    relations,
+    // count every related row for totalCount, ignoring the where from query (defaults to true)
+    filterConnectionTotalCount: false,
+  },
+});
+```
+
+A `where` on the relation itself always applies to the count, as does the junction table of a
+many-to-many relation defined with `.through(...)`. The count joins the junction table the same way
+the rows do, so a row that matches the junction twice counts twice, and appears twice in the
+connection.
+
+### Drizzle connections
+
+Similar to `t.drizzleField`, `t.drizzleConnection` allows you to define a connection field that acts
+as an entry point to your drizzle query. The `orderBy` in `t.drizzleConnection` works the same way
+as it does for `t.relatedConnection`
 
 ```ts
 builder.queryFields((t) => ({
-  user: t.drizzleFieldWithInput({
-    type: 'users',
-    input: {
-      id: t.input.id({ required: true }),
-    },
+  posts: t.drizzleConnection({
+    type: 'posts',
     resolve: (query, root, args, ctx) =>
-      db.query.users.findFirst(query({ where: { id: Number.parseInt(args.input.id, 10) } })),
+      db.query.posts.findMany(
+        query({
+          where: {
+            published: true,
+          },
+          orderBy: {
+            id: 'desc',
+          },
+        }),
+      ),
   }),
 }));
 ```
 
-## Variants
+#### drizzleConnection totalCount
+
+You can add a `totalCount` field to a `drizzleConnection` by providing a `totalCount` callback function that returns the count:
+
+```ts
+builder.queryFields((t) => ({
+  posts: t.drizzleConnection({
+    type: 'posts',
+    // Use db.$count() for a simple count query
+    totalCount: () => db.$count(posts, eq(posts.published, true)),
+    resolve: (query, root, args, ctx) =>
+      db.query.posts.findMany(
+        query({
+          where: {
+            published: true,
+          },
+          orderBy: {
+            id: 'desc',
+          },
+        }),
+      ),
+  }),
+}));
+```
+
+The `totalCount` callback receives the same arguments as a normal resolver (`parent`, `args`, `context`, `info`), allowing you to implement custom count logic based on the query context. The example above uses `db.$count()` for a simple count, but you can use any Drizzle query approach.
+
+When only the `totalCount` field is requested (without `edges` or `nodes`), the main query is skipped entirely and only the count query is executed for efficiency.
+
+#### Indirect relations as connections
+
+In many cases, you can define many to many connections via drizzle relations, allowing the `relatedConnection` API to work across
+more complex relations. In some cases you may want to define a connection for a relation not expressed directly as a relation in
+your drizzle schema.  For these cases, you can use the `drizzleConnectionHelpers`, which allows you to define connection with the `t.connection` API.
+
+```typescript
+// Create a drizzle object for the node type of your connection
+const Role = builder.drizzleObject('roles', {
+  name: 'Role',
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    name: t.exposeString('name'),
+  }),
+});
+
+
+
+// Create connection helpers for the userRoles join table.  This will allow you
+// to use the normal t.connection with a drizzle type
+const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
+  // select the data needed for the nodes
+  select: (nestedSelection) => ({
+    with: {
+      // use nestedSelection to create the correct selection for the node
+      role: nestedSelection(),
+    },
+  }),
+  // resolve the node from the returned list item
+  resolveNode: (userRole) => userRole.role,
+});
+
+builder.drizzleObjectField('users', 'rolesConnection', (t) =>
+  t.connection({
+    // The type for the Node
+    type: Role,
+    nodeNullable: true,
+    // since we are not using t.relatedConnection we need to manually
+    // include the selections for our connection
+    select: (args, ctx, nestedSelection) => ({
+      with: {
+        userRoles: rolesConnection.getQuery(args, ctx, nestedSelection),
+      },
+    }),
+    // This helper takes a list of nodes and formats them for the connection
+    resolve: (user, args, ctx) => {
+      return rolesConnection.resolve(user.userRoles, args, ctx, user);
+    },
+  }),
+);
+```
+
+The above example assumes that you are paginating a relation to a join table, where the pagination
+args are applied based on the relation to that join table, but the nodes themselves are nested
+deeper.
+
+`drizzleConnectionHelpers` can also be used to manually create a connection where the edge and
+connections share the same model, and pagination happens directly on a relation to nodes type (even
+if that relation is nested).
+
+```ts
+const commentConnectionHelpers = drizzleConnectionHelpers(builder, 'comments');
+
+const SelectPost = builder.drizzleObject('posts', {
+  fields: (t) => ({
+    title: t.exposeString('title'),
+    comments: t.connection({
+      type: commentConnectionHelpers.ref,
+      select: (args, ctx, nestedSelection) => ({
+        with: {
+          comments: commentConnectionHelpers.getQuery(args, ctx, nestedSelection),
+        },
+      }),
+      resolve: (parent, args, ctx) => commentConnectionHelpers.resolve(parent.comments, args, ctx),
+    }),
+  }),
+});
+```
+
+Replace the preceding `rolesConnection` helper and field to add filtering and ordering:
+
+```ts
+const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
+  // define additional arguments
+  args: (t) => ({}),
+  query: (args) => ({
+    // define an order
+    orderBy: {
+      roleId: 'asc',
+    },
+    // define a filter
+    where: {
+      accepted: true,
+    }
+  }),
+  // select the data needed for the nodes
+  select: (nestedSelection) => ({
+    with: {
+      // use nestedSelection to create the correct selection for the node
+      role: nestedSelection(),
+    },
+  }),
+  // resolve the node from the returned list item
+  resolveNode: (userRole) => userRole.role,
+});
+
+
+builder.drizzleObjectField('users', 'rolesConnection', (t) =>
+  t.connection({
+    type: Role,
+    nodeNullable: true,
+    // add the args from the connection helper to the field
+    args: rolesConnection.getArgs(),
+    select: (args, ctx, nestedSelection) => ({
+      with: {
+        userRoles: rolesConnection.getQuery(args, ctx, nestedSelection),
+      },
+    }),
+    resolve: (user, args, ctx) => rolesConnection.resolve(user.userRoles, args, ctx, user),
+  }),
+);
+```
+
+#### Extending connection edges
+
+This alternative exposes the join row’s `createdAt` on each edge. It assumes a registered
+`DateTime` scalar whose output type is `Date`.
+
+```typescript
+const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
+  select: (nestedSelection) => ({
+    with: {
+      role: nestedSelection(),
+    },
+  }),
+  resolveNode: (userRole) => userRole.role,
+});
+
+builder.drizzleObjectFields('users', (t) => ({
+  rolesConnection: t.connection(
+    {
+      type: Role,
+      nodeNullable: true,
+      select: (args, ctx, nestedSelection) => ({
+        with: {
+          userRoles: rolesConnection.getQuery(args, ctx, nestedSelection),
+        },
+      }),
+      resolve: (user, args, ctx) =>
+        rolesConnection.resolve(
+          user.userRoles,
+          args,
+          ctx,
+          user,
+        ),
+    },
+    {},
+    // options for the edge object
+    {
+      // define the additional fields on the edge object
+      fields: (edge) => ({
+        createdAt: edge.field({
+          type: 'DateTime',
+          // the parent shape for edge fields is inferred from the connections resolve function
+          resolve: (role) => role.createdAt,
+        }),
+      }),
+    },
+  ),
+}));
+```
+
+#### `drizzleConnectionHelpers` for non-relation connections
+
+You can also use `drizzleConnectionHelpers` for non-relation connections where you want a connection where your edges and nodes are not the same type.
+
+Note that when doing this, you need to be careful to properly merge the `where` clause generated by the connection helper with any additional `where` clause you need to apply to your query
+
+```typescript
+const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
+  select: (nestedSelection) => ({
+    with: {
+      role: nestedSelection(),
+    },
+  }),
+  resolveNode: (userRole) => userRole.role,
+});
+
+builder.queryFields((t) => ({
+  roles: t.connection({
+    type: Role,
+    nodeNullable: true,
+    args: {
+      userId: t.arg.int({ required: true }),
+    },
+    resolve: async (_, args, ctx, info) => {
+      const query = rolesConnection.getQuery(args, ctx, info);
+      const userRoles = await db.query.userRoles.findMany({
+        ...query,
+        where: {
+          AND: [query.where ?? {}, { userId: args.userId }],
+        },
+      });
+      return rolesConnection.resolve(userRoles, args, ctx);
+    },
+  }),
+}));
+```
+
+## Ordering and cursors
+
+### Ordering and cursors
+
+Connections page with a cursor that records where in the ordering the previous page ended. This
+applies to `t.relatedConnection`, `t.drizzleConnection`, and `drizzleConnectionHelpers`.
+
+#### Unique orderings
+
+`orderBy: { createdAt: 'desc' }` does not describe a unique ordering. Rows with the same timestamp
+can be returned in a different order on each query, so paging through the connection may return a row
+twice, or skip it.
+
+Pothos adds the primary key to the ordering when the columns you provide are not already unique, so
+this:
+
+```ts
+orderBy: { createdAt: 'desc' }
+```
+
+is queried as `createdAt desc, id desc`. You can add the tie breaker yourself if you want it in a
+different position or direction:
+
+```ts
+orderBy: { createdAt: 'desc', id: 'asc' }
+```
+
+Orderings that already contain the primary key, or a unique column or constraint whose columns are
+all marked `notNull()`, are used as provided. Nullable unique columns are not treated as unique,
+because rows containing a `null` are still tied with each other. Uniqueness declared with
+`uniqueIndex()` is not detected, so those orderings still get the primary key appended.
+
+Primary keys are used whether or not their columns are marked `notNull()`, since SQL makes primary
+key columns non-nullable anyway. That includes composite keys declared with
+`primaryKey({ columns: [...] })`.
+
+Nothing is appended when Pothos cannot find a key it can rely on, which means tables with no primary
+key, and tables whose only unique column is nullable. Those connections keep the ordering you wrote,
+so give them a tie breaker yourself.
+
+#### Nullable ordering columns
+
+A row whose ordering value is `null` cannot be paged past. `null` is not greater or less than
+anything in SQL, so no row compares as coming after it and the next page comes back empty. The same
+applies to an ordering expression that can evaluate to `null`.
+
+Order by columns that are `notNull()`, or give the expression a real value to fall back to with
+`coalesce`.
+
+#### Cursor values and precision
+
+A cursor stores the values your driver returned to JavaScript, and those values are compared against
+the column when the next page is requested. If the value in the cursor is not the value the database
+has, the comparison will not match the rows you expect.
+
+This comes up with timestamps. `timestamp({ mode: 'date' })` returns a JavaScript `Date`, which only
+holds milliseconds, while a Postgres `timestamptz` column stores microseconds. A row stored at
+`.086068` produces a cursor containing `.086`, and `created_at < '.086'` does not match the other
+rows in that millisecond, so they are never returned on any page.
+
+There are two ways to avoid this.
+
+The first is to map the column so the full value reaches JavaScript. `mode: 'string'` returns the
+timestamp as text, with the microseconds intact:
+
+```ts
+export const posts = pgTable('posts', {
+  id: serial('id').primaryKey(),
+  createdAt: timestamp('created_at', { withTimezone: true, mode: 'string' }).notNull(),
+});
+```
+
+The cursor stores that text, and Postgres parses it back to the value it stored. The column is still
+what gets ordered and compared, so an index on it is still used. The field is typed as a `string`
+rather than a `Date`.
+
+The second is to order by an expression that returns the full value, which lets you keep the `Date`
+mapping:
+
+```ts
+builder.queryFields((t) => ({
+  posts: t.drizzleConnection({
+    type: 'posts',
+    resolve: (query) =>
+      db.query.posts.findMany(
+        query({
+          extras: {
+            createdAtExact: (table) =>
+              sql`to_char(${table.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"')`,
+          },
+          orderBy: { createdAtExact: 'desc' },
+        }),
+      ),
+  }),
+}));
+```
+
+#### Ordering by an expression
+
+`orderBy` accepts the name of any extra declared in the same query. Pothos orders by the expression,
+builds the cursor from the value it returns, and compares the expression when paging:
+
+```ts
+query({
+  extras: { titleLength: (table) => sql`length(${table.title})` },
+  orderBy: { titleLength: 'asc' },
+})
+```
+
+Extras used this way should be written as a callback. Drizzle aliases the table it queries and passes
+that alias to the callback, so an expression built from the imported table object will reference a
+name the query does not have.
+
+With `drizzleConnectionHelpers`, declare the extra in `query` rather than in `select`. Only `query`
+is read when the ordering is resolved.
+
+The expression also needs to sort in the same order its values compare. A timestamp formatted as
+fixed width UTC text sorts the same way it does chronologically, but a local time or variable width
+format does not, and will skip rows.
+
+Ordering by an expression cannot use an index on the underlying column. If the table is large enough
+to need one, add an index on the expression.
+
+## Relay
+
+### Relay integration
+
+Relay provides some very useful best practices that are useful for most GraphQL APIs. To make it
+easy to comply with these best practices, the drizzle plugin has built in support for defining relay
+`nodes` and `connections`.
+
+### Relay Nodes
+
+Defining relay nodes works just like defining normal `drizzleObject`s, but requires specifying a
+column to use as the node's `id` field.
+
+```ts
+builder.drizzleNode('users', {
+  name: 'User',
+  id: {
+    column: (user) => user.id,
+    // other options for the ID field can be passed here
+  },
+  fields: (t) => ({
+    firstName: t.exposeString('firstName'),
+    lastName: t.exposeString('lastName'),
+  }),
+});
+```
+
+The id column can also be set to a list of columns for types with a composite primary key.
+
+## Type variants
+
+Use the [builder setup with Relay](https://pothos-graphql.dev/docs/plugins/drizzle/setup#integration-with-other-plugins), and include
+`Context: { user: { id: number } }` in `PothosTypes`. These examples assume an authenticated user
+and a registered posts type. The `users` table has a posts relation.
+
+### Variants
 
 It is often useful to be able to define multiple object types based on the same table. This can be
 done using a feature called `variants`. The `variants` API consists of 3 parts:
 
 - A `variant` option that can be passed instead of a name on `drizzleObjects`
 - The ability to pass an `ObjectRef` to the `type` option of `t.relation` and other similar fields
-- A `t.field` method that works similar to `t.relation`, but is used to define a GraphQL field that
+- A `t.variant` method that works similar to `t.relation`, but is used to define a GraphQL field that
   references a variant of the same record.
 
 ```ts
@@ -406,6 +1131,7 @@ builder.queryType({
 
 builder.drizzleNode('users', {
   name: 'User',
+  id: { column: (user) => user.id },
   fields: (t) => ({
     firstName: t.exposeString('firstName'),
     // This field will resolve to the Viewer type, but be set to null if the user is not the current user
@@ -416,12 +1142,13 @@ builder.drizzleNode('users', {
 });
 ```
 
-A `t.variant` field can have a `select` of its own. It is planned along with the variant's
+As an alternative to the User node definition above, a `t.variant` field can have a `select` of its own. It is planned along with the variant's
 type-level selection when the variant is queried through that field:
 
 ```ts
 builder.drizzleNode('users', {
   name: 'User',
+  id: { column: (user) => user.id },
   fields: (t) => ({
     viewer: t.variant(Viewer, {
       // loaded with the row when `viewer` is selected
@@ -437,6 +1164,8 @@ single query, which can fail if they disagree. See
 [Conflicting selections between variants](https://pothos-graphql.dev/docs/plugins/drizzle/query-planning#conflicting-selections-between-variants).
 
 ## Interfaces
+
+### Interfaces
 
 `builder.drizzleInterface` works just like `builder.drizzleObject`, and can be used to define
 either the primary type or a variant of a table as an interface that other variants implement. The
@@ -463,6 +1192,12 @@ builder.drizzleObject('users', {
     permissions: t.exposeStringList('permissions'),
   }),
 });
+
+builder.drizzleObject('users', {
+  variant: 'MemberViewer',
+  interfaces: [Viewer],
+  select: { columns: { id: true } },
+});
 ```
 
 Fields can be added to an interface later with `builder.drizzleInterfaceField` and
@@ -478,504 +1213,6 @@ builder.drizzleInterfaceFields(Viewer, (t) => ({
 An object type implementing a drizzle interface must be based on the same table. A plain object
 type that implements one is planned with the interface's table, so fragments on it will select the
 relations it inherits.
-
-## Related field
-
-The `t.relatedField` method allows you to define a field based on a relation that uses custom
-selections, including aggregations like counts. This is useful when you want to expose derived data
-from a relation without loading the full related records.
-
-### Count aggregations
-
-One common use case is adding a count field that efficiently counts related records:
-
-```ts
-import { count } from 'drizzle-orm';
-
-builder.drizzleNode('users', {
-  name: 'User',
-  id: { column: (user) => user.id },
-  fields: (t) => ({
-    firstName: t.exposeString('firstName'),
-    // Add a count of related posts
-    postsCount: t.relatedField('posts', {
-      type: 'Int',
-      // buildFilter creates the correct WHERE clause for the relation
-      select: (buildFilter) => ({
-        extras: {
-          postsCount: (parent) => db.$count(posts, buildFilter(parent)),
-        },
-      }),
-      resolve: (user) => user.postsCount,
-    }),
-  }),
-});
-```
-
-The `buildFilter` function passed to `select` generates the appropriate SQL filter based on the
-relation definition.  This is no different than using `t.field`, but the `buildFilter` helper makes
-it easier to filter for the related records.
-
-`t.relatedField` also accepts the normal field options (`description`, `deprecationReason`,
-`extensions`, and options added by other plugins like `authScopes`). Its `resolve` may be async,
-and receives the resolve `info` as its fourth argument.
-
-### SQLite many-to-many filters
-
-On SQLite, `buildFilter` can look up related target identities through the junction join when the
-target has a non-null unique key. PostgreSQL retains an `EXISTS` predicate to avoid an additional
-target join.
-
-For a custom `RAW` scope in a Drizzle relation definition, use the table supplied to the callback:
-
-```ts
-where: {
-  RAW: (target) => sql`${target.published} = true`,
-},
-```
-
-This lets Drizzle use the target's alias inside the lookup. A static SQL scope referencing the
-original target table, such as ``RAW: sql`${posts.published} = true` ``, is passed through unchanged
-and can still force SQLite to scan the target table. The same applies to a callback that ignores
-its table argument and references `posts` directly. Object filters such as
-`where: { published: true }` also use the supplied alias.
-
-## Related count
-
-For the common case of counting related records, there's a simpler `t.relatedCount` method that handles
-all the boilerplate for you:
-
-```ts
-builder.drizzleNode('users', {
-  name: 'User',
-  id: { column: (user) => user.id },
-  fields: (t) => ({
-    firstName: t.exposeString('firstName'),
-    // Simple count of all related comments
-    commentsCount: t.relatedCount('comments'),
-    // Count with a where filter
-    publishedPostsCount: t.relatedCount('posts', {
-      where: eq(posts.published, true),
-    }),
-  }),
-});
-```
-
-The `where` option accepts either a static SQL filter or a function that receives the field arguments
-and context:
-
-```ts
-publishedPostsCount: t.relatedCount('posts', {
-  args: {
-    category: t.arg.string(),
-  },
-  where: (args, ctx) => args.category
-    ? and(eq(posts.published, true), eq(posts.category, args.category))
-    : eq(posts.published, true),
-});
-```
-
-For a many-to-many relation (one defined with `.through(...)`), `t.relatedCount` counts distinct
-related rows, so a row reachable through two junction rows counts once. A `t.relatedConnection`'s
-`totalCount` counts the rows the connection pages over instead, which is one per junction row,
-since that is what the relational query builder returns for the relation.
-
-## Relay integration
-
-Relay provides some very useful best practices that are useful for most GraphQL APIs. To make it
-easy to comply with these best practices, the drizzle plugin has built in support for defining relay
-`nodes` and `connections`.
-
-## Relay Nodes
-
-Defining relay nodes works just like defining normal `drizzleObject`s, but requires specifying a
-column to use as the nodes `id` field.
-
-```ts
-builder.drizzleNode('users', {
-  name: 'User',
-  id: {
-    column: (user) => user.id,
-    // other options for the ID field can be passed here
-  },
-  fields: (t) => ({
-    firstName: t.exposeString('firstName'),
-    lastName: t.exposeString('lastName'),
-  }),
-});
-```
-
-The id column can also be set to a list of columns for types with a composite primary key.
-
-## Related connections
-
-To implement a relation as a connection, you can use `t.relatedConnection` instead of `t.relation`:
-
-```ts
-builder.drizzleNode('users', {
-  name: 'User',
-  fields: (t) => ({
-    posts: t.relatedConnection('posts'),
-  }),
-});
-```
-
-This will automatically define the `Connection`, and `Edge` types, and their respective fields. To
-customize the Connection and Edge types, options for these types can be passed as additional
-arguments to `t.relatedConnection`, just like `t.connection` from the relay plugin. See the
-[relay plugin docs](https://pothos-graphql.dev/docs/plugins/relay) for more details.
-
-You can also define a `query` like with `t.relation`. The only difference with `t.relatedConnection`
-is that the `orderBy` format is slightly changed.
-
-To comply with the relay spec and efficiently support backwards pagination, some queries need to be
-performed in reverse order, which requires inverting the orderBy clause. To do this automatically,
-the `t.relatedConnection` method accepts orderBy as an object like `{ asc: column }` or
-`{ desc: column }` rather than using the `asc(column)` and `desc(column)` helpers from drizzle.
-orderBy can still be returned as either a single column or array when ordering by multiple columns.
-
-Ordering defaults to using the table `primaryKey`, and the orderBy columns will also be used to
-derive the connections cursor.
-
-```ts
-builder.drizzleNode('users', {
-  name: 'User',
-  fields: (t) => ({
-    posts: t.relatedConnection('posts', {
-      query: () => ({
-        where: {
-          published: true,
-        },
-        orderBy: {
-          id: 'desc',
-        },
-      }),
-    }),
-  }),
-});
-```
-
-### Connection totalCount
-
-You can add a `totalCount` field to your connection by setting the `totalCount` option to `true`:
-
-```ts
-builder.drizzleNode('users', {
-  name: 'User',
-  fields: (t) => ({
-    posts: t.relatedConnection('posts', {
-      totalCount: true,
-      query: () => ({
-        where: {
-          published: true,
-        },
-        orderBy: {
-          id: 'desc',
-        },
-      }),
-    }),
-  }),
-});
-```
-
-This will automatically add a `totalCount` field to the connection type. The count query is only
-executed when the `totalCount` field is actually requested in the GraphQL query, and it's included
-as a subquery in the main database query for efficiency.
-
-```graphql
-query {
-  user(id: "...") {
-    posts(first: 10) {
-      totalCount
-      edges {
-        node {
-          id
-          title
-        }
-      }
-    }
-  }
-}
-```
-
-The count applies the `where` returned by the field's `query`, so it counts the same rows the
-connection paginates (only published posts in the example above). To count every related row
-regardless of the filter, set `filterConnectionTotalCount: false` in the `drizzle` plugin options:
-
-```ts
-const builder = new SchemaBuilder<PothosTypes>({
-  plugins: [DrizzlePlugin],
-  drizzle: {
-    client: db,
-    getTableConfig,
-    relations,
-    // count every related row for totalCount, ignoring the where from query (defaults to true)
-    filterConnectionTotalCount: false,
-  },
-});
-```
-
-A `where` on the relation itself always applies to the count, as does the junction table of a
-many-to-many relation defined with `.through(...)`. The count joins the junction table the same way
-the rows do, so a row that matches the junction twice counts twice, and appears twice in the
-connection.
-
-## Drizzle connections
-
-Similar to `t.drizzleField`, `t.drizzleConnection` allows you to define a connection field that acts
-as an entry point to your drizzle query. The `orderBy` in `t.drizzleConnection` works the same way
-as it does for `t.relatedConnection`
-
-```ts
-builder.queryFields((t) => ({
-  posts: t.drizzleConnection({
-    type: 'posts',
-    resolve: (query, root, args, ctx) =>
-      db.query.posts.findMany(
-        query({
-          where: {
-            published: true,
-          },
-          orderBy: {
-            id: 'desc',
-          },
-        }),
-      ),
-  }),
-}));
-```
-
-### drizzleConnection totalCount
-
-You can add a `totalCount` field to a `drizzleConnection` by providing a `totalCount` callback function that returns the count:
-
-```ts
-builder.queryFields((t) => ({
-  posts: t.drizzleConnection({
-    type: 'posts',
-    // Use db.$count() for a simple count query
-    totalCount: () => db.$count(posts, eq(posts.published, true)),
-    resolve: (query, root, args, ctx) =>
-      db.query.posts.findMany(
-        query({
-          where: {
-            published: true,
-          },
-          orderBy: {
-            id: 'desc',
-          },
-        }),
-      ),
-  }),
-}));
-```
-
-The `totalCount` callback receives the same arguments as a normal resolver (`parent`, `args`, `context`, `info`), allowing you to implement custom count logic based on the query context. The example above uses `db.$count()` for a simple count, but you can use any Drizzle query approach.
-
-When only the `totalCount` field is requested (without `edges` or `nodes`), the main query is skipped entirely and only the count query is executed for efficiency.
-
-### Indirect relations as connections
-
-In many cases, you can define many to many connections via drizzle relations, allowing the `relatedConnection` API to work across
-more complex relations. In some cases you may want to define a connection for a relation not expressed directly as a relation in
-your drizzle schema.  For these cases, you can use the `drizzleConnectionHelpers`, which allows you to define connection with the `t.connection` API.
-
-```typescript
-// Create a drizzle object for the node type of your connection
-const Role = builder.drizzleObject('roles', {
-  name: 'Role',
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    name: t.exposeString('name'),
-  }),
-});
-
-// Create connection helpers for the media type.  This will allow you
-// to use the normal t.connection with a drizzle type
-const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
-  // select the data needed for the nodes
-  select: (nestedSelection) => ({
-    with: {
-      // use nestedSelection to create the correct selection for the node
-      role: nestedSelection(),
-    },
-  }),
-  // resolve the node from the returned list item
-  resolveNode: (userRole) => userRole.role,
-});
-
-builder.drizzleObjectField('User', 'rolesConnection', (t) =>
-  t.connection({
-    // The type for the Node
-    type: Role,
-    // since we are not using t.relatedConnection we need to manually
-    // include the selections for our connection
-    select: (args, ctx, nestedSelection) => ({
-      with: {
-        userRoles: rolesConnection.getQuery(args, ctx, nestedSelection),
-      },
-    }),
-    // This helper takes a list of nodes and formats them for the connection
-    resolve: (user, args, ctx) => {
-      return rolesConnection.resolve(user.userRoles, args, ctx, user);
-    },
-  }),
-);
-```
-
-The above example assumes that you are paginating a relation to a join table, where the pagination
-args are applied based on the relation to that join table, but the nodes themselves are nested
-deeper.
-
-`drizzleConnectionHelpers` can also be used to manually create a connection where the edge and
-connections share the same model, and pagination happens directly on a relation to nodes type (even
-if that relation is nested).
-
-```ts
-const commentConnectionHelpers = drizzleConnectionHelpers(builder, 'Comment');
-
-const SelectPost = builder.drizzleObject('posts', {
-  fields: (t) => ({
-    title: t.exposeString('title'),
-    comments: t.connection({
-      type: commentConnectionHelpers.ref,
-      select: (args, ctx, nestedSelection) => ({
-        with: {
-          comments: commentConnectionHelpers.getQuery(args, ctx, nestedSelection),
-        },
-      }),
-      resolve: (parent, args, ctx) => commentConnectionHelpers.resolve(parent.comments, args, ctx),
-    }),
-  }),
-});
-```
-
-Arguments, ordering and filtering can also be defined in the helpers:
-
-```ts
-const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
-  // define additional arguments
-  args: (t) => ({}),
-  query: (args) => ({
-    // define an order
-    orderBy: {
-      roleId: 'asc',
-    }
-    // define a filter
-    where: {
-      accepted: true,
-    }
-  }),
-  // select the data needed for the nodes
-  select: (nestedSelection) => ({
-    with: {
-      // use nestedSelection to create the correct selection for the node
-      role: nestedSelection(),
-    },
-  }),
-  // resolve the node from the returned list item
-  resolveNode: (userRole) => userRole.role,
-});
-
-builder.drizzleObjectField('User', 'rolesConnection', (t) =>
-  t.connection({
-    type: Role,
-    // add the args from the connection helper to the field
-    args: rolesConnection.getArgs(),
-    select: (args, ctx, nestedSelection) => ({
-      with: {
-        userRoles: rolesConnection.getQuery(args, ctx, nestedSelection),
-      },
-    }),
-    resolve: (user, args, ctx) => rolesConnection.resolve(user.userRoles, args, ctx, user),
-  }),
-);
-```
-
-### Extending connection edges
-
-In some cases you may want to expose some data from an indirect connection on the edge object.
-
-```typescript
-const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
-  select: (nestedSelection) => ({
-    with: {
-      role: nestedSelection(),
-    },
-  }),
-  resolveNode: (userRole) => userRole.role,
-});
-
-builder.drizzleObjectFields('User', (t) => ({
-  rolesConnection: t.connection(
-    {
-      type: Role,
-      select: (args, ctx, nestedSelection) => ({
-        with: {
-          userRoles: rolesConnection.getQuery(args, ctx, nestedSelection),
-        },
-      }),
-      resolve: (user, args, ctx) =>
-        rolesConnection.resolve(
-          user.userRoles,
-          args,
-          ctx,
-          user,
-        ),
-    },
-    {},
-    // options for the edge object
-    {
-      // define the additional fields on the edge object
-      fields: (edge) => ({
-        createdAt: edge.field({
-          type: 'DateTime',
-          // the parent shape for edge fields is inferred from the connections resolve function
-          resolve: (role) => role.createdAt,
-        }),
-      }),
-    },
-  ),
-}));
-```
-
-### `drizzleConnectionHelpers` for non-relation connections
-
-You can also use `drizzleConnectionHelpers` for non-relation connections where you want a connection where your edges and nodes are not the same type.
-
-Note that when doing this, you need to be careful to properly merge the `where` clause generated by the connection helper with any additional `where` clause you need to apply to your query
-
-```typescript
-const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
-  select: (nestedSelection) => ({
-    with: {
-      role: nestedSelection(),
-    },
-  }),
-  resolveNode: (userRole) => userRole.role,
-});
-
-builder.queryFields((t) => ({
-  roles: t.connection({
-    type: Role,
-    args: {
-      userId: t.arg.int({ required: true }),
-    },
-    nodeNullable: true,
-    resolve: async (_, args, ctx, info) => {
-      const query = rolesConnection.getQuery(args, ctx, info);
-      const userRoles = await db.query.userRoles.findMany({
-        ...query,
-        where: {
-          ...query.where,
-          userId: args.userId,
-        },
-      });
-      return rolesConnection.resolve(userRoles, args, ctx);
-    },
-  }),
-}));
-```
 
 ## Query planning
 
@@ -1014,7 +1251,7 @@ still narrow the parent shape:
 builder.drizzleObject('users', {
   name: 'User',
   fields: (t) => ({
-    latestPosts: t.field({
+    previewPosts: t.field({
       type: [Post],
       select: (args, ctx, nestedSelection) => ({
         // what the query selects on the posts, limited to one
@@ -1037,12 +1274,17 @@ which are described under [Relation queries](https://pothos-graphql.dev/docs/plu
 
 ### Async selections
 
-Selections are synchronous unless the schema opts in with `AsyncSelections: true`:
+Selections are synchronous unless the schema opts in with `AsyncSelections: true`. This example
+uses request context methods that asynchronously return a user ID and a preview limit:
 
 ```ts
 const builder = new SchemaBuilder<{
   DrizzleRelations: typeof relations;
   AsyncSelections: true;
+  Context: {
+    currentUserId: () => Promise<number>;
+    previewSize: () => Promise<number>;
+  };
 }>({
   plugins: [DrizzlePlugin],
   drizzle: {
@@ -1069,7 +1311,7 @@ builder.drizzleObject('users', {
     posts: t.relation('posts', {
       query: async (args, ctx) => ({ where: { authorId: await ctx.currentUserId() } }),
     }),
-    latestPosts: t.field({
+    previewPosts: t.field({
       type: [Post],
       select: async (args, ctx, nestedSelection) => ({
         with: { posts: await nestedSelection({ limit: await ctx.previewSize() }) },

--- a/website/content/docs/plugins/drizzle/connections.mdx
+++ b/website/content/docs/plugins/drizzle/connections.mdx
@@ -3,6 +3,9 @@ title: Connections
 description: Creating relay connections with the Drizzle plugin
 ---
 
+Use the [builder setup with Relay](./setup#integration-with-other-plugins) and register the users
+and posts object types. Examples defining the same field or helper are alternatives.
+
 ## Related connections
 
 To implement a relation as a connection, you can use `t.relatedConnection` instead of `t.relation`:
@@ -10,6 +13,7 @@ To implement a relation as a connection, you can use `t.relatedConnection` inste
 ```ts
 builder.drizzleNode('users', {
   name: 'User',
+  id: { column: (user) => user.id },
   fields: (t) => ({
     posts: t.relatedConnection('posts'),
   }),
@@ -37,6 +41,7 @@ derive the connections cursor.
 ```ts
 builder.drizzleNode('users', {
   name: 'User',
+  id: { column: (user) => user.id },
   fields: (t) => ({
     posts: t.relatedConnection('posts', {
       query: () => ({
@@ -59,6 +64,7 @@ You can add a `totalCount` field to your connection by setting the `totalCount` 
 ```ts
 builder.drizzleNode('users', {
   name: 'User',
+  id: { column: (user) => user.id },
   fields: (t) => ({
     posts: t.relatedConnection('posts', {
       totalCount: true,
@@ -101,7 +107,7 @@ regardless of the filter, set `filterConnectionTotalCount: false` in the `drizzl
 
 ```ts
 const builder = new SchemaBuilder<PothosTypes>({
-  plugins: [DrizzlePlugin],
+  plugins: [RelayPlugin, DrizzlePlugin],
   drizzle: {
     client: db,
     getTableConfig,
@@ -189,7 +195,7 @@ const Role = builder.drizzleObject('roles', {
 
 
 
-// Create connection helpers for the media type.  This will allow you
+// Create connection helpers for the userRoles join table.  This will allow you
 // to use the normal t.connection with a drizzle type
 const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
   // select the data needed for the nodes
@@ -207,6 +213,7 @@ builder.drizzleObjectField('users', 'rolesConnection', (t) =>
   t.connection({
     // The type for the Node
     type: Role,
+    nodeNullable: true,
     // since we are not using t.relatedConnection we need to manually
     // include the selections for our connection
     select: (args, ctx, nestedSelection) => ({
@@ -249,7 +256,7 @@ const SelectPost = builder.drizzleObject('posts', {
 });
 ```
 
-Arguments, ordering and filtering can also be defined in the helpers:
+Replace the preceding `rolesConnection` helper and field to add filtering and ordering:
 
 ```ts
 const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
@@ -259,7 +266,7 @@ const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
     // define an order
     orderBy: {
       roleId: 'asc',
-    }
+    },
     // define a filter
     where: {
       accepted: true,
@@ -280,6 +287,7 @@ const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
 builder.drizzleObjectField('users', 'rolesConnection', (t) =>
   t.connection({
     type: Role,
+    nodeNullable: true,
     // add the args from the connection helper to the field
     args: rolesConnection.getArgs(),
     select: (args, ctx, nestedSelection) => ({
@@ -294,7 +302,8 @@ builder.drizzleObjectField('users', 'rolesConnection', (t) =>
 
 ### Extending connection edges
 
-In some cases you may want to expose some data from an indirect connection on the edge object.
+This alternative exposes the join row’s `createdAt` on each edge. It assumes a registered
+`DateTime` scalar whose output type is `Date`.
 
 ```typescript
 const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
@@ -310,6 +319,7 @@ builder.drizzleObjectFields('users', (t) => ({
   rolesConnection: t.connection(
     {
       type: Role,
+      nodeNullable: true,
       select: (args, ctx, nestedSelection) => ({
         with: {
           userRoles: rolesConnection.getQuery(args, ctx, nestedSelection),
@@ -358,17 +368,16 @@ const rolesConnection = drizzleConnectionHelpers(builder, 'userRoles', {
 builder.queryFields((t) => ({
   roles: t.connection({
     type: Role,
+    nodeNullable: true,
     args: {
       userId: t.arg.int({ required: true }),
     },
-    nodeNullable: true,
     resolve: async (_, args, ctx, info) => {
       const query = rolesConnection.getQuery(args, ctx, info);
       const userRoles = await db.query.userRoles.findMany({
         ...query,
         where: {
-          ...query.where,
-          userId: args.userId,
+          AND: [query.where ?? {}, { userId: args.userId }],
         },
       });
       return rolesConnection.resolve(userRoles, args, ctx);

--- a/website/content/docs/plugins/drizzle/index.mdx
+++ b/website/content/docs/plugins/drizzle/index.mdx
@@ -16,10 +16,8 @@ import { Callout } from 'fumadocs-ui/components/callout';
   Pothos specific changes.
 </Callout>
 
-This plugin provides tighter integration with drizzle, making it easier to define GraphQL object
-types based on your drizzle tables, and resolving the relations between them in as few queries as
-possible. It also has integrations for the relay plugin to make defining nodes and connections easy
-and efficient.
+The Drizzle plugin defines GraphQL types from your tables and plans database queries from GraphQL
+selections. It loads relations and integrates with Relay nodes and connections.
 
 ## Getting started
 
@@ -30,10 +28,11 @@ npm install --save @pothos/plugin-drizzle drizzle-orm@rc
 ```
 
 Define an object type for a table, expose the columns you want in your API, and add the relations
-you want to be able to query through:
+you want clients to query. This example uses the builder, database client, and `userId` context
+from Setup, with a users table related to posts:
 
 ```ts
-const UserRef = builder.drizzleObject('users', {
+const User = builder.drizzleObject('users', {
   name: 'User',
   fields: (t) => ({
     firstName: t.exposeString('firstName'),
@@ -42,10 +41,16 @@ const UserRef = builder.drizzleObject('users', {
   }),
 });
 
+builder.drizzleObject('posts', {
+  name: 'Post',
+  fields: (t) => ({ title: t.exposeString('title') }),
+});
+
 builder.queryType({
   fields: (t) => ({
     me: t.drizzleField({
       type: 'users',
+      nullable: true,
       resolve: (query, root, args, ctx) =>
         db.query.users.findFirst(query({ where: { id: ctx.userId } })),
     }),

--- a/website/content/docs/plugins/drizzle/interfaces.mdx
+++ b/website/content/docs/plugins/drizzle/interfaces.mdx
@@ -30,6 +30,12 @@ builder.drizzleObject('users', {
     permissions: t.exposeStringList('permissions'),
   }),
 });
+
+builder.drizzleObject('users', {
+  variant: 'MemberViewer',
+  interfaces: [Viewer],
+  select: { columns: { id: true } },
+});
 ```
 
 Fields can be added to an interface later with `builder.drizzleInterfaceField` and

--- a/website/content/docs/plugins/drizzle/objects.mdx
+++ b/website/content/docs/plugins/drizzle/objects.mdx
@@ -3,13 +3,16 @@ title: Drizzle Objects
 description: Defining GraphQL object types based on drizzle tables
 ---
 
+Use the builder and database client from [Setup](./setup). The examples below use a `users` table
+with an integer `id` and string `firstName` and `lastName` columns.
+
 ## Defining Objects
 
 The `builder.drizzleObject` method can be used to define GraphQL Object types based on a drizzle
 table:
 
 ```ts
-const UserRef = builder.drizzleObject('users', {
+const User = builder.drizzleObject('users', {
   name: 'User',
   fields: (t) => ({
     firstName: t.exposeString('firstName'),
@@ -19,16 +22,16 @@ const UserRef = builder.drizzleObject('users', {
 ```
 
 You will be able to "expose" any column in the table, and GraphQL fields do not need to match the
-names of the columns in your database. The returned `UserRef` can be used like any other `ObjectRef`
+names of the columns in your database. The returned `User` can be used like any other `ObjectRef`
 in Pothos.
 
 ## Custom fields
 
 You will often want to define fields in your API that do not correspond to a specific database
-column. To do this, you can define fields with a resolver like any other Pothos object type:
+column. For example, replace the object definition above with a computed full name:
 
 ```ts
-const UserRef = builder.drizzleObject('users', {
+const User = builder.drizzleObject('users', {
   name: 'User',
   fields: (t) => ({
     fullName: t.string({
@@ -49,13 +52,14 @@ object type in your schema:
 ```ts
 builder.queryType({
   fields: (t) => ({
-    post: t.drizzleField({
-      type: 'posts',
+    user: t.drizzleField({
+      type: 'users',
+      nullable: true,
       args: {
         id: t.arg.id({ required: true }),
       },
       resolve: (query, root, args, ctx) =>
-        db.query.posts.findFirst(
+        db.query.users.findFirst(
           query({
             where: {
               id: Number.parseInt(args.id, 10),
@@ -63,16 +67,16 @@ builder.queryType({
           }),
         ),
     }),
-    posts: t.drizzleField({
-      type: ['posts'],
-      resolve: (query, root, args, ctx) => db.query.posts.findMany(query()),
+    users: t.drizzleField({
+      type: ['users'],
+      resolve: (query, root, args, ctx) => db.query.users.findMany(query()),
     }),
   }),
 });
 ```
 
-The `resolve` function of a `drizzleField` will be passed a `query` function that MUST be called and
-passed to a drizzle `findOne` or `findMany` query. The `query` function optionally accepts any
+The `resolve` function of a `drizzleField` receives a `query` function. Call it and pass its result
+to a Drizzle `findFirst` or `findMany` query. The `query` function optionally accepts any
 arguments that are normally passed into the query, and will merge these options with the selection
 used to resolve data for the nested GraphQL selections.
 
@@ -81,12 +85,13 @@ used to resolve data for the nested GraphQL selections.
 With the [with-input plugin](https://pothos-graphql.dev/docs/plugins/with-input),
 `t.drizzleFieldWithInput` combines `t.drizzleField` with `t.fieldWithInput`. The `input` fields
 become an input object argument, and the resolver still receives the `query` function as its first
-argument:
+argument. This replaces the `user` field above:
 
 ```ts
 builder.queryFields((t) => ({
   user: t.drizzleFieldWithInput({
     type: 'users',
+    nullable: true,
     input: {
       id: t.input.id({ required: true }),
     },

--- a/website/content/docs/plugins/drizzle/query-planning.mdx
+++ b/website/content/docs/plugins/drizzle/query-planning.mdx
@@ -38,7 +38,7 @@ still narrow the parent shape:
 builder.drizzleObject('users', {
   name: 'User',
   fields: (t) => ({
-    latestPosts: t.field({
+    previewPosts: t.field({
       type: [Post],
       select: (args, ctx, nestedSelection) => ({
         // what the query selects on the posts, limited to one
@@ -61,12 +61,17 @@ which are described under [Relation queries](./relations#relation-queries).
 
 ## Async selections
 
-Selections are synchronous unless the schema opts in with `AsyncSelections: true`:
+Selections are synchronous unless the schema opts in with `AsyncSelections: true`. This example
+uses request context methods that asynchronously return a user ID and a preview limit:
 
 ```ts
 const builder = new SchemaBuilder<{
   DrizzleRelations: typeof relations;
   AsyncSelections: true;
+  Context: {
+    currentUserId: () => Promise<number>;
+    previewSize: () => Promise<number>;
+  };
 }>({
   plugins: [DrizzlePlugin],
   drizzle: {
@@ -93,7 +98,7 @@ builder.drizzleObject('users', {
     posts: t.relation('posts', {
       query: async (args, ctx) => ({ where: { authorId: await ctx.currentUserId() } }),
     }),
-    latestPosts: t.field({
+    previewPosts: t.field({
       type: [Post],
       select: async (args, ctx, nestedSelection) => ({
         with: { posts: await nestedSelection({ limit: await ctx.previewSize() }) },

--- a/website/content/docs/plugins/drizzle/relations.mdx
+++ b/website/content/docs/plugins/drizzle/relations.mdx
@@ -88,7 +88,7 @@ describes where in the GraphQL query the relation is being loaded:
   on), and `isList` (whether the field returns a list).
 
 You can read more about the relation query builder api
-[here](https://orm.drizzle.team/docs/rqb#querying)
+[here](https://orm.drizzle.team/docs/rqb-v2)
 
 ## Fallback queries
 

--- a/website/content/docs/plugins/drizzle/relay.mdx
+++ b/website/content/docs/plugins/drizzle/relay.mdx
@@ -12,7 +12,7 @@ easy to comply with these best practices, the drizzle plugin has built in suppor
 ## Relay Nodes
 
 Defining relay nodes works just like defining normal `drizzleObject`s, but requires specifying a
-column to use as the nodes `id` field.
+column to use as the node's `id` field.
 
 ```ts
 builder.drizzleNode('users', {

--- a/website/content/docs/plugins/drizzle/selections.mdx
+++ b/website/content/docs/plugins/drizzle/selections.mdx
@@ -10,7 +10,7 @@ with many columns, it can be more efficient to only select the needed columns. Y
 selected columns, and relations by passing a `select` option when defining the type:
 
 ```ts
-const UserRef = builder.drizzleObject('users', {
+const User = builder.drizzleObject('users', {
   name: 'User',
   select: {
     columns: {
@@ -21,7 +21,7 @@ const UserRef = builder.drizzleObject('users', {
       profile: true,
     },
     extras: {
-      lowercaseName: (users, sql) => sql<string>`lower(${users.firstName})`
+      lowercaseName: (users, { sql }) => sql<string>`lower(${users.firstName})`
     },
   },
   fields: (t) => ({
@@ -29,10 +29,11 @@ const UserRef = builder.drizzleObject('users', {
       resolve: (user, args, ctx, info) => `${user.firstName} ${user.lastName}`,
     }),
     bio: t.string({
-      resolve: (user) => user.profile.bio,
+      nullable: true,
+      resolve: (user) => user.profile?.bio,
     }),
-    email: t.string({
-      resolve: (user) => `${user.lowercaseName}@example.com`,
+    lowercaseName: t.string({
+      resolve: (user) => user.lowercaseName,
     }),
   }),
 });
@@ -45,10 +46,10 @@ selected can still be exposed as before.
 
 The previous example allows you to control what gets selected by default, but you often want to only
 select the columns that are required to fulfill a specific field. You can do this by adding the
-appropriate selections on each field:
+appropriate selections on each field. Replace the preceding User definition with:
 
 ```ts
-const UserRef = builder.drizzleObject('users', {
+const User = builder.drizzleObject('users', {
   name: 'User',
   select: {},
   fields: (t) => ({
@@ -59,18 +60,19 @@ const UserRef = builder.drizzleObject('users', {
       resolve: (user, args, ctx, info) => `${user.firstName} ${user.lastName}`,
     }),
     bio: t.string({
+      nullable: true,
       select: {
         with: { profile: true },
       },
-      resolve: (user) => user.profile.bio,
+      resolve: (user) => user.profile?.bio,
     }),
-    email: t.string({
+    lowercaseName: t.string({
       select: {
         extras: {
-          lowercaseName: (users, sql) => sql<string>`lower(${users.firstName})`
+          lowercaseName: (users, { sql }) => sql<string>`lower(${users.firstName})`
         },
       },
-      resolve: (user) => `${user.lowercaseName}@example.com`,
+      resolve: (user) => user.lowercaseName,
     }),
   }),
 });

--- a/website/content/docs/plugins/drizzle/setup.mdx
+++ b/website/content/docs/plugins/drizzle/setup.mdx
@@ -9,27 +9,31 @@ description: Setting up the Drizzle plugin
 npm install --save @pothos/plugin-drizzle drizzle-orm@rc
 ```
 
-The drizzle plugin is built on top of drizzles relational query builder, and requires that you
-define and configure all the relevant relations in your drizzle schema. See
-https://orm.drizzle.team/docs/relations-v2 for detailed documentation on the relations API.
+The Drizzle plugin uses the relational query builder. Define the tables and relations your schema
+will query; see Drizzle’s [relations API](https://orm.drizzle.team/docs/relations-v2).
 
 Once you have configured your drizzle schema, you can initialize your Pothos
-SchemaBuilder with the drizzle plugin:
+SchemaBuilder with the drizzle plugin. This example uses SQLite through `@libsql/client`;
+install that driver and use the `relations` exported by your application. For another database,
+use its Drizzle driver and matching `getTableConfig` import:
 
 ```ts
-import { drizzle } from 'drizzle-orm/...';
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
 // Import the appropriate getTableConfig for your dialect
 import { getTableConfig } from 'drizzle-orm/sqlite-core';
 import SchemaBuilder from '@pothos/core';
 import DrizzlePlugin from '@pothos/plugin-drizzle';
 import { relations } from './db/relations';
 
+const client = createClient({ url: 'file:./dev.db' });
 const db = drizzle({ client, relations });
 
-type DrizzleRelations = typeof relations
+type DrizzleRelations = typeof relations;
 
 export interface PothosTypes {
   DrizzleRelations: DrizzleRelations;
+  Context: { userId: number };
 }
 
 const builder = new SchemaBuilder<PothosTypes>({
@@ -42,13 +46,17 @@ const builder = new SchemaBuilder<PothosTypes>({
 });
 ```
 
+The examples use an authenticated request context with `userId: number`. Supply it through your
+GraphQL server; see [Context](/docs/guide/context).
+
 ### Integration with other plugins
 
 The drizzle plugin has integrations with several other plugins. While the `with-input` and `relay`
 plugins are not required, many examples will assume these plugins have been installed:
 
 ```ts
-import { drizzle } from 'drizzle-orm/...';
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
 import SchemaBuilder from '@pothos/core';
 import DrizzlePlugin from '@pothos/plugin-drizzle';
 import RelayPlugin from '@pothos/plugin-relay';
@@ -56,10 +64,12 @@ import WithInputPlugin from '@pothos/plugin-with-input';
 import { getTableConfig } from 'drizzle-orm/sqlite-core';
 import { relations } from './db/relations';
 
+const client = createClient({ url: 'file:./dev.db' });
 const db = drizzle({ client, relations });
 
 export interface PothosTypes {
   DrizzleRelations: typeof relations;
+  Context: { userId: number };
 }
 
 const builder = new SchemaBuilder<PothosTypes>({

--- a/website/content/docs/plugins/drizzle/variants.mdx
+++ b/website/content/docs/plugins/drizzle/variants.mdx
@@ -3,6 +3,10 @@ title: Type variants
 description: How to define multiple GraphQL types based on the same drizzle table
 ---
 
+Use the [builder setup with Relay](./setup#integration-with-other-plugins), and include
+`Context: { user: { id: number } }` in `PothosTypes`. These examples assume an authenticated user
+and a registered posts type. The `users` table has a posts relation.
+
 ## Variants
 
 It is often useful to be able to define multiple object types based on the same table. This can be
@@ -10,7 +14,7 @@ done using a feature called `variants`. The `variants` API consists of 3 parts:
 
 - A `variant` option that can be passed instead of a name on `drizzleObjects`
 - The ability to pass an `ObjectRef` to the `type` option of `t.relation` and other similar fields
-- A `t.field` method that works similar to `t.relation`, but is used to define a GraphQL field that
+- A `t.variant` method that works similar to `t.relation`, but is used to define a GraphQL field that
   references a variant of the same record.
 
 ```ts
@@ -55,6 +59,7 @@ builder.queryType({
 
 builder.drizzleNode('users', {
   name: 'User',
+  id: { column: (user) => user.id },
   fields: (t) => ({
     firstName: t.exposeString('firstName'),
     // This field will resolve to the Viewer type, but be set to null if the user is not the current user
@@ -65,12 +70,13 @@ builder.drizzleNode('users', {
 });
 ```
 
-A `t.variant` field can have a `select` of its own. It is planned along with the variant's
+As an alternative to the User node definition above, a `t.variant` field can have a `select` of its own. It is planned along with the variant's
 type-level selection when the variant is queried through that field:
 
 ```ts
 builder.drizzleNode('users', {
   name: 'User',
+  id: { column: (user) => user.id },
   fields: (t) => ({
     viewer: t.variant(Viewer, {
       // loaded with the row when `viewer` is selected


### PR DESCRIPTION
Make Drizzle examples consistent with the current relational query builder and Pothos APIs: use coherent User definitions and context, include required node IDs and Relay setup, destructure SQL extras operators correctly, and handle nullable profiles and helper nodes. Preserve the recent async-selection, planning, ordering, and cursor documentation and synchronize the README.

Validation: isolated strict checks cover both setup builders, all Objects examples, both Selections examples, variants, and all 11 connection/helper blocks. A real SQLite query executes the displayed field selections and checks computed names and a missing profile. Fifty-five focused async-selection, document-order, connection-order, and cursor-value tests pass. The final production website build and all 77 rendered documentation page/anchor checks passed.

The ordering-and-cursors page was audited and retained unchanged. Application table/relationship prerequisites are explicit; not every database recipe was executed.

Separate post-publication editorial and correctness reviews are complete; material findings were addressed.

Preservation re-review against original base `7c0a5490`: Audited every Drizzle page against the original base. Setup, model/interface definitions, query planning, async selections, relations, variants, Relay and cursor/ordering contracts remain covered; no additional restoration was needed.

All useful omissions identified by the new review were fixed and independently re-reviewed. The final integrated production website build, executable documentation checks, and links/anchors across 77 rendered pages pass. Dependency-install fences use `package-install` throughout the changed website pages and READMEs.
