### PR TITLE
docs: renew Errors, Validation, and Zod guides

### DIFF
--- a/packages/plugin-errors/README.md
+++ b/packages/plugin-errors/README.md
@@ -1,27 +1,21 @@
-# Errors Plugin
----
-title: Errors plugin
-description: Errors plugin docs for Pothos
----
+# Errors plugin
 
-A plugin for easily including error types in your GraphQL schema and hooking up error types to
-resolvers
+Represent expected failures as GraphQL result unions. Register error classes as object types, then
+list them in a field's `errors` option. The plugin catches matching errors and returns an error
+object that clients can query with fragments. Errors that do not match still become GraphQL errors.
 
 ## Usage
 
 ### Install
 
-```bash
+```package-install
 npm install --save @pothos/plugin-errors
 ```
-
-### Setup
-
-Ensure that the target in your `tsconfig.json` is set to `es6` or higher (default is `es3`).
 
 ### Example Usage
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import ErrorsPlugin from '@pothos/plugin-errors';
 const builder = new SchemaBuilder({
   plugins: [ErrorsPlugin],
@@ -48,7 +42,7 @@ builder.queryType({
         name: t.arg.string({ required: false }),
       },
       resolve: (parent, { name }) => {
-        if (name.slice(0, 1) !== name.slice(0, 1).toUpperCase()) {
+        if (name && name.slice(0, 1) !== name.slice(0, 1).toUpperCase()) {
           throw new Error('name must be capitalized');
         }
 
@@ -67,7 +61,7 @@ type Error {
 }
 
 type Query {
-  hello(name: String!): QueryHelloResult
+  hello(name: String): QueryHelloResult
 }
 
 union QueryHelloResult = Error | QueryHelloSuccess
@@ -104,38 +98,30 @@ errors plugin will automatically resolve to the corresponding error object type.
 - `directResult`: Sets the default for `directResult` option on fields (only affects non-list
   fields)
 - `onResolvedError`: A callback function that is called when an error is handled by the plugin
-- `defaultResultOptions`: Sets the defaults for `result` option on fields.
-  - `name`: Function to generate a custom name on the generated result types.
-    ```ts
-    export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
-      plugins: [ErrorPlugin, ValidationPlugin],
-      errors: {
-        defaultTypes: [Error],
-        defaultResultOptions: {
-          name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
-        },
-        defaultUnionOptions: {
-          name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
-        },
-      },
-    });
-    ```
-- `defaultUnionOptions`: Sets the defaults for `result` option on fields.
-  - `name`: Function to generate a custom name on the generated union types.
-    ```ts
-    export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
-      plugins: [ErrorPlugin, ValidationPlugin],
-      errors: {
-        defaultTypes: [Error],
-        defaultResultOptions: {
-          name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
-        },
-        defaultUnionOptions: {
-          name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
-        },
-      },
-    });
-    ```
+- `defaultResultOptions`: Defaults for generated success object types.
+- `defaultUnionOptions`: Defaults for generated result union types.
+- `defaultItemResultOptions`: Defaults for per-item success object types.
+- `defaultItemUnionOptions`: Defaults for per-item result union types.
+- `unsafelyHandleInputErrors`: Also catch input mapping and validation errors; see
+  [With validation plugin](#with-validation-plugin).
+
+The four type-options objects accept a `name` function receiving `{ parentTypeName, fieldName }`.
+Use distinct names for success objects and unions:
+
+```typescript
+const builder = new SchemaBuilder({
+  plugins: [ErrorsPlugin],
+  errors: {
+    defaultTypes: [Error],
+    defaultResultOptions: {
+      name: ({ parentTypeName, fieldName }) => `${parentTypeName}_${fieldName}_Success`,
+    },
+    defaultUnionOptions: {
+      name: ({ parentTypeName, fieldName }) => `${parentTypeName}_${fieldName}_Result`,
+    },
+  },
+});
+```
 
 ### Options on Fields
 
@@ -146,12 +132,12 @@ errors plugin will automatically resolve to the corresponding error object type.
 - `result`: An options object for result object type. Can include any normal object type options,
   and `name` option for setting a custom name for the result type.
 - `dataField`: An options object for the data field on the result object. This field will be named
-  `data` by default, but can be written by passing a custom `name` option.
+  `data` by default, but can be renamed by passing a custom `name` option.
 - `directResult`: Boolean, can only be set to true for non-list fields. This will directly include
   the fields type in the union rather than creating an intermediate Result object type. This will
   throw at build time if the type is not an object type.
 
-### Recommended Usage
+### A shared Error interface
 
 1. Set up an Error interface
 2. Create a BaseError object type
@@ -164,9 +150,10 @@ more specialized error types, they can just add a fragment for the errors it car
 pattern should also make it easier to make future changes without unexpected breaking changes for
 your clients.
 
-The following is a small example of this pattern:
+This is a separate setup from the first example:
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import ErrorsPlugin from '@pothos/plugin-errors';
 const builder = new SchemaBuilder({
   plugins: [ErrorsPlugin],
@@ -243,31 +230,42 @@ builder.queryType({
 
 ### With validation plugin
 
-To handle validation errors you will need to enable the `unsafelyHandleInputErrors` option in the
-errors plugin options. This will allow the errors plugin to catch errors thrown by the validation plugin.
-This setting is unsafe because it wraps and catches errors at a higher level which will allow you to
-bypass other plugin hooks like the `auth` plugin.  This enables you to return structured error responses for
-validation issues which happen BEFORE auth checks are executed, but this also means that those auth checks won't be run.
+The validation plugin runs before field resolution. Set `unsafelyHandleInputErrors: true` to
+return its failures as typed results. A validation failure then returns without running field
+authorization hooks, so only enable this when those error details may be returned before authorization.
 
-Once you enable the `unsafelyHandleInputErrors` option, you can define types for an InputValidationError
-(or any custom error you use in the validation plugin), the same way you would for any other error type. Below
-is a simple example of how this can be done, but the specifics of how you structure your error types are left up to you.
+This standalone example registers the validation error and its issues. Valid input reaches the
+resolver; invalid input returns `InputValidationError`.
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
+import ErrorsPlugin from '@pothos/plugin-errors';
+import ValidationPlugin, {
+  InputValidationError,
+  type StandardSchemaV1,
+} from '@pothos/plugin-validation';
+import { z } from 'zod';
+
+const builder = new SchemaBuilder({
+  plugins: [ErrorsPlugin, ValidationPlugin],
+  errors: { unsafelyHandleInputErrors: true },
+});
+
 const InputValidationIssue = builder
   .objectRef<StandardSchemaV1.Issue>('InputValidationIssue')
   .implement({
     fields: (t) => ({
       message: t.exposeString('message'),
       path: t.stringList({
-        resolve: (issue) => issue.path?.map((p) => String(p)),
+        resolve: (issue) => issue.path?.map((part) =>
+          String(typeof part === 'object' ? part.key : part),
+        ) ?? [],
       }),
     }),
   });
 
 builder.objectType(InputValidationError, {
   name: 'InputValidationError',
-  interfaces: [ErrorInterface],
   fields: (t) => ({
     issues: t.field({
       type: [InputValidationIssue],
@@ -276,6 +274,7 @@ builder.objectType(InputValidationError, {
   }),
 });
 
+builder.queryType();
 builder.queryField('fieldWithValidation', (t) =>
   t.boolean({
     errors: {
@@ -283,6 +282,7 @@ builder.queryField('fieldWithValidation', (t) =>
     },
     args: {
       string: t.arg.string({
+        required: true,
         validate: z.string().min(3, 'Too short'),
       }),
     },
@@ -295,9 +295,9 @@ Example query:
 
 ```graphql
 query {
-  validation(string: "a") {
+  fieldWithValidation(string: "a") {
     __typename
-    ... on QueryValidationSuccess {
+    ... on QueryFieldWithValidationSuccess {
       data
     }
     ... on InputValidationError {
@@ -318,11 +318,10 @@ BEFORE the dataloader plugin in your plugin list.
 If a field with `errors` returns a `loadableObject`, or `loadableNode` the errors plugin will now
 catch errors thrown when loading ids returned by the `resolve` function.
 
-If the field is a `List` field, errors that occur when resolving objects from `ids` will not be
-handled by the errors plugin. This is because those errors are associated with each item in the list
-rather than the list field itself. In the future, the dataloader plugin may have an option to throw
-an error at the field level if any items can not be loaded, which would allow the error plugin to
-handle these types of errors.
+For a list of loadable IDs, loading happens per item. A load failure is not a whole-field failure,
+so the field's `errors` option does not catch it. Use explicit error unions when you need typed
+results for individual loads; see [List item errors](#list-item-errors) for the separate
+`itemErrors` handling of errors returned or thrown while iterating the resolver's list.
 
 ### With the prisma plugin
 
@@ -338,102 +337,88 @@ plugin
 
 ### List item errors
 
-For fields that return lists, you can specify `itemErrors` to wrap the list items in a union type so
-that errors can be handled per-item rather than replacing the whole list with an error.
-
-The `itemErrors` options are exactly the same as the `errors` options, but they are applied to each
-item in the list rather than the whole list.
+Use `itemErrors` on a list field to wrap each item in its own result union. It accepts the same
+options as `errors`. The following addition to the shared Error interface example yields one success, then throws an error. The plugin returns that error as the final item:
 
 ```typescript
-builder.queryType({
-  fields: (t) => ({
-    listWithErrors: t.string({
-      itemErrors: {},
-      resolve: (parent, { name }) => {
-        return [
-          1,
-          2,
-          new Error('Boom'),
-          3,
-        ]
-      },
-    }),
+builder.queryField('listWithErrors', (t) =>
+  t.intList({
+    nullable: false,
+    itemErrors: {},
+    resolve: function* () {
+      yield 1;
+      throw new Error('Boom');
+    },
   }),
-});
+);
 ```
-
-This will produce a GraphQL schema that looks like:
 
 ```graphql
 type Query {
   listWithErrors: [QueryListWithErrorsItemResult!]!
 }
 
-union QueryListWithErrorsItemResult = Error | QueryListWithErrorsItemSuccess
+union QueryListWithErrorsItemResult = BaseError | QueryListWithErrorsItemSuccess
 
 type QueryListWithErrorsItemSuccess {
   data: Int!
 }
 ```
 
-Item errors also works with both sync and async iterators (in graphql@>=17, or other executors that support the @stream directive):
+At runtime, `itemErrors` also handles returned error instances. If the resolver's ordinary return
+type does not include errors, use an explicit error union for a list that mixes returned data and errors.
+
+The plugin also wraps sync and async iterators. A yielded error becomes an error item; a thrown
+error becomes the final item and closes the iterator. Async iterable execution requires an executor
+that supports it, such as GraphQL 17.
+
+Combine `errors: {}` with `itemErrors: {}` to handle a whole-field failure as well. The outer
+`QueryListWithErrorsResult` union contains `BaseError` and `QueryListWithErrorsSuccess`; the latter's
+`data` field contains the list of `QueryListWithErrorsItemResult` items.
+
+For an async source, the same field can use an async generator. Replace its resolver with:
 
 ```typescript
-builder.queryType({
-  fields: (t) => ({
-    asyncListWithErrors: t.string({
-      itemErrors: {},
-      resolve: async function* () {
+resolve: async function* () {
+  yield 1;
+  throw new Error('The next item could not be loaded');
+},
+```
+
+This requires an executor that supports async iterables. A thrown error ends the iterator;
+use an explicit error union when the source needs to return an error item and continue.
+
+To handle both a failure before the list is returned and a failure during iteration, replace
+`listWithErrors` with:
+
+```typescript
+builder.queryField('listWithErrors', (t) =>
+  t.intList({
+    nullable: false,
+    errors: {},
+    itemErrors: {},
+    args: { failBeforeLoad: t.arg.boolean() },
+    resolve: (_parent, { failBeforeLoad }) => {
+      if (failBeforeLoad) throw new Error('Could not load the list');
+      return (function* () {
         yield 1;
-        yield 2;
-        yield new Error('Boom');
-        yield 4;
-        throw new Error('Boom');
-      },
-    }),
+        throw new Error('Could not load the next item');
+      })();
+    },
   }),
-});
+);
 ```
 
-When an error is yielded, an error result will be added into the list, if the generator throws an error,
-the error will be added to the list, and no more results will be returned for that field
-
-
-You can also use the `errors` and `itemErrors` options together:
-
-```typescript
-
-builder.queryType({
-  fields: (t) => ({
-    listWithErrors: t.string({
-      itemErrors: {},
-      errors: {},
-      resolve: (parent, { name }) => {
-        return [
-          1,
-          new Error('Boom'),
-          3,
-        ]
-    }),
-  }),
-});
-```
-
-This will produce a GraphQL schema that looks like:
+The generated result types are:
 
 ```graphql
-
-type Query {
-  listWithErrors: [QueryListWithErrorsResult!]!
-}
-
-union QueryListWithErrorsResult = Error | QueryListWithErrorsSuccess
+union QueryListWithErrorsResult = BaseError | QueryListWithErrorsSuccess
 
 type QueryListWithErrorsSuccess {
   data: [QueryListWithErrorsItemResult!]!
 }
 
-union QueryListWithErrorsItemResult = Error | QueryListWithErrorsItemSuccess
+union QueryListWithErrorsItemResult = BaseError | QueryListWithErrorsItemSuccess
 
 type QueryListWithErrorsItemSuccess {
   data: Int!
@@ -445,17 +430,22 @@ type QueryListWithErrorsItemSuccess {
 Use `t.errorUnionField` and `t.errorUnionListField` to directly specify all members of the returned union type,
 including multiple success types and error types.
 
+The following additions use the `Error` class registered as `BaseError` in the shared-interface
+example. Each success shape has an `isTypeOf` check so Pothos can distinguish plain objects.
+The resolver bodies simulate create and update outcomes to demonstrate the union branches;
+replace them with your application's persistence logic.
+
 ```typescript
-const CreateResult = builder.objectRef<{ id: string; created: true }>('CreateResult').implement({
-  isTypeOf: (obj) => 'created' in obj,
+const CreateResult = builder.objectRef<{ id: string; created: boolean }>('CreateResult').implement({
+  isTypeOf: (obj) => typeof obj === 'object' && obj !== null && 'created' in obj,
   fields: (t) => ({
     id: t.exposeString('id'),
     created: t.exposeBoolean('created'),
   }),
 });
 
-const UpdateResult = builder.objectRef<{ id: string; updated: true }>('UpdateResult').implement({
-  isTypeOf: (obj) => 'updated' in obj,
+const UpdateResult = builder.objectRef<{ id: string; updated: boolean }>('UpdateResult').implement({
+  isTypeOf: (obj) => typeof obj === 'object' && obj !== null && 'updated' in obj,
   fields: (t) => ({
     id: t.exposeString('id'),
     updated: t.exposeBoolean('updated'),
@@ -465,21 +455,23 @@ const UpdateResult = builder.objectRef<{ id: string; updated: true }>('UpdateRes
 builder.mutationType({
   fields: (t) => ({
     modifyUser: t.errorUnionField({
-      types: [CreateResult, UpdateResult, ValidationError],
-      resolve: (parent, { action, name }) => {
-        if (name.length < 3) return new ValidationError('Name too short');
-        if (action === 'create') return { id: '123', created: true };
-        return { id: '123', updated: true };
+      types: [CreateResult, UpdateResult, Error],
+      args: {
+        id: t.arg.id({ required: true }),
+        name: t.arg.string({ required: true }),
+        create: t.arg.boolean({ required: true }),
+      },
+      resolve: (parent, { id, name, create }) => {
+        if (name.length < 3) return new Error('Name too short');
+        return create ? { id: String(id), created: true } : { id: String(id), updated: true };
       },
     }),
     processUsers: t.errorUnionListField({
-      types: [CreateResult, UpdateResult, ValidationError],
-      resolve: (parent, { operations }) =>
-        operations.map(op =>
-          op.invalid ? new ValidationError('Invalid') :
-          op.action === 'create' ? { id: op.id, created: true } :
-          { id: op.id, updated: true }
-        ),
+      types: [CreateResult, UpdateResult, Error],
+      args: { ids: t.arg.idList({ required: true }) },
+      resolve: (parent, { ids }) => ids.map((id) =>
+        id === 'unknown' ? new Error('User not found') : { id: String(id), updated: true },
+      ),
     }),
   }),
 });
@@ -487,43 +479,48 @@ builder.mutationType({
 
 #### Type resolution
 
-Union members are resolved using standard Pothos type resolution. You have three options:
+Union members use standard Pothos type resolution. Registering an error class with
+`builder.objectType` provides an `instanceof` check. Plain object types can supply `isTypeOf`, as
+above, or you can pass a custom `resolveType` in the field's `union` options. Error instances matched
+by the plugin are resolved before that custom callback.
 
-**Class-based types** (most error types) - automatically resolved via `instanceof` checks:
-```typescript
-class ValidationError extends Error { ... }
-builder.objectType(ValidationError, { name: 'ValidationError', fields: ... });
-// No isTypeOf needed - uses instanceof ValidationError
-```
+For example, this alternative field resolves its success branches explicitly using the
+`CreateResult` and `UpdateResult` types above:
 
-**`isTypeOf` function** - for plain object types:
 ```typescript
-const CreateResult = builder.objectRef<{ id: string }>('CreateResult').implement({
-  isTypeOf: (obj) => 'created' in obj,
-  fields: ...
-});
-```
-
-**Custom `resolveType` on union** - for complex resolution logic:
-```typescript
-t.errorUnionField({
-  types: [CreateResult, UpdateResult, ValidationError],
-  union: {
-    resolveType: (value) => {
-      if (value instanceof ValidationError) return 'ValidationError';
-      if ('created' in value) return 'CreateResult';
-      return 'UpdateResult';
+builder.mutationField('previewUserChange', (t) =>
+  t.errorUnionField({
+    types: [CreateResult, UpdateResult, Error],
+    args: { create: t.arg.boolean({ required: true }) },
+    union: {
+      resolveType: (value) => 'created' in value ? 'CreateResult' : 'UpdateResult',
     },
-  },
-  resolve: ...
-});
+    resolve: (_parent, { create }) =>
+      create ? { id: '1', created: true } : { id: '1', updated: true },
+  }),
+);
 ```
+
+Matched error instances use the plugin's error map, so this callback only needs to distinguish
+the success values.
 
 ### Using `builder.errorUnion`
 
 You can use `builder.errorUnion` to manually construct an error union type that can be used with any field.  Fields returning an error union will automatically handle returned or thrown errors.
 
+This addition to the shared-interface example distinguishes a missing user from invalid input.
+Both error types implement the shared `Error` interface, and validation failures expose the field
+that needs correction:
+
 ```typescript
+class NotFoundError extends Error {}
+
+class ValidationError extends Error {
+  constructor(message: string, public field: string) {
+    super(message);
+  }
+}
+
 builder.objectType(NotFoundError, {
   name: 'NotFoundError',
   interfaces: [ErrorInterface],
@@ -532,14 +529,11 @@ builder.objectType(NotFoundError, {
 builder.objectType(ValidationError, {
   name: 'ValidationError',
   interfaces: [ErrorInterface],
-  isTypeOf: (value) => value instanceof ValidationError,
-  fields: (t) => ({
-    field: t.exposeString('field'),
-  }),
+  fields: (t) => ({ field: t.exposeString('field') }),
 });
 
-const UserType = builder.objectRef<{ id: string; name: string }>('User').implement({
-  isTypeOf: (obj) => 'id' in obj && 'name' in obj,
+const User = builder.objectRef<{ id: string; name: string }>('User').implement({
+  isTypeOf: (obj) => typeof obj === 'object' && obj !== null && 'id' in obj && 'name' in obj,
   fields: (t) => ({
     id: t.exposeString('id'),
     name: t.exposeString('name'),
@@ -547,7 +541,7 @@ const UserType = builder.objectRef<{ id: string; name: string }>('User').impleme
 });
 
 const UserResult = builder.errorUnion('UserResult', {
-  types: [UserType, NotFoundError, ValidationError],
+  types: [User, NotFoundError, ValidationError],
 });
 
 builder.queryField('getUser', (t) =>
@@ -555,15 +549,24 @@ builder.queryField('getUser', (t) =>
     type: UserResult,
     args: { id: t.arg.string({ required: true }) },
     resolve: (_, { id }) => {
-      // Handles thrown errors
       if (!id) throw new ValidationError('ID required', 'id');
-      // Handles returned errors
       if (id === 'unknown') return new NotFoundError('User not found');
-
       return { id, name: 'User' };
     },
-  })
+  }),
 );
+```
+
+Clients can select the common message or the details of a particular failure:
+
+```graphql
+query {
+  getUser(id: "") {
+    ... on User { id name }
+    ... on Error { message }
+    ... on ValidationError { field }
+  }
+}
 ```
 
 #### Options

--- a/packages/plugin-validation/README.md
+++ b/packages/plugin-validation/README.md
@@ -1,8 +1,9 @@
 # Validation plugin
 
-A plugin for adding validation to field arguments, input object fields, and input types using modern validation libraries like [Zod](https://github.com/colinhacks/zod), [Valibot](https://valibot.dev), and [ArkType](https://arktype.io).
-
-This plugin provides a library-agnostic approach to validation by supporting any validation library that implements the [standard schema](https://standardschema.dev) interface, making it flexible and future-proof.
+Validate arguments and input objects before a field resolver runs. Attach a schema from any library
+that implements [Standard Schema](https://standardschema.dev), including Zod, Valibot, and ArkType.
+Validation can be asynchronous, and chained validators can transform the values passed to your resolver.
+If validation fails, the resolver does not run.
 
 ## Usage
 
@@ -21,6 +22,7 @@ npm install --save @pothos/plugin-validation arktype
 ### Setup
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import ValidationPlugin from '@pothos/plugin-validation';
 import { z } from 'zod'; // or your preferred validation library
 
@@ -34,6 +36,7 @@ builder.queryType({
       args: {
         // Validate individual arguments
         email: t.arg.string({
+          required: true,
           validate: z.string().email(),
         }),
       },
@@ -48,9 +51,12 @@ builder.queryType({
 The validation plugin supports validating inputs and arguments in several different ways:
 
 - **Argument validation**: `t.arg.string({ validate: schema })` or `t.arg.string().validate(schema)` - Validate individual arguments
-- **Validate all field args**: `t.field({ args, validate: schema, ... })` or `t.field({ args: t.validate(args), ... })` - Validate all arguments together
-- **Input type validation**: `builder.inputType({ validate: schema, ... })` or `builder.inputType({ ... }).validate(schema)` - Validate entire input objects
+- **Validate all field args**: `t.field({ args, validate: schema, ... })` or `t.field({ args: t.validate(args, schema), ... })` - Validate all arguments together
+- **Input type validation**: `builder.inputType('Input', { validate: schema, ... })` or `builder.inputType('Input', { ... }).validate(schema)` - Validate entire input objects
 - **Input field validation**: `t.string({ validate: schema })` or `t.string().validate(schema)` - Validate individual input type fields
+
+Each example below is independent. Reuse the setup imports and builder configuration, then use the
+example's query and input definitions in place of any earlier ones.
 
 ## Validation Patterns
 
@@ -64,9 +70,10 @@ builder.queryType({
     user: t.string({
       args: {
         email: t.arg.string({
+          required: true,
           validate: z.string().email(),
         }),
-        name: t.arg.string()
+        name: t.arg.string({ required: true })
           .validate(z.string().min(2).max(50)),
       },
       resolve: (_, args) => `User: ${args.name}`,
@@ -85,7 +92,7 @@ builder.queryType({
     processData: t.string({
       args: {
         // Convert comma-separated string to array
-        tags: t.arg.string()
+        tags: t.arg.string({ required: true })
           .validate(z.string().transform(str => str.split(',').map(s => s.trim()))),
       },
       resolve: (_, args) => {
@@ -98,7 +105,8 @@ builder.queryType({
 
 ### Validating all Field Arguments Together
 
-You can validate all arguments of a field together by passing a validation schema to the `t.field`
+Pass `validate` on the output field to check its arguments together. Optional GraphQL arguments
+can be omitted or explicitly `null`; use a schema that accepts both when those are valid inputs.
 
 ```typescript
 builder.queryType({
@@ -111,8 +119,8 @@ builder.queryType({
       // Ensure at least one contact method is provided
       validate: z
         .object({
-          email: z.string().optional(),
-          phone: z.string().optional(),
+          email: z.string().nullish(),
+          phone: z.string().nullish(),
         })
         .refine(
           (args) => !!args.phone || !!args.email,
@@ -126,7 +134,7 @@ builder.queryType({
 
 #### With transforms
 
-To transform all arguments together, you will need to use t.validate(args):
+Use `t.validate(args, schema)` to transform all arguments and infer the transformed resolver arguments:
 
 ```typescript
 builder.queryType({
@@ -137,8 +145,8 @@ builder.queryType({
         phone: t.arg.string(),
       },
         z.object({
-          email: z.string().optional(),
-          phone: z.string().optional(),
+          email: z.string().nullish(),
+          phone: z.string().nullish(),
         })
         .refine(
           (args) => !!args.phone || !!args.email,
@@ -169,8 +177,8 @@ Validate entire input objects with complex validation logic using either object 
 // Object syntax
 const UserInput = builder.inputType('UserInput', {
   fields: (t) => ({
-    name: t.string(),
-    age: t.int(),
+    name: t.string({ required: true }),
+    age: t.int({ required: true }),
   }),
   validate: z
     .object({
@@ -190,30 +198,30 @@ Transform entire input types:
 ```typescript
 const UserInput = builder.inputType('RawUserInput', {
   fields: (t) => ({
-    fullName: t.string(),
-    birthYear: t.string(),
+    fullName: t.string({ required: true }),
+    email: t.string({ required: true }),
   }),
 }).validate(
   z.object({
     fullName: z.string(),
-    birthYear: z.string(),
+    email: z.string().email(),
   }).transform(data => ({
     firstName: data.fullName.split(' ')[0],
     lastName: data.fullName.split(' ').slice(1).join(' '),
-    age: new Date().getFullYear() - parseInt(data.birthYear),
+    email: data.email.toLowerCase(),
   }))
 );
 
 builder.queryType({
   fields: (t) => ({
-    createUser: t.string({
+    previewUser: t.string({
       args: {
-        userData: t.arg({ type: UserInput }),
+        userData: t.arg({ type: UserInput, required: true }),
       },
       resolve: (_, args) => {
         // args.userData has transformed shape:
-        // { firstName: string, lastName: string, age: number }
-        return `Created user: ${args.userData.firstName} ${args.userData.lastName}`;
+        // { firstName: string, lastName: string, email: string }
+        return `User preview: ${args.userData.firstName} ${args.userData.lastName} <${args.userData.email}>`;
       },
     }),
   }),
@@ -228,6 +236,7 @@ Validate individual fields within input types:
 const UserInput = builder.inputType('UserInput', {
   fields: (t) => ({
     name: t.string({
+      required: true,
       validate: z.string().min(2).refine(
         (name) => name[0].toUpperCase() === name[0],
         { message: 'Name must be capitalized' }
@@ -244,34 +253,20 @@ Transform field values during validation:
 ```typescript
 const UserInput = builder.inputType('UserInput', {
   fields: (t) => ({
-    birthDate: t.string()
-      .validate(z.string().regex(/^\d{4}-\d{2}-\d{2}$/))
+    birthDate: t.string({ required: true })
+      .validate(z.iso.date())
       .validate(z.string().transform(str => new Date(str))),
   }),
 });
 ```
-
-## Supported Validation Libraries
-
-This plugin works with multiple validation libraries, giving you the flexibility to choose the one that best fits your needs:
-
-- **[Zod](https://zod.dev)** - TypeScript-first schema validation with static type inference
-- **[Valibot](https://valibot.dev)** - The open source schema library for TypeScript with bundle size, type safety and developer experience in mind
-- **[ArkType](https://arktype.io)** - TypeScript's 1:1 validator, optimized from editor to runtime
-- Any library implementing the [standard schema](https://standardschema.dev) interface
 
 
 ## Plugin Options
 
 ### 'validationError'
 
-The `validationError` option allows you to customize how validation errors are handled and formatted. This is useful for:
-
-- Customizing error messages for your application's needs
-- Logging validation failures for monitoring
-- Integrating with error tracking services
-- Providing context-specific error messages
-
+By default, failed validation throws `InputValidationError`, which contains Standard Schema issues
+with their messages and paths. Set `validationError` to return your own error or message.
 
 ```typescript
 const builder = new SchemaBuilder({
@@ -293,6 +288,10 @@ Your error handler can return:
 - **String**: Return a string message (will be wrapped in a PothosValidationError)
 - **Throw**: Throw an error directly
 
+To return validation failures as typed GraphQL results, see the
+[errors plugin integration](https://pothos-graphql.dev/docs/plugins/errors#with-validation-plugin). This requires
+`unsafelyHandleInputErrors`, because input validation runs before field authorization hooks.
+
 ### Validation Execution Order
 
 Understanding when and how validations are executed:
@@ -300,7 +299,7 @@ Understanding when and how validations are executed:
 1. **Input Field Validation**: Individual input fields are validated first
 2. **Input Type Validation**: Whole input object validation runs after field validation passes
 3. **Argument Validation**: Individual field arguments are validated
-4. **Field-Level Validation**: Cross-field validation with `t.validate()` runs last
+4. **Field-Level Validation**: The output field's `validate` option and `t.validate()` run last
 
 When there are multiple validations for the same field or type, they are executed in order, so that any transforms are applied before passing to the next schema.
 Validations for separate fields or arguments are executed in parallel, and their results are merged into a single set of issues.

--- a/packages/plugin-zod/README.md
+++ b/packages/plugin-zod/README.md
@@ -1,79 +1,77 @@
-# Zod Validation Plugin
+# Zod validation plugin
 
-A plugin for adding validation for field arguments based on
-[zod](https://github.com/colinhacks/zod). This plugin does not expose zod directly, but most of the
-options map closely to the validations available in zod.
+> The [validation plugin](https://pothos-graphql.dev/docs/plugins/validation) is now the recommended way to validate a
+>   schema. It supports zod alongside several other validation libraries. Use this page to maintain schemas that already use the zod plugin.
 
-## Usage
+The zod plugin validates field arguments and input fields with [zod](https://github.com/colinhacks/zod). You attach a `validate` option wherever you accept input (a single argument, a whole field's args, an input object, or one of its fields) and the plugin builds a zod validator that runs before your resolver. It does not re-export zod; instead `validate` takes a small options object whose keys map onto the zod methods you already know (`min`, `max`, `email`, `regex`, and so on), or an actual zod schema when you want the full API.
 
-### Install
-
-To use the zod plugin you will need to install both `zod` package and the zod plugin:
+## Install
 
 ```package-install
 npm install --save zod @pothos/plugin-zod
 ```
 
-### Setup
+## Setup
+
+Add the plugin, then optionally hand it a `validationError` callback to shape what clients see when validation fails.
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import ZodPlugin from '@pothos/plugin-zod';
+
 const builder = new SchemaBuilder({
   plugins: [ZodPlugin],
   zod: {
-    // optionally customize how errors are formatted
-    validationError: (zodError, args, context, info) => {
-      // the default behavior is to just throw the zod error directly
-      return zodError;
-    },
+    // Runs when validation fails. Return a string or Error, or throw your own.
+    // The default is to throw the raw ZodError.
+    validationError: (zodError, _args, _context, _info) => zodError.message,
   },
 });
+```
 
+`validationError` receives the `ZodError`, the field's `args`, the `context`, and the GraphQL `info`. Return a `string` (thrown as a `PothosValidationError`), return an `Error` instance (thrown as-is), or throw directly. Skip it to surface the raw zod error.
+
+Examples below are separate additions to this setup; query and mutation examples are alternatives.
+
+## Validating a single argument
+
+Add `validate` to any argument. The keys you pass are constraints for that argument's type; here an email string capped at 254 characters.
+
+```typescript
 builder.queryType({
   fields: (t) => ({
-    simple: t.boolean({
+    playerByEmail: t.boolean({
       args: {
-        // Validate individual args
         email: t.arg.string({
+          required: true,
           validate: {
             email: true,
+            maxLength: 254,
           },
         }),
-        phone: t.arg.string(),
       },
-      // Validate all args together
-      validate: (args) => !!args.phone || !!args.email,
       resolve: () => true,
     }),
   }),
 });
 ```
 
-## Options
+## Validating all arguments together
 
-`validationError`: (optional) A function that will be called when validation fails. The function
-will be passed the zod validation error, as well as the args, context and info objects. It can
-throw an error, or return an error message or custom Error instance.
-
-### Examples
-
-#### With custom message
+Cross-field rules ("at least one of these," "start before end") belong on the field's own `validate`, which receives the whole args object. It can be a function, or a `[function, options]` pair when you want a message.
 
 ```typescript
-builder.queryType({
+builder.mutationType({
   fields: (t) => ({
-    withMessage: t.boolean({
+    inviteToTeam: t.boolean({
       args: {
-        email: t.arg.string({
-          validate: {
-            email: [true, { message: 'invalid email address' }],
-          },
-        }),
+        email: t.arg.string({ validate: { email: true } }),
         phone: t.arg.string(),
       },
+      // Require at least one contact method across the two args.
       validate: [
-        (args) => !!args.phone || !!args.email,
-        { message: 'Must provide either phone number or email address' },
+        (args) => !!args.email || !!args.phone,
+        { message: 'Provide either an email address or a phone number' },
       ],
       resolve: () => true,
     }),
@@ -81,19 +79,36 @@ builder.queryType({
 });
 ```
 
-### Validating List
+## Custom messages
+
+Every constraint accepts either a bare value or a `[value, { message }]` pair. The pair form is a `Constraint`; the options object is passed straight to the underlying zod method, so anything zod's method accepts (a `message`, and a `path` for object refinements) works.
 
 ```typescript
-builder.queryType({
+// Inside a field builder callback:
+t.arg.int({
+  validate: {
+    min: [0, { message: 'jersey number cannot be negative' }],
+    max: [99, { message: 'jersey number must be under 100' }],
+    int: true,
+  },
+});
+```
+
+## Lists
+
+List arguments validate the list and its items in one options object. Constraints like `minLength` / `maxLength` / `length` apply to the array; `items` carries the constraints for each element.
+
+```typescript
+builder.mutationType({
   fields: (t) => ({
-    list: t.boolean({
+    setRoster: t.boolean({
       args: {
-        list: t.arg.stringList({
+        emails: t.arg.stringList({
           validate: {
+            maxLength: 12,
             items: {
               email: true,
             },
-            maxLength: 3,
           },
         }),
       },
@@ -103,43 +118,64 @@ builder.queryType({
 });
 ```
 
-### Using your own zod schemas
-
-If you just want to use a zod schema defined somewhere else, rather than using the validation
-options you can use the `schema` option:
+`items` also accepts a refinement function or a `[function, { message }]` pair. For example,
+inside a field's arguments:
 
 ```typescript
-builder.queryType({
-  fields: (t) => ({
-    list: t.boolean({
-      args: {
-        max5: t.arg.int({
-          validate: {
-            schema: zod.number().int().max(5),
-          },
-        }),
-      },
-      resolve: () => true,
-    }),
-  }),
+t.arg.stringList({
+  validate: {
+    items: [(value) => value.trim().length > 0, { message: 'Items must not be blank' }],
+  },
 });
 ```
 
-You can also validate all arguments together using a zod schema:
+## Input objects
+
+`validate` works the same on an input type and on its fields. Put per-field rules on each field, and cross-field rules on the input type itself, where the callback receives the whole object.
+
+```typescript
+const RegisterTeamInput = builder.inputType('RegisterTeamInput', {
+  fields: (t) => ({
+    name: t.string({ required: true, validate: { minLength: 3, maxLength: 40 } }),
+    contactEmail: t.string({ required: true, validate: { email: true } }),
+    backupEmail: t.string({ required: false, validate: { email: true } }),
+  }),
+  // Runs against the assembled input object.
+  validate: [
+    (input) => input.contactEmail !== input.backupEmail,
+    { message: 'backup email must differ from contact email' },
+  ],
+});
+```
+
+## Bring your own zod schema
+
+Pass an existing zod schema with the `schema` key to reuse its rules on an argument:
+
+```typescript
+import { z } from 'zod';
+
+t.arg.int({
+  validate: {
+    schema: z.number().int().max(5),
+  },
+});
+```
+
+...or on the whole field, validating every argument at once:
 
 ```typescript
 builder.queryType({
   fields: (t) => ({
-    simple: t.boolean({
+    validateCredentials: t.boolean({
       args: {
-        email: t.arg.string(),
-        phone: t.arg.string(),
+        email: t.arg.string({ required: true }),
+        password: t.arg.string({ required: true }),
       },
-      // Validate all args together using own zod schema
       validate: {
-        schema: zod.object({
-          email: zod.string().email(),
-          phone: zod.string(),
+        schema: z.object({
+          email: z.string().email(),
+          password: z.string().min(8),
         }),
       },
       resolve: () => true,
@@ -148,237 +184,112 @@ builder.queryType({
 });
 ```
 
-## API
+You can combine `schema` with the constraint keys. The plugin pipes your schema into the generated validator, so both run. Validation uses `parseAsync` before the resolver, so refinements may return a `Promise<boolean>`. The parsed value is passed to the resolver. This plugin does not infer transformed argument types; use the [validation plugin](https://pothos-graphql.dev/docs/plugins/validation) when transforms change the resolver argument shape.
 
-### On Object fields (for validating field arguments)
+## Constraint reference
 
-- `validate`: `Refinement<T>` | `Refinement<T>[]` | `ValidationOptions`.
+`validate` accepts a bare refinement function, an array of them, or an options object. The options object always allows these keys:
 
-### On InputObjects (for validating all fields of an input object)
+| Key | Type | Purpose |
+| --- | --- | --- |
+| `type` | `'number' \| 'bigint' \| 'boolean' \| 'date' \| 'string' \| 'object' \| 'array'` | Pin the base zod type. See [How it works](#how-it-works) for why this matters. |
+| `refine` | function or `[function, { message?, path? }]`, or an array of either | A predicate handed to zod's `refine`. Receives the validated value; returns `boolean` or `Promise<boolean>`. |
+| `schema` | `ZodType` | A zod schema piped into the generated validator. |
 
-- `validate`: `Refinement<T>` | `Refinement<T>[]` | `ValidationOptions`.
+The remaining keys depend on the field's type. Each value is a `Constraint`, either a bare value or `[value, { message }]`:
 
-### On arguments or input object fields (for validating a specific input field or argument)
+| Type | Additional keys |
+| --- | --- |
+| Number | `min`, `max`, `int`, `positive`, `nonnegative`, `negative`, `nonpositive` |
+| String | `minLength`, `maxLength`, `length`, `email`, `url`, `uuid`, `regex` |
+| Array | `minLength`, `maxLength`, `length`, `items` (nested validation options or a refinement for each element) |
+| BigInt | *(base keys only)* |
+| Boolean | *(base keys only)* |
+| Date | *(base keys only)* |
+| Object | *(base keys only)* |
 
-- `validate`: `Refinement<T>` | `Refinement<T>[]` | `ValidationOptions`.
+## How it works
 
-### `Refinement`
-
-A `Refinement` is a function that will be passed to the `zod` `refine` method. It receives the args
-object, input object, or value of the specific field the refinement is defined on. It should return
-a `boolean` or `Promise<boolean>`.
-
-`Refinement`s can either be just a function: `(val) => isValid(val)`, or an array with the function,
-and an options object like: `[(val) => isValid(val), { message: 'field should be valid' }]`.
-
-The options object may have a `message` property, and if the type being validated is an object, it
-can also include a `path` property with an array of strings indicating the path of the field in the
-object being validated. See the zod docs on `refine` for more details.
-
-### `ValidationOptions`
-
-The validation options available depend on the type being validated. Each property of
-`ValidationOptions` can either be a value specific to the constraint, or an array with the value,
-and the options passed to the underlying zod method. This options object can be used to set a custom
-error message:
+Each argument and input field builds its own zod validator from its `validate` options. At runtime the plugin has no access to the JavaScript type behind a GraphQL type, so when you pass plain constraints it builds a union of every base type that could satisfy them. A lone `maxLength`, for example, fits both strings and arrays:
 
 ```typescript
-{
-  validate: {
-    max: [10, { message: 'should not be more than 10' }],
-    int: true,
-  }
-}
+z.union([z.string().max(5), z.array(z.unknown()).max(5)]);
 ```
 
-#### Number
+An `email` constraint only fits strings, so the union collapses to one member. When the argument is not required, the whole validator is wrapped `.optional().nullable()` rather than folded into the union.
 
-- `type`?: `'number'`
-- `refine`?: `Refinement<number> | Refinement<number>[]`
-- `min`?: `Constraint<number>`
-- `max`?: `Constraint<number>`
-- `positive`?: `Constraint<boolean>`
-- `nonnegative`?: `Constraint<boolean>`
-- `negative`?: `Constraint<boolean>`
-- `nonpositive`?: `Constraint<boolean>`
-- `int`?: `Constraint<boolean>`
-- `schema`?: `ZodSchema<number>`
-
-#### BigInt
-
-- `type`?: `'bigint'`
-- `refine`?: `Refinement<bigint> | Refinement<bigint>[]`
-- `schema`?: `ZodSchema<bigint>`
-
-#### Boolean
-
-- `type`?: `'boolean'`
-- `refine`?: `Refinement<boolean> | Refinement<boolean>[]`
-- `schema`?: `ZodSchema<boolean>`
-
-#### Date
-
-- `type`?: `'boolean'`
-- `refine`?: `Refinement<boolean> | Refinement<boolean>[]`
-- `schema`?: `ZodSchema<Date>`
-
-#### String
-
-- `type`?: `'string'`;
-- `refine`?: `Refinement<string> | Refinement<string>[]`
-- `minLength`?: `Constraint<number>`
-- `maxLength`?: `Constraint<number>`
-- `length`?: `Constraint<number>`
-- `url`?: `Constraint<boolean>`
-- `uuid`?: `Constraint<boolean>`
-- `email`?: `Constraint<boolean>`
-- `regex`?: `Constraint<RegExp>`
-- `schema`?: `ZodSchema<string>`
-
-#### Object
-
-- `type`?: `'object'`;
-- `refine`?: `Refinement<T> | Refinement<T>[]`
-- `schema`?: `ZodSchema<Ts>`
-
-#### Array
-
-- `type`?: `'array'`;
-- `refine`?: `Refinement<T[]> | Refinement<T[]>[]`
-- `minLength`?: `Constraint<number>`
-- `maxLength`?: `Constraint<number>`
-- `length`?: `Constraint<number>`
-- `items`?: `ValidationOptions<T> | Refinement<T>`
-- `schema`?: `ZodSchema<T[]>`
-
-### How it works
-
-Each arg on an object field, and each field on an input type with validation will build its own zod
-validator. These validators will be a union of all potential types that can apply the validations
-defined for that field. For example, if you define an optional field with a `maxLength` validator,
-it will create a zod schema that looks something like:
+Set `type` to skip the guessing and pin one base type:
 
 ```typescript
-zod.union([zod.null(), zod.undefined(), zod.array().maxLength(5), zod.string().maxLength(5)]);
+// { validate: { type: 'string', maxLength: 5 } } builds:
+z.string().max(5);
 ```
 
-If you set an `email` validation instead the schema might look like:
+Three cases sidestep the union entirely:
+
+- **Input object** args and fields always validate with `z.looseObject(...)`.
+- **List** args and fields always validate with `.array()`.
+- **Refinement-only** validators (a bare function, or an options object with just `refine` and/or `schema`) validate against `z.unknown()`, since no constraint narrows the type.
+
+A `schema` is piped into whatever the plugin generates (`yourSchema.pipe(generated)`), so your schema and the constraints both run.
+
+
+
+## Sharing schemas with client code
+
+To reuse a validator on the client, write it as an ordinary zod schema in a shared module, then attach it with `schema`:
 
 ```typescript
-zod.union([zod.null(), zod.undefined(), zod.string().email()]);
+// shared/validators.ts
+import { z } from 'zod';
+
+export const jerseyNumber = z.number().int().min(0).max(99);
 ```
 
-At runtime, we don't know anything about the types being used by your schema, we can't infer the
-expected js type from the type definition, so the best we can do is limit the valid types based on
-what validations they support. The `type` validation allows explicitly validating the `type` of a
-field to be one of the base types supported by zod:
-
 ```typescript
-// field
-{
-validate: {
-  type: 'string',
-  maxLength: 5
-}
-// generated
-zod.union([zod.null(), zod.undefined(), zod.string().maxLength(5)]);
-```
-
-There are a few exceptions to the above:
-
-1. args and input fields that are `InputObject`s always use `zod.object()` rather than creating a
-   union of potential types.
-
-1. args and input fields that are list types always use `zod.array()`.
-
-1. If you only include a `refine` validation (or just pass a function directly to validate) we will
-   just use `zod`s unknown validator instead:
-
-```typescript
-// field
-{
-  validate: (val) => isValid(val),
-}
-// generated
-zod.union([zod.null(), zod.undefined(), zod.unknown().refine((val) => isValid(val))]);
-```
-
-If the validation options include a `schema` that schema will be used as an intersection with the
-generated validator:
-
-```typescript
-// field
-{
-  validate: {
-    int: true,
-    schema: zod.number().max(10),
-}
-// generated
-zod.union([zod.null(), zod.undefined(),  zod.intersection(zod.number().max(10), zod.number().int())]);
-```
-
-### Sharing schemas with client code
-
-The easiest way to share validators is to use them to define schemas for your fields in an external
-file using the normal zod APIs, and then attaching those to your fields using the `schema` option.
-
-```typescript
-// shared
-import { ValidationOptions } from '@pothos/plugin-zod';
-
-const numberValidation = zod.number().max(5);
-
 // server
-builder.queryType({
-  fields: (t) => ({
-    example: t.boolean({
-      args: {
-        num: t.arg.int({
-          validate: {
-            schema: numberValidation,
-          }
-        }),
-      },
-      resolve: () => true,
-    }),
-  });
-});
+import { jerseyNumber } from './shared/validators';
 
+t.arg.int({
+  validate: { schema: jerseyNumber },
+});
+```
+
+```typescript
 // client
-numberValidator.parse(3) // pass
-numberValidator.parse('3') // fail
+import { jerseyNumber } from './shared/validators';
+
+jerseyNumber.parse(23); // pass
+jerseyNumber.parse(100); // throws
 ```
 
-You can also use the `createZodSchema` helper from the plugin directly to create zod Schemas from an
-options object:
+If you would rather share the constraint options object, the plugin exports `createZodSchema` to turn one into a zod schema on demand. Type the options with the exported `ValidationOptions`:
 
 ```typescript
-// shared
-import { ValidationOptions } from '@pothos/plugin-zod';
+// shared/validators.ts
+import type { ValidationOptions } from '@pothos/plugin-zod';
 
-const numberValidation: ValidationOptions<number> = {
-  max: 5,
+export const jerseyNumberOptions: ValidationOptions<number> = {
+  min: 0,
+  max: 99,
+  int: true,
 };
+```
 
+```typescript
 // server
-builder.queryType({
-  fields: (t) => ({
-    example: t.boolean({
-      args: {
-        num: t.arg.int({
-          validate: numberValidation,
-        }),
-      },
-      resolve: () => true,
-    }),
-  });
-});
+import { jerseyNumberOptions } from './shared/validators';
 
+t.arg.int({ validate: jerseyNumberOptions });
+```
+
+```typescript
 // client
 import { createZodSchema } from '@pothos/plugin-zod';
+import { jerseyNumberOptions } from './shared/validators';
 
-const validator = createZodSchema(numberValidator);
+const validator = createZodSchema(jerseyNumberOptions);
 
-validator.parse(3) // pass
-validator.parse('3') // fail
+validator.parse(23); // pass
+validator.parse(100); // throws
 ```

--- a/website/content/docs/plugins/errors.mdx
+++ b/website/content/docs/plugins/errors.mdx
@@ -3,8 +3,9 @@ title: Errors plugin
 description: Errors plugin docs for Pothos
 ---
 
-A plugin for easily including error types in your GraphQL schema and hooking up error types to
-resolvers
+Represent expected failures as GraphQL result unions. Register error classes as object types, then
+list them in a field's `errors` option. The plugin catches matching errors and returns an error
+object that clients can query with fragments. Errors that do not match still become GraphQL errors.
 
 ## Usage
 
@@ -14,13 +15,10 @@ resolvers
 npm install --save @pothos/plugin-errors
 ```
 
-### Setup
-
-Ensure that the target in your `tsconfig.json` is set to `es6` or higher (default is `es3`).
-
 ### Example Usage
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import ErrorsPlugin from '@pothos/plugin-errors';
 const builder = new SchemaBuilder({
   plugins: [ErrorsPlugin],
@@ -47,7 +45,7 @@ builder.queryType({
         name: t.arg.string({ required: false }),
       },
       resolve: (parent, { name }) => {
-        if (name.slice(0, 1) !== name.slice(0, 1).toUpperCase()) {
+        if (name && name.slice(0, 1) !== name.slice(0, 1).toUpperCase()) {
           throw new Error('name must be capitalized');
         }
 
@@ -66,7 +64,7 @@ type Error {
 }
 
 type Query {
-  hello(name: String!): QueryHelloResult
+  hello(name: String): QueryHelloResult
 }
 
 union QueryHelloResult = Error | QueryHelloSuccess
@@ -103,38 +101,30 @@ errors plugin will automatically resolve to the corresponding error object type.
 - `directResult`: Sets the default for `directResult` option on fields (only affects non-list
   fields)
 - `onResolvedError`: A callback function that is called when an error is handled by the plugin
-- `defaultResultOptions`: Sets the defaults for `result` option on fields.
-  - `name`: Function to generate a custom name on the generated result types.
-    ```ts
-    export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
-      plugins: [ErrorPlugin, ValidationPlugin],
-      errors: {
-        defaultTypes: [Error],
-        defaultResultOptions: {
-          name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
-        },
-        defaultUnionOptions: {
-          name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
-        },
-      },
-    });
-    ```
-- `defaultUnionOptions`: Sets the defaults for `result` option on fields.
-  - `name`: Function to generate a custom name on the generated union types.
-    ```ts
-    export const builderWithCustomErrorTypeNames = new SchemaBuilder<{}>({
-      plugins: [ErrorPlugin, ValidationPlugin],
-      errors: {
-        defaultTypes: [Error],
-        defaultResultOptions: {
-          name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
-        },
-        defaultUnionOptions: {
-          name: ({ parentTypeName, fieldName }) => `${fieldName}_Custom`,
-        },
-      },
-    });
-    ```
+- `defaultResultOptions`: Defaults for generated success object types.
+- `defaultUnionOptions`: Defaults for generated result union types.
+- `defaultItemResultOptions`: Defaults for per-item success object types.
+- `defaultItemUnionOptions`: Defaults for per-item result union types.
+- `unsafelyHandleInputErrors`: Also catch input mapping and validation errors; see
+  [With validation plugin](#with-validation-plugin).
+
+The four type-options objects accept a `name` function receiving `{ parentTypeName, fieldName }`.
+Use distinct names for success objects and unions:
+
+```typescript
+const builder = new SchemaBuilder({
+  plugins: [ErrorsPlugin],
+  errors: {
+    defaultTypes: [Error],
+    defaultResultOptions: {
+      name: ({ parentTypeName, fieldName }) => `${parentTypeName}_${fieldName}_Success`,
+    },
+    defaultUnionOptions: {
+      name: ({ parentTypeName, fieldName }) => `${parentTypeName}_${fieldName}_Result`,
+    },
+  },
+});
+```
 
 ### Options on Fields
 
@@ -145,12 +135,12 @@ errors plugin will automatically resolve to the corresponding error object type.
 - `result`: An options object for result object type. Can include any normal object type options,
   and `name` option for setting a custom name for the result type.
 - `dataField`: An options object for the data field on the result object. This field will be named
-  `data` by default, but can be written by passing a custom `name` option.
+  `data` by default, but can be renamed by passing a custom `name` option.
 - `directResult`: Boolean, can only be set to true for non-list fields. This will directly include
   the fields type in the union rather than creating an intermediate Result object type. This will
   throw at build time if the type is not an object type.
 
-### Recommended Usage
+### A shared Error interface
 
 1. Set up an Error interface
 2. Create a BaseError object type
@@ -163,9 +153,10 @@ more specialized error types, they can just add a fragment for the errors it car
 pattern should also make it easier to make future changes without unexpected breaking changes for
 your clients.
 
-The following is a small example of this pattern:
+This is a separate setup from the first example:
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import ErrorsPlugin from '@pothos/plugin-errors';
 const builder = new SchemaBuilder({
   plugins: [ErrorsPlugin],
@@ -242,31 +233,42 @@ builder.queryType({
 
 ### With validation plugin
 
-To handle validation errors you will need to enable the `unsafelyHandleInputErrors` option in the
-errors plugin options. This will allow the errors plugin to catch errors thrown by the validation plugin.
-This setting is unsafe because it wraps and catches errors at a higher level which will allow you to
-bypass other plugin hooks like the `auth` plugin.  This enables you to return structured error responses for
-validation issues which happen BEFORE auth checks are executed, but this also means that those auth checks won't be run.
+The validation plugin runs before field resolution. Set `unsafelyHandleInputErrors: true` to
+return its failures as typed results. A validation failure then returns without running field
+authorization hooks, so only enable this when those error details may be returned before authorization.
 
-Once you enable the `unsafelyHandleInputErrors` option, you can define types for an InputValidationError
-(or any custom error you use in the validation plugin), the same way you would for any other error type. Below
-is a simple example of how this can be done, but the specifics of how you structure your error types are left up to you.
+This standalone example registers the validation error and its issues. Valid input reaches the
+resolver; invalid input returns `InputValidationError`.
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
+import ErrorsPlugin from '@pothos/plugin-errors';
+import ValidationPlugin, {
+  InputValidationError,
+  type StandardSchemaV1,
+} from '@pothos/plugin-validation';
+import { z } from 'zod';
+
+const builder = new SchemaBuilder({
+  plugins: [ErrorsPlugin, ValidationPlugin],
+  errors: { unsafelyHandleInputErrors: true },
+});
+
 const InputValidationIssue = builder
   .objectRef<StandardSchemaV1.Issue>('InputValidationIssue')
   .implement({
     fields: (t) => ({
       message: t.exposeString('message'),
       path: t.stringList({
-        resolve: (issue) => issue.path?.map((p) => String(p)),
+        resolve: (issue) => issue.path?.map((part) =>
+          String(typeof part === 'object' ? part.key : part),
+        ) ?? [],
       }),
     }),
   });
 
 builder.objectType(InputValidationError, {
   name: 'InputValidationError',
-  interfaces: [ErrorInterface],
   fields: (t) => ({
     issues: t.field({
       type: [InputValidationIssue],
@@ -275,6 +277,7 @@ builder.objectType(InputValidationError, {
   }),
 });
 
+builder.queryType();
 builder.queryField('fieldWithValidation', (t) =>
   t.boolean({
     errors: {
@@ -282,6 +285,7 @@ builder.queryField('fieldWithValidation', (t) =>
     },
     args: {
       string: t.arg.string({
+        required: true,
         validate: z.string().min(3, 'Too short'),
       }),
     },
@@ -294,9 +298,9 @@ Example query:
 
 ```graphql
 query {
-  validation(string: "a") {
+  fieldWithValidation(string: "a") {
     __typename
-    ... on QueryValidationSuccess {
+    ... on QueryFieldWithValidationSuccess {
       data
     }
     ... on InputValidationError {
@@ -317,11 +321,10 @@ BEFORE the dataloader plugin in your plugin list.
 If a field with `errors` returns a `loadableObject`, or `loadableNode` the errors plugin will now
 catch errors thrown when loading ids returned by the `resolve` function.
 
-If the field is a `List` field, errors that occur when resolving objects from `ids` will not be
-handled by the errors plugin. This is because those errors are associated with each item in the list
-rather than the list field itself. In the future, the dataloader plugin may have an option to throw
-an error at the field level if any items can not be loaded, which would allow the error plugin to
-handle these types of errors.
+For a list of loadable IDs, loading happens per item. A load failure is not a whole-field failure,
+so the field's `errors` option does not catch it. Use explicit error unions when you need typed
+results for individual loads; see [List item errors](#list-item-errors) for the separate
+`itemErrors` handling of errors returned or thrown while iterating the resolver's list.
 
 ### With the prisma plugin
 
@@ -337,102 +340,88 @@ plugin
 
 ### List item errors
 
-For fields that return lists, you can specify `itemErrors` to wrap the list items in a union type so
-that errors can be handled per-item rather than replacing the whole list with an error.
-
-The `itemErrors` options are exactly the same as the `errors` options, but they are applied to each
-item in the list rather than the whole list.
+Use `itemErrors` on a list field to wrap each item in its own result union. It accepts the same
+options as `errors`. The following addition to the shared Error interface example yields one success, then throws an error. The plugin returns that error as the final item:
 
 ```typescript
-builder.queryType({
-  fields: (t) => ({
-    listWithErrors: t.string({
-      itemErrors: {},
-      resolve: (parent, { name }) => {
-        return [
-          1,
-          2,
-          new Error('Boom'),
-          3,
-        ]
-      },
-    }),
+builder.queryField('listWithErrors', (t) =>
+  t.intList({
+    nullable: false,
+    itemErrors: {},
+    resolve: function* () {
+      yield 1;
+      throw new Error('Boom');
+    },
   }),
-});
+);
 ```
-
-This will produce a GraphQL schema that looks like:
 
 ```graphql
 type Query {
   listWithErrors: [QueryListWithErrorsItemResult!]!
 }
 
-union QueryListWithErrorsItemResult = Error | QueryListWithErrorsItemSuccess
+union QueryListWithErrorsItemResult = BaseError | QueryListWithErrorsItemSuccess
 
 type QueryListWithErrorsItemSuccess {
   data: Int!
 }
 ```
 
-Item errors also works with both sync and async iterators (in graphql@>=17, or other executors that support the @stream directive):
+At runtime, `itemErrors` also handles returned error instances. If the resolver's ordinary return
+type does not include errors, use an explicit error union for a list that mixes returned data and errors.
+
+The plugin also wraps sync and async iterators. A yielded error becomes an error item; a thrown
+error becomes the final item and closes the iterator. Async iterable execution requires an executor
+that supports it, such as GraphQL 17.
+
+Combine `errors: {}` with `itemErrors: {}` to handle a whole-field failure as well. The outer
+`QueryListWithErrorsResult` union contains `BaseError` and `QueryListWithErrorsSuccess`; the latter's
+`data` field contains the list of `QueryListWithErrorsItemResult` items.
+
+For an async source, the same field can use an async generator. Replace its resolver with:
 
 ```typescript
-builder.queryType({
-  fields: (t) => ({
-    asyncListWithErrors: t.string({
-      itemErrors: {},
-      resolve: async function* () {
+resolve: async function* () {
+  yield 1;
+  throw new Error('The next item could not be loaded');
+},
+```
+
+This requires an executor that supports async iterables. A thrown error ends the iterator;
+use an explicit error union when the source needs to return an error item and continue.
+
+To handle both a failure before the list is returned and a failure during iteration, replace
+`listWithErrors` with:
+
+```typescript
+builder.queryField('listWithErrors', (t) =>
+  t.intList({
+    nullable: false,
+    errors: {},
+    itemErrors: {},
+    args: { failBeforeLoad: t.arg.boolean() },
+    resolve: (_parent, { failBeforeLoad }) => {
+      if (failBeforeLoad) throw new Error('Could not load the list');
+      return (function* () {
         yield 1;
-        yield 2;
-        yield new Error('Boom');
-        yield 4;
-        throw new Error('Boom');
-      },
-    }),
+        throw new Error('Could not load the next item');
+      })();
+    },
   }),
-});
+);
 ```
 
-When an error is yielded, an error result will be added into the list, if the generator throws an error,
-the error will be added to the list, and no more results will be returned for that field
-
-
-You can also use the `errors` and `itemErrors` options together:
-
-```typescript
-
-builder.queryType({
-  fields: (t) => ({
-    listWithErrors: t.string({
-      itemErrors: {},
-      errors: {},
-      resolve: (parent, { name }) => {
-        return [
-          1,
-          new Error('Boom'),
-          3,
-        ]
-    }),
-  }),
-});
-```
-
-This will produce a GraphQL schema that looks like:
+The generated result types are:
 
 ```graphql
-
-type Query {
-  listWithErrors: [QueryListWithErrorsResult!]!
-}
-
-union QueryListWithErrorsResult = Error | QueryListWithErrorsSuccess
+union QueryListWithErrorsResult = BaseError | QueryListWithErrorsSuccess
 
 type QueryListWithErrorsSuccess {
   data: [QueryListWithErrorsItemResult!]!
 }
 
-union QueryListWithErrorsItemResult = Error | QueryListWithErrorsItemSuccess
+union QueryListWithErrorsItemResult = BaseError | QueryListWithErrorsItemSuccess
 
 type QueryListWithErrorsItemSuccess {
   data: Int!
@@ -444,17 +433,22 @@ type QueryListWithErrorsItemSuccess {
 Use `t.errorUnionField` and `t.errorUnionListField` to directly specify all members of the returned union type,
 including multiple success types and error types.
 
+The following additions use the `Error` class registered as `BaseError` in the shared-interface
+example. Each success shape has an `isTypeOf` check so Pothos can distinguish plain objects.
+The resolver bodies simulate create and update outcomes to demonstrate the union branches;
+replace them with your application's persistence logic.
+
 ```typescript
-const CreateResult = builder.objectRef<{ id: string; created: true }>('CreateResult').implement({
-  isTypeOf: (obj) => 'created' in obj,
+const CreateResult = builder.objectRef<{ id: string; created: boolean }>('CreateResult').implement({
+  isTypeOf: (obj) => typeof obj === 'object' && obj !== null && 'created' in obj,
   fields: (t) => ({
     id: t.exposeString('id'),
     created: t.exposeBoolean('created'),
   }),
 });
 
-const UpdateResult = builder.objectRef<{ id: string; updated: true }>('UpdateResult').implement({
-  isTypeOf: (obj) => 'updated' in obj,
+const UpdateResult = builder.objectRef<{ id: string; updated: boolean }>('UpdateResult').implement({
+  isTypeOf: (obj) => typeof obj === 'object' && obj !== null && 'updated' in obj,
   fields: (t) => ({
     id: t.exposeString('id'),
     updated: t.exposeBoolean('updated'),
@@ -464,21 +458,23 @@ const UpdateResult = builder.objectRef<{ id: string; updated: true }>('UpdateRes
 builder.mutationType({
   fields: (t) => ({
     modifyUser: t.errorUnionField({
-      types: [CreateResult, UpdateResult, ValidationError],
-      resolve: (parent, { action, name }) => {
-        if (name.length < 3) return new ValidationError('Name too short');
-        if (action === 'create') return { id: '123', created: true };
-        return { id: '123', updated: true };
+      types: [CreateResult, UpdateResult, Error],
+      args: {
+        id: t.arg.id({ required: true }),
+        name: t.arg.string({ required: true }),
+        create: t.arg.boolean({ required: true }),
+      },
+      resolve: (parent, { id, name, create }) => {
+        if (name.length < 3) return new Error('Name too short');
+        return create ? { id: String(id), created: true } : { id: String(id), updated: true };
       },
     }),
     processUsers: t.errorUnionListField({
-      types: [CreateResult, UpdateResult, ValidationError],
-      resolve: (parent, { operations }) =>
-        operations.map(op =>
-          op.invalid ? new ValidationError('Invalid') :
-          op.action === 'create' ? { id: op.id, created: true } :
-          { id: op.id, updated: true }
-        ),
+      types: [CreateResult, UpdateResult, Error],
+      args: { ids: t.arg.idList({ required: true }) },
+      resolve: (parent, { ids }) => ids.map((id) =>
+        id === 'unknown' ? new Error('User not found') : { id: String(id), updated: true },
+      ),
     }),
   }),
 });
@@ -486,43 +482,48 @@ builder.mutationType({
 
 #### Type resolution
 
-Union members are resolved using standard Pothos type resolution. You have three options:
+Union members use standard Pothos type resolution. Registering an error class with
+`builder.objectType` provides an `instanceof` check. Plain object types can supply `isTypeOf`, as
+above, or you can pass a custom `resolveType` in the field's `union` options. Error instances matched
+by the plugin are resolved before that custom callback.
 
-**Class-based types** (most error types) - automatically resolved via `instanceof` checks:
-```typescript
-class ValidationError extends Error { ... }
-builder.objectType(ValidationError, { name: 'ValidationError', fields: ... });
-// No isTypeOf needed - uses instanceof ValidationError
-```
+For example, this alternative field resolves its success branches explicitly using the
+`CreateResult` and `UpdateResult` types above:
 
-**`isTypeOf` function** - for plain object types:
 ```typescript
-const CreateResult = builder.objectRef<{ id: string }>('CreateResult').implement({
-  isTypeOf: (obj) => 'created' in obj,
-  fields: ...
-});
-```
-
-**Custom `resolveType` on union** - for complex resolution logic:
-```typescript
-t.errorUnionField({
-  types: [CreateResult, UpdateResult, ValidationError],
-  union: {
-    resolveType: (value) => {
-      if (value instanceof ValidationError) return 'ValidationError';
-      if ('created' in value) return 'CreateResult';
-      return 'UpdateResult';
+builder.mutationField('previewUserChange', (t) =>
+  t.errorUnionField({
+    types: [CreateResult, UpdateResult, Error],
+    args: { create: t.arg.boolean({ required: true }) },
+    union: {
+      resolveType: (value) => 'created' in value ? 'CreateResult' : 'UpdateResult',
     },
-  },
-  resolve: ...
-});
+    resolve: (_parent, { create }) =>
+      create ? { id: '1', created: true } : { id: '1', updated: true },
+  }),
+);
 ```
+
+Matched error instances use the plugin's error map, so this callback only needs to distinguish
+the success values.
 
 ### Using `builder.errorUnion`
 
 You can use `builder.errorUnion` to manually construct an error union type that can be used with any field.  Fields returning an error union will automatically handle returned or thrown errors.
 
+This addition to the shared-interface example distinguishes a missing user from invalid input.
+Both error types implement the shared `Error` interface, and validation failures expose the field
+that needs correction:
+
 ```typescript
+class NotFoundError extends Error {}
+
+class ValidationError extends Error {
+  constructor(message: string, public field: string) {
+    super(message);
+  }
+}
+
 builder.objectType(NotFoundError, {
   name: 'NotFoundError',
   interfaces: [ErrorInterface],
@@ -531,14 +532,11 @@ builder.objectType(NotFoundError, {
 builder.objectType(ValidationError, {
   name: 'ValidationError',
   interfaces: [ErrorInterface],
-  isTypeOf: (value) => value instanceof ValidationError,
-  fields: (t) => ({
-    field: t.exposeString('field'),
-  }),
+  fields: (t) => ({ field: t.exposeString('field') }),
 });
 
-const UserType = builder.objectRef<{ id: string; name: string }>('User').implement({
-  isTypeOf: (obj) => 'id' in obj && 'name' in obj,
+const User = builder.objectRef<{ id: string; name: string }>('User').implement({
+  isTypeOf: (obj) => typeof obj === 'object' && obj !== null && 'id' in obj && 'name' in obj,
   fields: (t) => ({
     id: t.exposeString('id'),
     name: t.exposeString('name'),
@@ -546,7 +544,7 @@ const UserType = builder.objectRef<{ id: string; name: string }>('User').impleme
 });
 
 const UserResult = builder.errorUnion('UserResult', {
-  types: [UserType, NotFoundError, ValidationError],
+  types: [User, NotFoundError, ValidationError],
 });
 
 builder.queryField('getUser', (t) =>
@@ -554,15 +552,24 @@ builder.queryField('getUser', (t) =>
     type: UserResult,
     args: { id: t.arg.string({ required: true }) },
     resolve: (_, { id }) => {
-      // Handles thrown errors
       if (!id) throw new ValidationError('ID required', 'id');
-      // Handles returned errors
       if (id === 'unknown') return new NotFoundError('User not found');
-
       return { id, name: 'User' };
     },
-  })
+  }),
 );
+```
+
+Clients can select the common message or the details of a particular failure:
+
+```graphql
+query {
+  getUser(id: "") {
+    ... on User { id name }
+    ... on Error { message }
+    ... on ValidationError { field }
+  }
+}
 ```
 
 #### Options

--- a/website/content/docs/plugins/validation.mdx
+++ b/website/content/docs/plugins/validation.mdx
@@ -3,9 +3,10 @@ title: Validation plugin
 description: Validation plugin docs for Pothos
 ---
 
-A plugin for adding validation to field arguments, input object fields, and input types using modern validation libraries like [Zod](https://github.com/colinhacks/zod), [Valibot](https://valibot.dev), and [ArkType](https://arktype.io).
-
-This plugin provides a library-agnostic approach to validation by supporting any validation library that implements the [standard schema](https://standardschema.dev) interface, making it flexible and future-proof.
+Validate arguments and input objects before a field resolver runs. Attach a schema from any library
+that implements [Standard Schema](https://standardschema.dev), including Zod, Valibot, and ArkType.
+Validation can be asynchronous, and chained validators can transform the values passed to your resolver.
+If validation fails, the resolver does not run.
 
 ## Usage
 
@@ -24,6 +25,7 @@ npm install --save @pothos/plugin-validation arktype
 ### Setup
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import ValidationPlugin from '@pothos/plugin-validation';
 import { z } from 'zod'; // or your preferred validation library
 
@@ -37,6 +39,7 @@ builder.queryType({
       args: {
         // Validate individual arguments
         email: t.arg.string({
+          required: true,
           validate: z.string().email(),
         }),
       },
@@ -51,9 +54,12 @@ builder.queryType({
 The validation plugin supports validating inputs and arguments in several different ways:
 
 - **Argument validation**: `t.arg.string({ validate: schema })` or `t.arg.string().validate(schema)` - Validate individual arguments
-- **Validate all field args**: `t.field({ args, validate: schema, ... })` or `t.field({ args: t.validate(args), ... })` - Validate all arguments together
-- **Input type validation**: `builder.inputType({ validate: schema, ... })` or `builder.inputType({ ... }).validate(schema)` - Validate entire input objects
+- **Validate all field args**: `t.field({ args, validate: schema, ... })` or `t.field({ args: t.validate(args, schema), ... })` - Validate all arguments together
+- **Input type validation**: `builder.inputType('Input', { validate: schema, ... })` or `builder.inputType('Input', { ... }).validate(schema)` - Validate entire input objects
 - **Input field validation**: `t.string({ validate: schema })` or `t.string().validate(schema)` - Validate individual input type fields
+
+Each example below is independent. Reuse the setup imports and builder configuration, then use the
+example's query and input definitions in place of any earlier ones.
 
 ## Validation Patterns
 
@@ -67,9 +73,10 @@ builder.queryType({
     user: t.string({
       args: {
         email: t.arg.string({
+          required: true,
           validate: z.string().email(),
         }),
-        name: t.arg.string()
+        name: t.arg.string({ required: true })
           .validate(z.string().min(2).max(50)),
       },
       resolve: (_, args) => `User: ${args.name}`,
@@ -88,7 +95,7 @@ builder.queryType({
     processData: t.string({
       args: {
         // Convert comma-separated string to array
-        tags: t.arg.string()
+        tags: t.arg.string({ required: true })
           .validate(z.string().transform(str => str.split(',').map(s => s.trim()))),
       },
       resolve: (_, args) => {
@@ -101,7 +108,8 @@ builder.queryType({
 
 ### Validating all Field Arguments Together
 
-You can validate all arguments of a field together by passing a validation schema to the `t.field`
+Pass `validate` on the output field to check its arguments together. Optional GraphQL arguments
+can be omitted or explicitly `null`; use a schema that accepts both when those are valid inputs.
 
 ```typescript
 builder.queryType({
@@ -114,8 +122,8 @@ builder.queryType({
       // Ensure at least one contact method is provided
       validate: z
         .object({
-          email: z.string().optional(),
-          phone: z.string().optional(),
+          email: z.string().nullish(),
+          phone: z.string().nullish(),
         })
         .refine(
           (args) => !!args.phone || !!args.email,
@@ -129,7 +137,7 @@ builder.queryType({
 
 #### With transforms
 
-To transform all arguments together, you will need to use t.validate(args):
+Use `t.validate(args, schema)` to transform all arguments and infer the transformed resolver arguments:
 
 ```typescript
 builder.queryType({
@@ -140,8 +148,8 @@ builder.queryType({
         phone: t.arg.string(),
       },
         z.object({
-          email: z.string().optional(),
-          phone: z.string().optional(),
+          email: z.string().nullish(),
+          phone: z.string().nullish(),
         })
         .refine(
           (args) => !!args.phone || !!args.email,
@@ -172,8 +180,8 @@ Validate entire input objects with complex validation logic using either object 
 // Object syntax
 const UserInput = builder.inputType('UserInput', {
   fields: (t) => ({
-    name: t.string(),
-    age: t.int(),
+    name: t.string({ required: true }),
+    age: t.int({ required: true }),
   }),
   validate: z
     .object({
@@ -193,30 +201,30 @@ Transform entire input types:
 ```typescript
 const UserInput = builder.inputType('RawUserInput', {
   fields: (t) => ({
-    fullName: t.string(),
-    birthYear: t.string(),
+    fullName: t.string({ required: true }),
+    email: t.string({ required: true }),
   }),
 }).validate(
   z.object({
     fullName: z.string(),
-    birthYear: z.string(),
+    email: z.string().email(),
   }).transform(data => ({
     firstName: data.fullName.split(' ')[0],
     lastName: data.fullName.split(' ').slice(1).join(' '),
-    age: new Date().getFullYear() - parseInt(data.birthYear),
+    email: data.email.toLowerCase(),
   }))
 );
 
 builder.queryType({
   fields: (t) => ({
-    createUser: t.string({
+    previewUser: t.string({
       args: {
-        userData: t.arg({ type: UserInput }),
+        userData: t.arg({ type: UserInput, required: true }),
       },
       resolve: (_, args) => {
         // args.userData has transformed shape:
-        // { firstName: string, lastName: string, age: number }
-        return `Created user: ${args.userData.firstName} ${args.userData.lastName}`;
+        // { firstName: string, lastName: string, email: string }
+        return `User preview: ${args.userData.firstName} ${args.userData.lastName} <${args.userData.email}>`;
       },
     }),
   }),
@@ -231,6 +239,7 @@ Validate individual fields within input types:
 const UserInput = builder.inputType('UserInput', {
   fields: (t) => ({
     name: t.string({
+      required: true,
       validate: z.string().min(2).refine(
         (name) => name[0].toUpperCase() === name[0],
         { message: 'Name must be capitalized' }
@@ -247,34 +256,20 @@ Transform field values during validation:
 ```typescript
 const UserInput = builder.inputType('UserInput', {
   fields: (t) => ({
-    birthDate: t.string()
-      .validate(z.string().regex(/^\d{4}-\d{2}-\d{2}$/))
+    birthDate: t.string({ required: true })
+      .validate(z.iso.date())
       .validate(z.string().transform(str => new Date(str))),
   }),
 });
 ```
-
-## Supported Validation Libraries
-
-This plugin works with multiple validation libraries, giving you the flexibility to choose the one that best fits your needs:
-
-- **[Zod](https://zod.dev)** - TypeScript-first schema validation with static type inference
-- **[Valibot](https://valibot.dev)** - The open source schema library for TypeScript with bundle size, type safety and developer experience in mind
-- **[ArkType](https://arktype.io)** - TypeScript's 1:1 validator, optimized from editor to runtime
-- Any library implementing the [standard schema](https://standardschema.dev) interface
 
 
 ## Plugin Options
 
 ### 'validationError'
 
-The `validationError` option allows you to customize how validation errors are handled and formatted. This is useful for:
-
-- Customizing error messages for your application's needs
-- Logging validation failures for monitoring
-- Integrating with error tracking services
-- Providing context-specific error messages
-
+By default, failed validation throws `InputValidationError`, which contains Standard Schema issues
+with their messages and paths. Set `validationError` to return your own error or message.
 
 ```typescript
 const builder = new SchemaBuilder({
@@ -296,6 +291,10 @@ Your error handler can return:
 - **String**: Return a string message (will be wrapped in a PothosValidationError)
 - **Throw**: Throw an error directly
 
+To return validation failures as typed GraphQL results, see the
+[errors plugin integration](./errors#with-validation-plugin). This requires
+`unsafelyHandleInputErrors`, because input validation runs before field authorization hooks.
+
 ### Validation Execution Order
 
 Understanding when and how validations are executed:
@@ -303,7 +302,7 @@ Understanding when and how validations are executed:
 1. **Input Field Validation**: Individual input fields are validated first
 2. **Input Type Validation**: Whole input object validation runs after field validation passes
 3. **Argument Validation**: Individual field arguments are validated
-4. **Field-Level Validation**: Cross-field validation with `t.validate()` runs last
+4. **Field-Level Validation**: The output field's `validate` option and `t.validate()` run last
 
 When there are multiple validations for the same field or type, they are executed in order, so that any transforms are applied before passing to the next schema.
 Validations for separate fields or arguments are executed in parallel, and their results are merged into a single set of issues.

--- a/website/content/docs/plugins/zod.mdx
+++ b/website/content/docs/plugins/zod.mdx
@@ -1,91 +1,84 @@
 ---
-title: Zod Validation plugin
-description: Zod plugin docs for Pothos
+title: Zod validation plugin
+description: Validate field arguments and input fields with a validate option that maps onto zod constraints.
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
 
 <Callout type="warn">
-  [The new Pothos Validation plugin](https://pothos-graphql.dev/docs/plugins/validation) is now the recommended way
-  to add validation to your schema, and has support for zod, as well as several other validation libraries.
-
-  This plugin should continue to work, but does not support async validation, or validations that transform data.
+  The [validation plugin](./validation) is now the recommended way to validate a
+  schema. It supports zod alongside several other validation libraries. Use this page to maintain schemas that already use the zod plugin.
 </Callout>
 
-A plugin for adding validation for field arguments based on
-[zod](https://github.com/colinhacks/zod). This plugin does not expose zod directly, but most of the
-options map closely to the validations available in zod.
+The zod plugin validates field arguments and input fields with [zod](https://github.com/colinhacks/zod). You attach a `validate` option wherever you accept input (a single argument, a whole field's args, an input object, or one of its fields) and the plugin builds a zod validator that runs before your resolver. It does not re-export zod; instead `validate` takes a small options object whose keys map onto the zod methods you already know (`min`, `max`, `email`, `regex`, and so on), or an actual zod schema when you want the full API.
 
-## Usage
-
-### Install
-
-To use the zod plugin you will need to install both `zod` package and the zod plugin:
+## Install
 
 ```package-install
 npm install --save zod @pothos/plugin-zod
 ```
 
-### Setup
+## Setup
+
+Add the plugin, then optionally hand it a `validationError` callback to shape what clients see when validation fails.
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import ZodPlugin from '@pothos/plugin-zod';
+
 const builder = new SchemaBuilder({
   plugins: [ZodPlugin],
   zod: {
-    // optionally customize how errors are formatted
-    validationError: (zodError, args, context, info) => {
-      // the default behavior is to just throw the zod error directly
-      return zodError;
-    },
+    // Runs when validation fails. Return a string or Error, or throw your own.
+    // The default is to throw the raw ZodError.
+    validationError: (zodError, _args, _context, _info) => zodError.message,
   },
 });
+```
 
+`validationError` receives the `ZodError`, the field's `args`, the `context`, and the GraphQL `info`. Return a `string` (thrown as a `PothosValidationError`), return an `Error` instance (thrown as-is), or throw directly. Skip it to surface the raw zod error.
+
+Examples below are separate additions to this setup; query and mutation examples are alternatives.
+
+## Validating a single argument
+
+Add `validate` to any argument. The keys you pass are constraints for that argument's type; here an email string capped at 254 characters.
+
+```typescript
 builder.queryType({
   fields: (t) => ({
-    simple: t.boolean({
+    playerByEmail: t.boolean({
       args: {
-        // Validate individual args
         email: t.arg.string({
+          required: true,
           validate: {
             email: true,
+            maxLength: 254,
           },
         }),
-        phone: t.arg.string(),
       },
-      // Validate all args together
-      validate: (args) => !!args.phone || !!args.email,
       resolve: () => true,
     }),
   }),
 });
 ```
 
-## Options
+## Validating all arguments together
 
-`validationError`: (optional) A function that will be called when validation fails. The function
-will be passed the zod validation error, as well as the args, context and info objects. It can
-throw an error, or return an error message or custom Error instance.
-
-### Examples
-
-#### With custom message
+Cross-field rules ("at least one of these," "start before end") belong on the field's own `validate`, which receives the whole args object. It can be a function, or a `[function, options]` pair when you want a message.
 
 ```typescript
-builder.queryType({
+builder.mutationType({
   fields: (t) => ({
-    withMessage: t.boolean({
+    inviteToTeam: t.boolean({
       args: {
-        email: t.arg.string({
-          validate: {
-            email: [true, { message: 'invalid email address' }],
-          },
-        }),
+        email: t.arg.string({ validate: { email: true } }),
         phone: t.arg.string(),
       },
+      // Require at least one contact method across the two args.
       validate: [
-        (args) => !!args.phone || !!args.email,
-        { message: 'Must provide either phone number or email address' },
+        (args) => !!args.email || !!args.phone,
+        { message: 'Provide either an email address or a phone number' },
       ],
       resolve: () => true,
     }),
@@ -93,19 +86,36 @@ builder.queryType({
 });
 ```
 
-### Validating List
+## Custom messages
+
+Every constraint accepts either a bare value or a `[value, { message }]` pair. The pair form is a `Constraint`; the options object is passed straight to the underlying zod method, so anything zod's method accepts (a `message`, and a `path` for object refinements) works.
 
 ```typescript
-builder.queryType({
+// Inside a field builder callback:
+t.arg.int({
+  validate: {
+    min: [0, { message: 'jersey number cannot be negative' }],
+    max: [99, { message: 'jersey number must be under 100' }],
+    int: true,
+  },
+});
+```
+
+## Lists
+
+List arguments validate the list and its items in one options object. Constraints like `minLength` / `maxLength` / `length` apply to the array; `items` carries the constraints for each element.
+
+```typescript
+builder.mutationType({
   fields: (t) => ({
-    list: t.boolean({
+    setRoster: t.boolean({
       args: {
-        list: t.arg.stringList({
+        emails: t.arg.stringList({
           validate: {
+            maxLength: 12,
             items: {
               email: true,
             },
-            maxLength: 3,
           },
         }),
       },
@@ -115,43 +125,64 @@ builder.queryType({
 });
 ```
 
-### Using your own zod schemas
-
-If you just want to use a zod schema defined somewhere else, rather than using the validation
-options you can use the `schema` option:
+`items` also accepts a refinement function or a `[function, { message }]` pair. For example,
+inside a field's arguments:
 
 ```typescript
-builder.queryType({
-  fields: (t) => ({
-    list: t.boolean({
-      args: {
-        max5: t.arg.int({
-          validate: {
-            schema: zod.number().int().max(5),
-          },
-        }),
-      },
-      resolve: () => true,
-    }),
-  }),
+t.arg.stringList({
+  validate: {
+    items: [(value) => value.trim().length > 0, { message: 'Items must not be blank' }],
+  },
 });
 ```
 
-You can also validate all arguments together using a zod schema:
+## Input objects
+
+`validate` works the same on an input type and on its fields. Put per-field rules on each field, and cross-field rules on the input type itself, where the callback receives the whole object.
+
+```typescript
+const RegisterTeamInput = builder.inputType('RegisterTeamInput', {
+  fields: (t) => ({
+    name: t.string({ required: true, validate: { minLength: 3, maxLength: 40 } }),
+    contactEmail: t.string({ required: true, validate: { email: true } }),
+    backupEmail: t.string({ required: false, validate: { email: true } }),
+  }),
+  // Runs against the assembled input object.
+  validate: [
+    (input) => input.contactEmail !== input.backupEmail,
+    { message: 'backup email must differ from contact email' },
+  ],
+});
+```
+
+## Bring your own zod schema
+
+Pass an existing zod schema with the `schema` key to reuse its rules on an argument:
+
+```typescript
+import { z } from 'zod';
+
+t.arg.int({
+  validate: {
+    schema: z.number().int().max(5),
+  },
+});
+```
+
+...or on the whole field, validating every argument at once:
 
 ```typescript
 builder.queryType({
   fields: (t) => ({
-    simple: t.boolean({
+    validateCredentials: t.boolean({
       args: {
-        email: t.arg.string(),
-        phone: t.arg.string(),
+        email: t.arg.string({ required: true }),
+        password: t.arg.string({ required: true }),
       },
-      // Validate all args together using own zod schema
       validate: {
-        schema: zod.object({
-          email: zod.string().email(),
-          phone: zod.string(),
+        schema: z.object({
+          email: z.string().email(),
+          password: z.string().min(8),
         }),
       },
       resolve: () => true,
@@ -160,237 +191,112 @@ builder.queryType({
 });
 ```
 
-## API
+You can combine `schema` with the constraint keys. The plugin pipes your schema into the generated validator, so both run. Validation uses `parseAsync` before the resolver, so refinements may return a `Promise<boolean>`. The parsed value is passed to the resolver. This plugin does not infer transformed argument types; use the [validation plugin](./validation) when transforms change the resolver argument shape.
 
-### On Object fields (for validating field arguments)
+## Constraint reference
 
-- `validate`: `Refinement<T>` | `Refinement<T>[]` | `ValidationOptions`.
+`validate` accepts a bare refinement function, an array of them, or an options object. The options object always allows these keys:
 
-### On InputObjects (for validating all fields of an input object)
+| Key | Type | Purpose |
+| --- | --- | --- |
+| `type` | `'number' \| 'bigint' \| 'boolean' \| 'date' \| 'string' \| 'object' \| 'array'` | Pin the base zod type. See [How it works](#how-it-works) for why this matters. |
+| `refine` | function or `[function, { message?, path? }]`, or an array of either | A predicate handed to zod's `refine`. Receives the validated value; returns `boolean` or `Promise<boolean>`. |
+| `schema` | `ZodType` | A zod schema piped into the generated validator. |
 
-- `validate`: `Refinement<T>` | `Refinement<T>[]` | `ValidationOptions`.
+The remaining keys depend on the field's type. Each value is a `Constraint`, either a bare value or `[value, { message }]`:
 
-### On arguments or input object fields (for validating a specific input field or argument)
+| Type | Additional keys |
+| --- | --- |
+| Number | `min`, `max`, `int`, `positive`, `nonnegative`, `negative`, `nonpositive` |
+| String | `minLength`, `maxLength`, `length`, `email`, `url`, `uuid`, `regex` |
+| Array | `minLength`, `maxLength`, `length`, `items` (nested validation options or a refinement for each element) |
+| BigInt | *(base keys only)* |
+| Boolean | *(base keys only)* |
+| Date | *(base keys only)* |
+| Object | *(base keys only)* |
 
-- `validate`: `Refinement<T>` | `Refinement<T>[]` | `ValidationOptions`.
+## How it works
 
-### `Refinement`
-
-A `Refinement` is a function that will be passed to the `zod` `refine` method. It receives the args
-object, input object, or value of the specific field the refinement is defined on. It should return
-a `boolean` or `Promise<boolean>`.
-
-`Refinement`s can either be just a function: `(val) => isValid(val)`, or an array with the function,
-and an options object like: `[(val) => isValid(val), { message: 'field should be valid' }]`.
-
-The options object may have a `message` property, and if the type being validated is an object, it
-can also include a `path` property with an array of strings indicating the path of the field in the
-object being validated. See the zod docs on `refine` for more details.
-
-### `ValidationOptions`
-
-The validation options available depend on the type being validated. Each property of
-`ValidationOptions` can either be a value specific to the constraint, or an array with the value,
-and the options passed to the underlying zod method. This options object can be used to set a custom
-error message:
+Each argument and input field builds its own zod validator from its `validate` options. At runtime the plugin has no access to the JavaScript type behind a GraphQL type, so when you pass plain constraints it builds a union of every base type that could satisfy them. A lone `maxLength`, for example, fits both strings and arrays:
 
 ```typescript
-{
-  validate: {
-    max: [10, { message: 'should not be more than 10' }],
-    int: true,
-  }
-}
+z.union([z.string().max(5), z.array(z.unknown()).max(5)]);
 ```
 
-#### Number
+An `email` constraint only fits strings, so the union collapses to one member. When the argument is not required, the whole validator is wrapped `.optional().nullable()` rather than folded into the union.
 
-- `type`?: `'number'`
-- `refine`?: `Refinement<number> | Refinement<number>[]`
-- `min`?: `Constraint<number>`
-- `max`?: `Constraint<number>`
-- `positive`?: `Constraint<boolean>`
-- `nonnegative`?: `Constraint<boolean>`
-- `negative`?: `Constraint<boolean>`
-- `nonpositive`?: `Constraint<boolean>`
-- `int`?: `Constraint<boolean>`
-- `schema`?: `ZodSchema<number>`
-
-#### BigInt
-
-- `type`?: `'bigint'`
-- `refine`?: `Refinement<bigint> | Refinement<bigint>[]`
-- `schema`?: `ZodSchema<bigint>`
-
-#### Boolean
-
-- `type`?: `'boolean'`
-- `refine`?: `Refinement<boolean> | Refinement<boolean>[]`
-- `schema`?: `ZodSchema<boolean>`
-
-#### Date
-
-- `type`?: `'boolean'`
-- `refine`?: `Refinement<boolean> | Refinement<boolean>[]`
-- `schema`?: `ZodSchema<Date>`
-
-#### String
-
-- `type`?: `'string'`;
-- `refine`?: `Refinement<string> | Refinement<string>[]`
-- `minLength`?: `Constraint<number>`
-- `maxLength`?: `Constraint<number>`
-- `length`?: `Constraint<number>`
-- `url`?: `Constraint<boolean>`
-- `uuid`?: `Constraint<boolean>`
-- `email`?: `Constraint<boolean>`
-- `regex`?: `Constraint<RegExp>`
-- `schema`?: `ZodSchema<string>`
-
-#### Object
-
-- `type`?: `'object'`;
-- `refine`?: `Refinement<T> | Refinement<T>[]`
-- `schema`?: `ZodSchema<Ts>`
-
-#### Array
-
-- `type`?: `'array'`;
-- `refine`?: `Refinement<T[]> | Refinement<T[]>[]`
-- `minLength`?: `Constraint<number>`
-- `maxLength`?: `Constraint<number>`
-- `length`?: `Constraint<number>`
-- `items`?: `ValidationOptions<T> | Refinement<T>`
-- `schema`?: `ZodSchema<T[]>`
-
-### How it works
-
-Each arg on an object field, and each field on an input type with validation will build its own zod
-validator. These validators will be a union of all potential types that can apply the validations
-defined for that field. For example, if you define an optional field with a `maxLength` validator,
-it will create a zod schema that looks something like:
+Set `type` to skip the guessing and pin one base type:
 
 ```typescript
-zod.union([zod.null(), zod.undefined(), zod.array().maxLength(5), zod.string().maxLength(5)]);
+// { validate: { type: 'string', maxLength: 5 } } builds:
+z.string().max(5);
 ```
 
-If you set an `email` validation instead the schema might look like:
+Three cases sidestep the union entirely:
+
+- **Input object** args and fields always validate with `z.looseObject(...)`.
+- **List** args and fields always validate with `.array()`.
+- **Refinement-only** validators (a bare function, or an options object with just `refine` and/or `schema`) validate against `z.unknown()`, since no constraint narrows the type.
+
+A `schema` is piped into whatever the plugin generates (`yourSchema.pipe(generated)`), so your schema and the constraints both run.
+
+
+
+## Sharing schemas with client code
+
+To reuse a validator on the client, write it as an ordinary zod schema in a shared module, then attach it with `schema`:
 
 ```typescript
-zod.union([zod.null(), zod.undefined(), zod.string().email()]);
+// shared/validators.ts
+import { z } from 'zod';
+
+export const jerseyNumber = z.number().int().min(0).max(99);
 ```
 
-At runtime, we don't know anything about the types being used by your schema, we can't infer the
-expected js type from the type definition, so the best we can do is limit the valid types based on
-what validations they support. The `type` validation allows explicitly validating the `type` of a
-field to be one of the base types supported by zod:
-
 ```typescript
-// field
-{
-validate: {
-  type: 'string',
-  maxLength: 5
-}
-// generated
-zod.union([zod.null(), zod.undefined(), zod.string().maxLength(5)]);
-```
-
-There are a few exceptions to the above:
-
-1. args and input fields that are `InputObject`s always use `zod.object()` rather than creating a
-   union of potential types.
-
-1. args and input fields that are list types always use `zod.array()`.
-
-1. If you only include a `refine` validation (or just pass a function directly to validate) we will
-   just use `zod`s unknown validator instead:
-
-```typescript
-// field
-{
-  validate: (val) => isValid(val),
-}
-// generated
-zod.union([zod.null(), zod.undefined(), zod.unknown().refine((val) => isValid(val))]);
-```
-
-If the validation options include a `schema` that schema will be used as an intersection with the
-generated validator:
-
-```typescript
-// field
-{
-  validate: {
-    int: true,
-    schema: zod.number().max(10),
-}
-// generated
-zod.union([zod.null(), zod.undefined(),  zod.intersection(zod.number().max(10), zod.number().int())]);
-```
-
-### Sharing schemas with client code
-
-The easiest way to share validators is to use them to define schemas for your fields in an external
-file using the normal zod APIs, and then attaching those to your fields using the `schema` option.
-
-```typescript
-// shared
-import { ValidationOptions } from '@pothos/plugin-zod';
-
-const numberValidation = zod.number().max(5);
-
 // server
-builder.queryType({
-  fields: (t) => ({
-    example: t.boolean({
-      args: {
-        num: t.arg.int({
-          validate: {
-            schema: numberValidation,
-          }
-        }),
-      },
-      resolve: () => true,
-    }),
-  });
-});
+import { jerseyNumber } from './shared/validators';
 
+t.arg.int({
+  validate: { schema: jerseyNumber },
+});
+```
+
+```typescript
 // client
-numberValidator.parse(3) // pass
-numberValidator.parse('3') // fail
+import { jerseyNumber } from './shared/validators';
+
+jerseyNumber.parse(23); // pass
+jerseyNumber.parse(100); // throws
 ```
 
-You can also use the `createZodSchema` helper from the plugin directly to create zod Schemas from an
-options object:
+If you would rather share the constraint options object, the plugin exports `createZodSchema` to turn one into a zod schema on demand. Type the options with the exported `ValidationOptions`:
 
 ```typescript
-// shared
-import { ValidationOptions } from '@pothos/plugin-zod';
+// shared/validators.ts
+import type { ValidationOptions } from '@pothos/plugin-zod';
 
-const numberValidation: ValidationOptions<number> = {
-  max: 5,
+export const jerseyNumberOptions: ValidationOptions<number> = {
+  min: 0,
+  max: 99,
+  int: true,
 };
+```
 
+```typescript
 // server
-builder.queryType({
-  fields: (t) => ({
-    example: t.boolean({
-      args: {
-        num: t.arg.int({
-          validate: numberValidation,
-        }),
-      },
-      resolve: () => true,
-    }),
-  });
-});
+import { jerseyNumberOptions } from './shared/validators';
 
+t.arg.int({ validate: jerseyNumberOptions });
+```
+
+```typescript
 // client
 import { createZodSchema } from '@pothos/plugin-zod';
+import { jerseyNumberOptions } from './shared/validators';
 
-const validator = createZodSchema(numberValidator);
+const validator = createZodSchema(jerseyNumberOptions);
 
-validator.parse(3) // pass
-validator.parse('3') // fail
+validator.parse(23); // pass
+validator.parse(100); // throws
 ```


### PR DESCRIPTION
Renew Errors, Validation, and Zod around coherent result shapes and truthful validation examples. Correct nullable arguments, list-item error handling, custom unions, transformations, and legacy Zod capability claims. Distinguish independent schemas and validate real ISO dates. Synchronize package READMEs.

Validation: exact snippets strict-typecheck and current-source execution checks handled errors, iterator failures, custom/manual unions, issue paths, transforms, null cases, and rejected-input side effects. Legacy Zod async behavior and invalid date rejection were executed. Package suites pass 272 tests with 4 skipped. Final website build and rendered documentation links/anchors pass.

Separate post-publication editorial and correctness reviews are complete; material findings were addressed.

Preservation re-review against original base `7c0a5490`: Restored distinct manual error-union branches and validation metadata, custom union resolution, async and combined list-error examples, and Zod item refinements. Standard Schema validation coverage is retained. Exact additions pass strict checks and focused execution; independent re-review passed.

All useful omissions identified by the new review were fixed and independently re-reviewed. The final integrated production website build, executable documentation checks, and links/anchors across 77 rendered pages pass. Dependency-install fences use `package-install` throughout the changed website pages and READMEs.
