### PR TITLE
test(docs): retain executable example and rendered link checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,28 @@ behavior.
 
 ## Docs
 
-Documentation lives in the `/docs` directory, but the contents of the plugin docs are duplicated in
+Documentation lives in the `website/content/docs` directory, but the contents of the plugin docs are duplicated in
 the README.md of each plugin so that each package has a useful readme when published to npm. If you
 are editing documentation for a plugin, keeping those changes in sync with the packages README files
 is usually required. This is a temporary workaround until a better solution can be found.
+
+
+### Reviewing documentation changes
+
+Review both the resulting page and the documentation at the PR's base commit. For stacked PRs,
+also compare the complete rewrite with the original base before the stack.
+
+For each substantive removed explanation, setup step, option, caveat, or example, record where its
+useful information is now covered. A review may accept consolidation, a linked replacement that
+supports the same task, or removal of obsolete behavior verified against current source or upstream
+documentation. Record the reason and evidence for each removal without a replacement. Shorter prose,
+passing examples, and successful builds alone do not establish that coverage was preserved.
+
+Check complete reader workflows: installation and initialization, connected examples, alternative
+configurations, error handling, resource cleanup, and relevant limitations. Verify that shared
+examples define the imports, models, and setup needed by the sections that refer to them. Treat an
+unaccounted loss of useful coverage as a review finding and resolve it before approving the rewrite.
+
+Keep the coverage mapping with the review results, alongside correctness and style findings. After
+fixes, recheck the affected workflows and synchronize the plugin README. Large reductions deserve
+extra scrutiny, but the same preservation check applies to small deletions.

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,9 @@
     "next-build": "next build",
     "build-ci": "next build",
     "start": "next start",
-    "postinstall": "fumadocs-mdx"
+    "postinstall": "fumadocs-mdx",
+    "check:examples": "node scripts/check-doc-examples.mjs",
+    "check:links": "node scripts/check-doc-links.mjs"
   },
   "engines": {
     "pnpm": ">=9.0.0"

--- a/website/scripts/README.md
+++ b/website/scripts/README.md
@@ -1,0 +1,37 @@
+# Documentation checks
+
+After installing the workspace dependencies, run these commands from the repository root.
+
+```sh
+pnpm --dir website check:examples
+```
+
+This extracts the current Overview schema, the Guide schema/query/response, and the Printing Schemas
+example directly from MDX. It checks their types against the current core source, executes the
+queries, checks optional argument behavior and the computed field, and reads the generated SDL back
+as a schema. Temporary files are removed when the command finishes.
+
+The check uses the workspace compiler and source aliases. It does not validate the Guide's npm
+installation, NodeNext configuration, Yoga server, or every documentation snippet. Changes to those
+parts still need a fresh installation and HTTP check. `doc-example-assertions.mjs` runs inside the
+temporary fixture created by `check-doc-examples.mjs`.
+
+To check links and anchors, build and start the website:
+
+```sh
+pnpm --dir website exec fumadocs-mdx
+pnpm --dir website exec next build --webpack
+pnpm --dir website start
+```
+
+Then, in another terminal:
+
+```sh
+pnpm --dir website check:links
+# Or pass the origin of a server on another port:
+pnpm --dir website check:links http://localhost:4317
+```
+
+This loads every documentation route from the local server and checks links to documentation pages
+and their rendered anchors. Links to `https://pothos-graphql.dev/docs/...` are checked against the
+same local pages. External websites, assets, and Markdown export routes are outside this check.

--- a/website/scripts/check-doc-examples.mjs
+++ b/website/scripts/check-doc-examples.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const require = createRequire(join(root, 'package.json'));
+const fixture = await mkdtemp(join(root, '.docs-check-'));
+
+async function codeBlocks(page, language) {
+  const source = await readFile(join(root, 'website/content/docs', page), 'utf8');
+  return [...source.matchAll(/^```([^\n]+)\n([\s\S]*?)^```/gm)]
+    .filter((match) => match[1] === language)
+    .map((match) => match[2]);
+}
+
+try {
+  const guide = await codeBlocks('guide/index.mdx', 'typescript');
+  const overview = await codeBlocks('index.mdx', 'typescript');
+  const printing = await codeBlocks('guide/printing-schemas.mdx', 'typescript');
+  const queries = await codeBlocks('guide/index.mdx', 'graphql');
+  const json = await codeBlocks('guide/index.mdx', 'json');
+  assert.equal(guide.length, 2, 'Expected schema and server snippets in the guide');
+  assert.equal(overview.length, 1, 'Expected one overview schema');
+  assert.equal(printing.length, 1, 'Expected one printing example');
+  assert.equal(queries.length, 1, 'Expected one guide query');
+  assert.equal(json.length, 2, 'Expected tsconfig and response JSON');
+
+  await Promise.all([
+    writeFile(join(fixture, 'package.json'), '{"type":"commonjs"}\n'),
+    writeFile(join(fixture, 'schema.ts'), guide[0]),
+    writeFile(join(fixture, 'overview.ts'), overview[0]),
+    writeFile(join(fixture, 'printing.ts'), printing[0]),
+    writeFile(join(fixture, 'query.graphql'), queries[0]),
+    writeFile(join(fixture, 'expected.json'), json[1]),
+    writeFile(
+      join(fixture, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          moduleResolution: 'Bundler',
+          esModuleInterop: true,
+          strict: true,
+          noEmit: true,
+          skipLibCheck: true,
+          types: ['node'],
+          paths: { '@pothos/core': ['../packages/core/src/index.ts'] },
+        },
+        include: ['*.ts'],
+      }),
+    ),
+    writeFile(
+      join(fixture, 'check.mjs'),
+      await readFile(join(root, 'website/scripts/doc-example-assertions.mjs'), 'utf8'),
+    ),
+  ]);
+
+  execFileSync(
+    process.execPath,
+    [join(dirname(require.resolve('typescript/package.json')), 'bin/tsc'), '-p', fixture],
+    {
+      cwd: root,
+      stdio: 'inherit',
+    },
+  );
+  execFileSync(
+    process.execPath,
+    [require.resolve('tsx/cli'), '--tsconfig', join(fixture, 'tsconfig.json'), 'check.mjs'],
+    { cwd: fixture, stdio: 'inherit' },
+  );
+} finally {
+  await rm(fixture, { recursive: true, force: true });
+}

--- a/website/scripts/check-doc-links.mjs
+++ b/website/scripts/check-doc-links.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { readdir } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const docs = resolve(dirname(fileURLToPath(import.meta.url)), '../content/docs');
+const base = new URL(process.argv[2] ?? 'http://localhost:3000');
+assert.equal(base.pathname, '/', 'Pass the website origin without a path');
+const files = await readdir(docs, { recursive: true });
+const routes = files
+  .filter((file) => file.endsWith('.mdx'))
+  .map((file) => `/docs/${file.replaceAll('\\', '/').slice(0, -4)}`.replace(/\/index$/, ''));
+const pages = new Map(
+  await Promise.all(
+    routes.map(async (route) => {
+      const response = await fetch(new URL(route, base), { signal: AbortSignal.timeout(15000) });
+      assert.equal(response.status, 200, `${route}: HTTP ${response.status}`);
+      const html = await response.text();
+      return [
+        route,
+        {
+          ids: new Set([...html.matchAll(/\bid="([^"]+)"/g)].map((match) => match[1])),
+          links: new Set([...html.matchAll(/\bhref="([^"]+)"/g)].map((match) => match[1])),
+        },
+      ];
+    }),
+  ),
+);
+
+const failures = [];
+for (const [route, page] of pages) {
+  for (const href of page.links) {
+    const url = new URL(href.replaceAll('&amp;', '&'), new URL(route, base));
+    if (url.origin !== base.origin && url.origin !== 'https://pothos-graphql.dev') {
+      continue;
+    }
+    const path = url.pathname.replace(/\/$/, '');
+    if (!/^\/docs(?:\/|$)/.test(path) || path.endsWith('.mdx')) {
+      continue;
+    }
+    const target = pages.get(path);
+    if (!target) {
+      failures.push(`${route}: ${href} (missing page)`);
+    } else if (url.hash && !target.ids.has(decodeURIComponent(url.hash.slice(1)))) {
+      failures.push(`${route}: ${href} (missing anchor)`);
+    }
+  }
+}
+assert.equal(failures.length, 0, `Broken documentation links:\n${failures.join('\n')}`);
+console.log(
+  `Passed: internal pages and anchors across ${pages.size} rendered documentation pages.`,
+);

--- a/website/scripts/doc-example-assertions.mjs
+++ b/website/scripts/doc-example-assertions.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { buildSchema, graphql, printSchema, validateSchema } = require('graphql');
+const { schema: overview } = require('./overview.ts');
+const { schema } = require('./schema.ts');
+require('./printing.ts');
+
+const result = await graphql({ schema, source: await readFile('query.graphql', 'utf8') });
+assert.deepEqual(
+  JSON.parse(JSON.stringify(result)),
+  JSON.parse(await readFile('expected.json', 'utf8')),
+);
+for (const [source, expected] of [
+  ['{ hello }', 'hello, World'],
+  ['{ hello(name: null) }', 'hello, World'],
+  ['{ hello(name: "") }', 'hello, '],
+]) {
+  const response = await graphql({ schema, source });
+  assert.equal(response.errors, undefined);
+  assert.equal(response.data.hello, expected);
+}
+const giraffe = await graphql({ schema: overview, source: '{ giraffe { name heightInFeet } }' });
+assert.deepEqual(JSON.parse(JSON.stringify(giraffe)), {
+  data: { giraffe: { name: 'Gina', heightInFeet: 16.4042 } },
+});
+const backingField = await graphql({ schema: overview, source: '{ giraffe { heightInMeters } }' });
+assert.equal(backingField.errors?.length, 1);
+assert.match(backingField.errors[0].message, /Cannot query field "heightInMeters"/);
+
+const sdl = await readFile('schema.graphql', 'utf8');
+const restored = buildSchema(sdl);
+assert.deepEqual(validateSchema(restored), []);
+assert.equal(printSchema(restored), printSchema(schema));
+console.log(
+  'Passed: guide query and arguments, overview backing data, and printed SDL round trip.',
+);


### PR DESCRIPTION
Retain two documentation checks that previously lived only in temporary validation directories. Extract the current Overview, Guide schema/query/response, and Printing examples from MDX, strictly typecheck them against core source, execute their queries and SDL round trip, and audit documentation links and anchors against a running website.

Run `pnpm --dir website check:examples` and `pnpm --dir website check:links [origin]`. Setup and coverage limits are in `website/scripts/README.md`. Example checks, negative checks for a wrong resolver type and changed argument behavior, and Biome passed. The final built site passes the link check across 77 documentation pages.

These commands do not validate every snippet, the Guide's fresh npm/Yoga setup, external websites, or Markdown export routes. The checks remain explicitly runnable rather than expanding CI workflows.

Separate post-publication editorial and correctness reviews are complete; material findings were addressed.

Preservation re-review against original base `7c0a5490`: CONTRIBUTING.md now requires comparison with the original documentation, a mapping for substantive removed content, evidence for obsolete material, and rechecks of restored workflows. Existing executable-example and rendered-link checks remain.

All useful omissions identified by the new review were fixed and independently re-reviewed. The final integrated production website build, executable documentation checks, and links/anchors across 77 rendered pages pass. Dependency-install fences use `package-install` throughout the changed website pages and READMEs.
