### PR TITLE
docs: renew schema variants and field helper guides

### DIFF
--- a/packages/plugin-mocks/README.md
+++ b/packages/plugin-mocks/README.md
@@ -1,18 +1,20 @@
-# Mocks Plugin for Pothos
+# Mocks plugin
 
-A simple plugin for adding resolver mocks to a GraphQL schema.
+Replace selected field resolvers when building a schema for tests or local development.
+Mocks are configured per `toSchema()` call, so the same builder can produce mocked and unmocked schemas.
 
 ## Usage
 
 ### Install
 
-```bash
-yarn add @pothos/plugin-mocks
+```package-install
+npm install --save @pothos/plugin-mocks
 ```
 
 ### Setup
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import MocksPlugin from '@pothos/plugin-mocks';
 const builder = new SchemaBuilder({
   plugins: [MocksPlugin],
@@ -69,9 +71,10 @@ builder.toSchema({
   mocks: {
     Subscription: {
       someField: {
-        resolve: (parent, args, context, info) => 'Mock result!',
-        subscribe: (parent, args, context, info) => {
-          /* return a mock async iterator */
+        resolve: (event) => event,
+        subscribe: async function* () {
+          yield 'First event';
+          yield 'Second event';
         },
       },
     },

--- a/packages/plugin-simple-objects/README.md
+++ b/packages/plugin-simple-objects/README.md
@@ -1,23 +1,15 @@
-# Simple Objects Plugin for Pothos
+# Simple objects plugin
 
-The Simple Objects Plugin provides a way to define objects and interfaces without defining type
-definitions for those objects, while still getting full type safety.
+Infer an object's backing shape from its GraphQL fields. Use `simpleObject` or `simpleInterface`
+when the resolver returns data in the same shape as the schema. For an existing application model,
+use a core `objectRef` or `interfaceRef` with that model's type.
 
 ## Usage
 
 ### Install
 
-```bash
-yarn add @pothos/plugin-simple-objects
-```
-
-### Setup
-
-```typescript
-import SimpleObjectsPlugin from '@pothos/plugin-simple-objects';
-const builder = new SchemaBuilder({
-  plugins: [SimpleObjectsPlugin],
-});
+```package-install
+npm install --save @pothos/plugin-simple-objects
 ```
 
 ### Example
@@ -49,13 +41,13 @@ const Node = builder.simpleInterface('Node', {
   }),
 });
 
-const UserType = builder.simpleObject(
+const User = builder.simpleObject(
   'User',
   {
     interfaces: [Node],
     fields: (t) => ({
-      firstName: t.string(),
-      lastName: t.string(),
+      firstName: t.string({ nullable: false }),
+      lastName: t.string({ nullable: false }),
       contactInfo: t.field({
         type: ContactInfo,
         nullable: false,
@@ -73,13 +65,13 @@ const UserType = builder.simpleObject(
 builder.queryType({
   fields: (t) => ({
     user: t.field({
-      type: UserType,
+      type: User,
       args: {
         id: t.arg.id({ required: true }),
       },
-      resolve: (parent, args, { User }) => {
+      resolve: (parent, { id }) => {
         return {
-          id: '1003',
+          id: String(id),
           firstName: 'Leia',
           lastName: 'Organa',
           contactInfo: {
@@ -99,12 +91,12 @@ In some cases, you may want to add more complex fields with resolvers or args wh
 just passed down from the parent.
 
 In these cases, you can either add the field in the 3rd arg (fields) as shown above, or you can add
-additional fields to the type using methods like `builder.objectType`:
+additional fields with `builder.objectFields`. This adds a different computed field to `User`:
 
 ```typescript
-builder.objectType(UserType, (t) => ({
-  fullName: t.string({
-    resolve: (user) => `${user.firstName} ${user.lastName}`,
+builder.objectFields(User, (t) => ({
+  initials: t.string({
+    resolve: (user) => `${user.firstName.slice(0, 1)}${user.lastName.slice(0, 1)}`,
   }),
 }));
 ```

--- a/packages/plugin-sub-graph/README.md
+++ b/packages/plugin-sub-graph/README.md
@@ -1,116 +1,119 @@
-# SubGraph Plugin for Pothos
+# SubGraph plugin
 
-A plugin for creating sub-selections of your graph. This allows you to use the same code/types for
-multiple variants of your API.
+Use one set of type definitions to build several API variants. Tag types and fields with named
+sub-graphs, then pass `subGraph` to `builder.toSchema()` to select a variant. This is separate from
+Apollo Federation: a sub-graph here is a filtered view of your own schema.
 
-One common use case for this is to share implementations between your public and internal APIs, by
-only exposing a subset of your graph publicly.
+## Install
 
-## Usage
-
-### Install
-
-```bash
-yarn add @pothos/plugin-sub-graph
+```package-install
+npm install --save @pothos/plugin-sub-graph
 ```
 
-### Setup
+## Build public and internal schemas
+
+Declare the sub-graph names in `SubGraphs`. In this example, types and fields belong to both variants
+by default, while `internalNotes` is available only in the internal API:
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import SubGraphPlugin from '@pothos/plugin-sub-graph';
+
 const builder = new SchemaBuilder<{
   SubGraphs: 'Public' | 'Internal';
 }>({
   plugins: [SubGraphPlugin],
   subGraphs: {
-    defaultForTypes: [],
+    defaultForTypes: ['Public', 'Internal'],
     fieldsInheritFromTypes: true,
   },
 });
 
-//in another file:
+const Product = builder.objectRef<{
+  id: string;
+  name: string;
+  internalNotes: string;
+}>('Product').implement({
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    name: t.exposeString('name'),
+    internalNotes: t.exposeString('internalNotes', {
+      subGraphs: ['Internal'],
+    }),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    product: t.field({
+      type: Product,
+      resolve: () => ({ id: '1', name: 'Notebook', internalNotes: 'Restock next week' }),
+    }),
+  }),
+});
 
 const schema = builder.toSchema();
 const publicSchema = builder.toSchema({ subGraph: 'Public' });
 const internalSchema = builder.toSchema({ subGraph: 'Internal' });
+```
 
-// You can also build a graph containing multiple subgraphs:
+`{ product { name } }` works in either variant. `{ product { internalNotes } }` fails GraphQL
+validation against `publicSchema`. Calling `toSchema()` without a sub-graph retains the full schema.
+
+## Combine variants
+
+An array includes types and fields belonging to any listed sub-graph:
+
+```typescript
 const combinedSchema = builder.toSchema({ subGraph: ['Internal', 'Public'] });
-
-// Or create a graph of the intersection between multiple subgraphs:
-const allSchema = builder.toSchema({ subGraph: { all: ['Internal', 'Public'] } });
 ```
 
-### Options on Types
-
-- `subGraphs`: An optional array of sub-graph the type should be included in.
-
-### Object and Interface types:
-
-- `defaultSubGraphsForFields`: Default sub-graph for fields of the type to be included in.
-
-## Options on Fields
-
-- `subGraphs`: An optional array of sub-graph the field to be included in. If not provided, will
-
-  fallback to:
-
-  - `defaultSubGraphsForFields` if set on type
-  - `subGraphs` of the type if `subGraphs.fieldsInheritFromTypes` was set in the builder
-  - an empty array
-
-### Options on Builder
-
-- `subGraphs.defaultForTypes`: Specifies what sub-graph a type is part of by default.
-- `subGraphs.fieldsInheritFromTypes`: defaults to `false`. When true, fields on a type will default
-  to being part of the same sub-graph as their parent type. Only applies when type does not have
-  `defaultSubGraphsForFields` set.
-
-### Usage
+The `all` form includes only membership shared by every listed sub-graph:
 
 ```typescript
-builder.queryType({
-  // Query type will be available in default, Public, and Internal schemas
-  subGraphs: ['Public', 'Internal'],
-  // Fields on the Query object will now default to not being a part of any subgraph
-  defaultSubGraphsForFields: [];
-  fields: (t) => ({
-    someField: t.string({
-      // someField will be in the default schema and "Internal" sub graph, but
-      // not present in the Public sub graph
-      subGraphs: ['Internal']
-      resolve: () => {
-        throw new Error('Not implemented');
-      },
-    }),
-  }),
-});
+const sharedSchema = builder.toSchema({ subGraph: { all: ['Internal', 'Public'] } });
 ```
 
-### Missing types
+For the example above, the combined schema includes `internalNotes`; the shared schema omits it.
 
-When creating a sub-graph, the plugin will only copy in types that are included in the sub-graph,
-either by explicitly setting it on the type, or because the sub-graph is included in the default
-list. Like types, output fields that are not included in a sub-graph will also be omitted. Arguments
-and fields on Input types can not be removed because that would break assumptions about argument
-types in resolvers.
+## Membership options
 
-If a type that is not included in the sub-graph is referenced by another part of the graph that is
-included in the graph, a runtime error will be thrown when the sub graph is constructed. This can
-happen in a number of cases including cases where a removed type is used in the interfaces of an
-object, a member of a union, or the type of a field argument.
+Set `subGraphs` on a type or field to override its defaults. A type without this option uses
+`subGraphs.defaultForTypes` from the builder.
 
-### Explicitly including types
+A field's membership is determined in this order:
 
-You can use the `explicitlyIncludeType` option to explicitly include types in a sub-graph that are
-unreachable.  This isn't normally required, but there are some edge cases where this may be useful.
+1. Its own `subGraphs` option.
+2. Its parent type's `defaultSubGraphsForFields` option.
+3. Its parent type's membership, when `subGraphs.fieldsInheritFromTypes` is `true`.
+4. The builder's `subGraphs.defaultForFields` option.
+5. An empty array.
 
-For instance, when extending external references with the federation plugin, the externalRef may
-not be reachable directly through your schema, but you may still want to include it when building the
-schema.  To work around this, we can explicitly include any types that have a `key` directive:
+`fieldsInheritFromTypes` defaults to `false`. An explicit empty array overrides the fallback, so
+`defaultSubGraphsForFields: []` on a type makes its fields opt in individually.
 
+## Inputs and missing types
+
+Nullable arguments and input fields can also have `subGraphs`. Required arguments and input fields
+cannot be removed from a retained field or input object: resolvers may depend on them being present.
+The plugin rejects a schema that tries to remove one.
+
+An output field is omitted when its return type is excluded. Other references can make a filtered
+schema invalid, such as a retained union containing an excluded member or a required argument using
+an excluded input type. Include those dependencies in the variant or exclude the referring field or
+type as well. Build and validate each variant you intend to serve.
+
+## Include unreachable types
+
+Types that remain unreachable after filtering are normally omitted. The
+`subGraphs.explicitlyIncludeType` callback retains matching types that already belong to the selected
+sub-graph, even when no field reaches them.
+
+For federation entities, `hasResolvableKey` can retain an otherwise unreachable external reference.
+Use this as a separate builder setup with both plugins:
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import FederationPlugin, { hasResolvableKey } from '@pothos/plugin-federation';
 import SubGraphPlugin from '@pothos/plugin-sub-graph';
 
@@ -119,7 +122,9 @@ const builder = new SchemaBuilder<{
 }>({
   plugins: [SubGraphPlugin, FederationPlugin],
   subGraphs: {
-    explicitlyIncludeType: (type, subGraphs) => hasResolvableKey(type)
+    defaultForTypes: ['Public', 'Internal'],
+    fieldsInheritFromTypes: true,
+    explicitlyIncludeType: (type) => hasResolvableKey(type),
   },
 });
 ```

--- a/packages/plugin-with-input/README.md
+++ b/packages/plugin-with-input/README.md
@@ -1,8 +1,8 @@
-# With-Input Plugin
+# With-Input plugin
 
-A plugin for creating fields with a single input object. This plugin adds a new `t.fieldWithInput`
-method that allows you to more easily define fields with a single input type without having to
-define it separately.
+Define a field and its input object together with `t.fieldWithInput`. The plugin creates the
+input type and a required `input` argument. Use a core `builder.inputType` instead when several
+fields should share the same input type.
 
 ## Usage
 
@@ -15,6 +15,7 @@ npm install --save @pothos/plugin-with-input
 ### Setup
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import WithInputPlugin from '@pothos/plugin-with-input';
 const builder = new SchemaBuilder({
   plugins: [WithInputPlugin],
@@ -51,7 +52,7 @@ This will produce a schema like:
 
 ```graphql
 type Query {
-  example(input: QueryExampleInput!): ID!
+  example(input: QueryExampleInput!): ID
 }
 
 input QueryExampleInput {
@@ -63,7 +64,7 @@ The input name will default to `${ParentType.name}${Field.name}Input`.
 
 ### Customizing your input object
 
-You can customize the name of your Input object, and the name of the input argument:
+Replace the previous query definition with this version to customize both names:
 
 ```typescript
 builder.queryType({
@@ -104,7 +105,7 @@ const builder = new SchemaBuilder<{ WithInputArgRequired: false }>({
 });
 ```
 
-arg requiredness can also be set on a per field basis by setting `argOptions.required`
+Alternatively, keep the original builder and set `argOptions.required` on an individual field.
 
 ```typescript
 builder.queryType({
@@ -121,13 +122,15 @@ builder.queryType({
         return args.input?.someInput;
       },
     }),
+  }),
 });
 ```
 
 ### Prisma plugin integration
 
 If you are using the prisma plugin you can use `t.prismaFieldWithInput` to add prisma fields with
-input objects:
+input objects. This example assumes a builder configured for the Prisma and With-Input plugins,
+a `User` Prisma object, and a Prisma client named `prisma`:
 
 ```typescript
 builder.queryField('user', (t) =>

--- a/website/content/docs/plugins/mocks.mdx
+++ b/website/content/docs/plugins/mocks.mdx
@@ -3,7 +3,8 @@ title: Mocks plugin
 description: Mocks plugin docs for Pothos
 ---
 
-A simple plugin for adding resolver mocks to a GraphQL schema.
+Replace selected field resolvers when building a schema for tests or local development.
+Mocks are configured per `toSchema()` call, so the same builder can produce mocked and unmocked schemas.
 
 ## Usage
 
@@ -16,6 +17,7 @@ npm install --save @pothos/plugin-mocks
 ### Setup
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import MocksPlugin from '@pothos/plugin-mocks';
 const builder = new SchemaBuilder({
   plugins: [MocksPlugin],
@@ -72,9 +74,10 @@ builder.toSchema({
   mocks: {
     Subscription: {
       someField: {
-        resolve: (parent, args, context, info) => 'Mock result!',
-        subscribe: (parent, args, context, info) => {
-          /* return a mock async iterator */
+        resolve: (event) => event,
+        subscribe: async function* () {
+          yield 'First event';
+          yield 'Second event';
         },
       },
     },

--- a/website/content/docs/plugins/simple-objects.mdx
+++ b/website/content/docs/plugins/simple-objects.mdx
@@ -3,8 +3,9 @@ title: Simple objects plugin
 description: Simple objects plugin docs for Pothos
 ---
 
-The Simple Objects Plugin provides a way to define objects and interfaces without defining type
-definitions for those objects, while still getting full type safety.
+Infer an object's backing shape from its GraphQL fields. Use `simpleObject` or `simpleInterface`
+when the resolver returns data in the same shape as the schema. For an existing application model,
+use a core `objectRef` or `interfaceRef` with that model's type.
 
 ## Usage
 
@@ -12,15 +13,6 @@ definitions for those objects, while still getting full type safety.
 
 ```package-install
 npm install --save @pothos/plugin-simple-objects
-```
-
-### Setup
-
-```typescript
-import SimpleObjectsPlugin from '@pothos/plugin-simple-objects';
-const builder = new SchemaBuilder({
-  plugins: [SimpleObjectsPlugin],
-});
 ```
 
 ### Example
@@ -52,13 +44,13 @@ const Node = builder.simpleInterface('Node', {
   }),
 });
 
-const UserType = builder.simpleObject(
+const User = builder.simpleObject(
   'User',
   {
     interfaces: [Node],
     fields: (t) => ({
-      firstName: t.string(),
-      lastName: t.string(),
+      firstName: t.string({ nullable: false }),
+      lastName: t.string({ nullable: false }),
       contactInfo: t.field({
         type: ContactInfo,
         nullable: false,
@@ -76,13 +68,13 @@ const UserType = builder.simpleObject(
 builder.queryType({
   fields: (t) => ({
     user: t.field({
-      type: UserType,
+      type: User,
       args: {
         id: t.arg.id({ required: true }),
       },
-      resolve: (parent, args, { User }) => {
+      resolve: (parent, { id }) => {
         return {
-          id: '1003',
+          id: String(id),
           firstName: 'Leia',
           lastName: 'Organa',
           contactInfo: {
@@ -102,12 +94,12 @@ In some cases, you may want to add more complex fields with resolvers or args wh
 just passed down from the parent.
 
 In these cases, you can either add the field in the 3rd arg (fields) as shown above, or you can add
-additional fields to the type using methods like `builder.objectType`:
+additional fields with `builder.objectFields`. This adds a different computed field to `User`:
 
 ```typescript
-builder.objectType(UserType, (t) => ({
-  fullName: t.string({
-    resolve: (user) => `${user.firstName} ${user.lastName}`,
+builder.objectFields(User, (t) => ({
+  initials: t.string({
+    resolve: (user) => `${user.firstName.slice(0, 1)}${user.lastName.slice(0, 1)}`,
   }),
 }));
 ```

--- a/website/content/docs/plugins/sub-graph.mdx
+++ b/website/content/docs/plugins/sub-graph.mdx
@@ -1,119 +1,122 @@
 ---
 title: SubGraph plugin
-description: SubGraph plugin docs for Pothos
+description: Build public and internal API variants from one set of types and fields.
 ---
 
-A plugin for creating sub-selections of your graph. This allows you to use the same code/types for
-multiple variants of your API.
+Use one set of type definitions to build several API variants. Tag types and fields with named
+sub-graphs, then pass `subGraph` to `builder.toSchema()` to select a variant. This is separate from
+Apollo Federation: a sub-graph here is a filtered view of your own schema.
 
-One common use case for this is to share implementations between your public and internal APIs, by
-only exposing a subset of your graph publicly.
-
-## Usage
-
-### Install
+## Install
 
 ```package-install
 npm install --save @pothos/plugin-sub-graph
 ```
 
-### Setup
+## Build public and internal schemas
+
+Declare the sub-graph names in `SubGraphs`. In this example, types and fields belong to both variants
+by default, while `internalNotes` is available only in the internal API:
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import SubGraphPlugin from '@pothos/plugin-sub-graph';
+
 const builder = new SchemaBuilder<{
   SubGraphs: 'Public' | 'Internal';
 }>({
   plugins: [SubGraphPlugin],
   subGraphs: {
-    defaultForTypes: [],
+    defaultForTypes: ['Public', 'Internal'],
     fieldsInheritFromTypes: true,
   },
 });
 
-//in another file:
+const Product = builder.objectRef<{
+  id: string;
+  name: string;
+  internalNotes: string;
+}>('Product').implement({
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    name: t.exposeString('name'),
+    internalNotes: t.exposeString('internalNotes', {
+      subGraphs: ['Internal'],
+    }),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    product: t.field({
+      type: Product,
+      resolve: () => ({ id: '1', name: 'Notebook', internalNotes: 'Restock next week' }),
+    }),
+  }),
+});
 
 const schema = builder.toSchema();
 const publicSchema = builder.toSchema({ subGraph: 'Public' });
 const internalSchema = builder.toSchema({ subGraph: 'Internal' });
+```
 
-// You can also build a graph containing multiple subgraphs:
+`{ product { name } }` works in either variant. `{ product { internalNotes } }` fails GraphQL
+validation against `publicSchema`. Calling `toSchema()` without a sub-graph retains the full schema.
+
+## Combine variants
+
+An array includes types and fields belonging to any listed sub-graph:
+
+```typescript
 const combinedSchema = builder.toSchema({ subGraph: ['Internal', 'Public'] });
-
-// Or create a graph of the intersection between multiple subgraphs:
-const allSchema = builder.toSchema({ subGraph: { all: ['Internal', 'Public'] } });
 ```
 
-### Options on Types
-
-- `subGraphs`: An optional array of sub-graph the type should be included in.
-
-### Object and Interface types:
-
-- `defaultSubGraphsForFields`: Default sub-graph for fields of the type to be included in.
-
-## Options on Fields
-
-- `subGraphs`: An optional array of sub-graph the field to be included in. If not provided, will
-
-  fallback to:
-
-  - `defaultForFields` if set on type
-  - `subGraphs` of the type if `subGraphs.fieldsInheritFromTypes` was set in the builder
-  - an empty array
-
-### Options on Builder
-
-- `subGraphs.defaultForTypes`: Specifies what sub-graph a type is part of by default.
-- `subGraphs.fieldsInheritFromTypes`: defaults to `false`. When true, fields on a type will default
-  to being part of the same sub-graph as their parent type. Only applies when type does not have
-  `defaultForFields` set.
-
-### Usage
+The `all` form includes only membership shared by every listed sub-graph:
 
 ```typescript
-builder.queryType({
-  // Query type will be available in default, Public, and Internal schemas
-  subGraphs: ['Public', 'Internal'],
-  // Fields on the Query object will now default to not being a part of any subgraph
-  defaultForFields: [];
-  fields: (t) => ({
-    someField: t.string({
-      // someField will be in the default schema and "Internal" sub graph, but
-      // not present in the Public sub graph
-      subGraphs: ['Internal']
-      resolve: () => {
-        throw new Error('Not implemented');
-      },
-    }),
-  }),
-});
+const sharedSchema = builder.toSchema({ subGraph: { all: ['Internal', 'Public'] } });
 ```
 
-### Missing types
+For the example above, the combined schema includes `internalNotes`; the shared schema omits it.
 
-When creating a sub-graph, the plugin will only copy in types that are included in the sub-graph,
-either by explicitly setting it on the type, or because the sub-graph is included in the default
-list. Like types, output fields that are not included in a sub-graph will also be omitted. Arguments
-and fields on Input types can not be removed because that would break assumptions about argument
-types in resolvers.
+## Membership options
 
-If a type that is not included in the sub-graph is referenced by another part of the graph that is
-included in the graph, a runtime error will be thrown when the sub graph is constructed. This can
-happen in a number of cases including cases where a removed type is used in the interfaces of an
-object, a member of a union, or the type of a field argument.
+Set `subGraphs` on a type or field to override its defaults. A type without this option uses
+`subGraphs.defaultForTypes` from the builder.
 
-### Explicitly including types
+A field's membership is determined in this order:
 
-You can use the `explicitlyIncludeType` option to explicitly include types in a sub-graph that are
-unreachable.  This isn't normally required, but there are some edge cases where this may be useful.
+1. Its own `subGraphs` option.
+2. Its parent type's `defaultSubGraphsForFields` option.
+3. Its parent type's membership, when `subGraphs.fieldsInheritFromTypes` is `true`.
+4. The builder's `subGraphs.defaultForFields` option.
+5. An empty array.
 
-For instance, when extending external references with the federation plugin, the externalRef may
-not be reachable directly through your schema, but you may still want to include it when building the
-schema.  To work around this, we can explicitly include any types that have a `key` directive:
+`fieldsInheritFromTypes` defaults to `false`. An explicit empty array overrides the fallback, so
+`defaultSubGraphsForFields: []` on a type makes its fields opt in individually.
 
+## Inputs and missing types
+
+Nullable arguments and input fields can also have `subGraphs`. Required arguments and input fields
+cannot be removed from a retained field or input object: resolvers may depend on them being present.
+The plugin rejects a schema that tries to remove one.
+
+An output field is omitted when its return type is excluded. Other references can make a filtered
+schema invalid, such as a retained union containing an excluded member or a required argument using
+an excluded input type. Include those dependencies in the variant or exclude the referring field or
+type as well. Build and validate each variant you intend to serve.
+
+## Include unreachable types
+
+Types that remain unreachable after filtering are normally omitted. The
+`subGraphs.explicitlyIncludeType` callback retains matching types that already belong to the selected
+sub-graph, even when no field reaches them.
+
+For federation entities, `hasResolvableKey` can retain an otherwise unreachable external reference.
+Use this as a separate builder setup with both plugins:
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import FederationPlugin, { hasResolvableKey } from '@pothos/plugin-federation';
 import SubGraphPlugin from '@pothos/plugin-sub-graph';
 
@@ -122,7 +125,9 @@ const builder = new SchemaBuilder<{
 }>({
   plugins: [SubGraphPlugin, FederationPlugin],
   subGraphs: {
-    explicitlyIncludeType: (type, subGraphs) => hasResolvableKey(type)
+    defaultForTypes: ['Public', 'Internal'],
+    fieldsInheritFromTypes: true,
+    explicitlyIncludeType: (type) => hasResolvableKey(type),
   },
 });
 ```

--- a/website/content/docs/plugins/with-input.mdx
+++ b/website/content/docs/plugins/with-input.mdx
@@ -3,9 +3,9 @@ title: With-Input plugin
 description: With-Input plugin docs for Pothos
 ---
 
-A plugin for creating fields with a single input object. This plugin adds a new `t.fieldWithInput`
-method that allows you to more easily define fields with a single input type without having to
-define it separately.
+Define a field and its input object together with `t.fieldWithInput`. The plugin creates the
+input type and a required `input` argument. Use a core `builder.inputType` instead when several
+fields should share the same input type.
 
 ## Usage
 
@@ -18,6 +18,7 @@ npm install --save @pothos/plugin-with-input
 ### Setup
 
 ```typescript
+import SchemaBuilder from '@pothos/core';
 import WithInputPlugin from '@pothos/plugin-with-input';
 const builder = new SchemaBuilder({
   plugins: [WithInputPlugin],
@@ -54,7 +55,7 @@ This will produce a schema like:
 
 ```graphql
 type Query {
-  example(input: QueryExampleInput!): ID!
+  example(input: QueryExampleInput!): ID
 }
 
 input QueryExampleInput {
@@ -66,7 +67,7 @@ The input name will default to `${ParentType.name}${Field.name}Input`.
 
 ### Customizing your input object
 
-You can customize the name of your Input object, and the name of the input argument:
+Replace the previous query definition with this version to customize both names:
 
 ```typescript
 builder.queryType({
@@ -107,7 +108,7 @@ const builder = new SchemaBuilder<{ WithInputArgRequired: false }>({
 });
 ```
 
-arg requiredness can also be set on a per field basis by setting `argOptions.required`
+Alternatively, keep the original builder and set `argOptions.required` on an individual field.
 
 ```typescript
 builder.queryType({
@@ -124,13 +125,15 @@ builder.queryType({
         return args.input?.someInput;
       },
     }),
+  }),
 });
 ```
 
 ### Prisma plugin integration
 
 If you are using the prisma plugin you can use `t.prismaFieldWithInput` to add prisma fields with
-input objects:
+input objects. This example assumes a builder configured for the Prisma and With-Input plugins,
+a `User` Prisma object, and a Prisma client named `prisma`:
 
 ```typescript
 builder.queryField('user', (t) =>


### PR DESCRIPTION
Renew Mocks, Simple Objects, Sub-Graph, and With-Input examples with consistent backing data and field definitions. Clarify inferred object shapes, mock behavior, schema membership, and generated input options; synchronize package READMEs.

Validation: exact primary examples strict-typecheck. Current-source queries compare mocked/real resolvers, computed fields, public/internal/combined/shared schemas, and required/renamed/optional generated input arguments and SDL. Relevant package tests pass, including all three With-Input tests under Node 24. Final website build and rendered documentation links/anchors pass.

Separate post-publication editorial and correctness reviews are complete; material findings were addressed.

Preservation re-review against original base `7c0a5490`: Compared all removed content for Directives, Mocks, Simple Objects, SubGraph, and With-Input. Configuration, integrations, alternatives, and limitations remain covered; obsolete or incorrect API claims were corrected with source evidence.

All useful omissions identified by the new review were fixed and independently re-reviewed. The final integrated production website build, executable documentation checks, and links/anchors across 77 rendered pages pass. Dependency-install fences use `package-install` throughout the changed website pages and READMEs.
