### PR TITLE
fix: provision Prisma Next postgres for releases

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -21,6 +21,19 @@ jobs:
       pull-requests: write
 
     services:
+      prisma-next-postgres:
+        image: postgres:18.2
+        ports:
+          - '5456:5432'
+        env:
+          POSTGRES_USER: prisma
+          POSTGRES_PASSWORD: prisma
+          POSTGRES_DB: prisma_next
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
       # Label used to access the service container
       postgres:
         # Docker Hub image


### PR DESCRIPTION
The release workflow fails before publishing because Prisma Next runtime tests connect to localhost:5456 without a PostgreSQL service. Add the same postgres:18.2 service used by Node.js CI, including the prisma_next database and health check.

Validation: parsed workflow YAML, verified service equality with Node.js CI and the expected test endpoint, and passed git diff --check. The release run will validate the full suite.