### PR TITLE
docs: make foundational guides runnable in the playground

### DIFF
--- a/website/content/docs/guide/args.mdx
+++ b/website/content/docs/guide/args.mdx
@@ -13,22 +13,7 @@ second parameter.
 
 Use `t.arg` with a scalar type name:
 
-```typescript
-import SchemaBuilder from '@pothos/core';
-
-const builder = new SchemaBuilder({});
-
-builder.queryType({
-  fields: (t) => ({
-    greeting: t.string({
-      args: {
-        name: t.arg({ type: 'String', required: true }),
-      },
-      resolve: (_parent, args) => `Hello, ${args.name}!`,
-    }),
-  }),
-});
-```
+<include cwd lang="typescript" meta='playground example="foundations-arguments"'>playground-examples/foundations-arguments/schema.ts#greeting</include>
 
 ### Using convenience methods
 
@@ -44,50 +29,18 @@ See [Changing Default Nullability](./changing-default-nullability) to change thi
 An optional argument can be omitted or explicitly set to `null`. A `defaultValue` applies when
 an argument is omitted; it does not replace an explicit `null`. The resolver below handles both:
 
-```typescript
-builder.queryField('repeat', (t) =>
-  t.string({
-    args: {
-      text: t.arg.string({ required: true }),
-      times: t.arg.int({ defaultValue: 2 }),
-    },
-    resolve: (_parent, args) => args.text.repeat(Math.max(0, args.times ?? 1)),
-  }),
-);
-```
+<include cwd lang="typescript" meta='playground example="foundations-arguments"'>playground-examples/foundations-arguments/schema.ts#defaults</include>
 
 ## Lists
 
 Wrap a type in an array to create a list argument, or use a list helper:
 
-```typescript
-builder.queryField('knownGiraffes', (t) =>
-  t.stringList({
-    args: {
-      names: t.arg.stringList({ required: true }),
-      moreNames: t.arg({ type: ['String'], required: true }),
-    },
-    resolve: (_parent, args) =>
-      [...args.names, ...args.moreNames].filter((name) => ['Gina', 'James'].includes(name)),
-  }),
-);
-```
+<include cwd lang="typescript" meta='playground example="foundations-arguments"'>playground-examples/foundations-arguments/schema.ts#lists</include>
 
 List items are non-null by default, even when the list argument is optional. Use separate `list`
 and `items` settings to allow null entries in a required list:
 
-```typescript
-builder.queryField('nonNullNames', (t) =>
-  t.stringList({
-    args: {
-      names: t.arg.stringList({
-        required: { list: true, items: false },
-      }),
-    },
-    resolve: (_parent, args) => args.names.filter((name) => name != null),
-  }),
-);
-```
+<include cwd lang="typescript" meta='playground example="foundations-arguments"'>playground-examples/foundations-arguments/schema.ts#nullable-items</include>
 
 ## Other types
 
@@ -96,55 +49,14 @@ and unions cannot be argument types.
 
 This object field accepts an enum argument to choose the unit for its result:
 
-```typescript
-const LengthUnit = builder.enumType('LengthUnit', {
-  values: { Feet: {}, Meters: {} },
-});
-
-const GiraffeRef = builder.objectRef<{ heightInMeters: number }>('Giraffe').implement({
-  fields: (t) => ({
-    height: t.float({
-      args: {
-        unit: t.arg({ type: LengthUnit, defaultValue: 'Meters' }),
-      },
-      resolve: (giraffe, args) =>
-        args.unit === 'Feet' ? giraffe.heightInMeters * 3.281 : giraffe.heightInMeters,
-    }),
-  }),
-});
-
-builder.queryField('giraffe', (t) =>
-  t.field({
-    type: GiraffeRef,
-    resolve: () => ({ heightInMeters: 5 }),
-  }),
-);
-```
+<include cwd lang="typescript" meta='playground example="foundations-arguments"'>playground-examples/foundations-arguments/schema.ts#enum</include>
 
 ## Nested Lists
 
 Use `t.arg.listRef` to nest lists. Its `required` option controls the items of that list;
 `required` on `t.arg` controls whether the outermost list can be omitted or null.
 
-```typescript
-builder.queryField('countNames', (t) =>
-  t.int({
-    args: {
-      groups: t.arg({
-        type: t.arg.listRef(t.arg.listRef('String', { required: false })),
-        required: true,
-      }),
-    },
-    resolve: (_parent, args) =>
-      args.groups.reduce(
-        (count, group) => count + group.filter((name) => name != null).length,
-        0,
-      ),
-  }),
-);
-
-export const schema = builder.toSchema();
-```
+<include cwd lang="typescript" meta='playground example="foundations-arguments"'>playground-examples/foundations-arguments/schema.ts#nested-lists</include>
 
 Here, `groups` has GraphQL type `[[String]!]!`: the outer list and each inner list are required,
 but strings inside the inner lists can be null. Without `{ required: false }`, those strings
@@ -155,20 +67,7 @@ would also be non-null.
 The examples above form one schema. This query exercises required arguments, defaults, lists,
 and the enum argument on an object field:
 
-```graphql
-query {
-  greeting(name: "Gina")
-  repeat(text: "ha")
-  once: repeat(text: "ha", times: null)
-  knownGiraffes(names: ["Gina", "Unknown"], moreNames: ["James"])
-  nonNullNames(names: ["Gina", null, "James"])
-  giraffe {
-    meters: height
-    feet: height(unit: Feet)
-  }
-  countNames(groups: [["Gina", null], ["James"]])
-}
-```
+<include cwd lang="graphql" meta='playground example="foundations-arguments"'>playground-examples/foundations-arguments/Arguments.graphql</include>
 
 ```json
 {

--- a/website/content/docs/guide/context.mdx
+++ b/website/content/docs/guide/context.mdx
@@ -8,55 +8,20 @@ example, you can use it to make the current user available throughout your schem
 
 First, let's define the user data and add a `Context` type to the builder:
 
-```typescript
-import SchemaBuilder from '@pothos/core';
-
-interface User {
-  id: string;
-  firstName: string;
-  username: string;
-}
-
-const builder = new SchemaBuilder<{
-  Context: {
-    currentUser: User | null;
-  };
-}>({});
-```
+<include cwd lang="typescript" meta='playground example="foundations-context"'>playground-examples/foundations-context/schema.ts#context</include>
 
 Next, we can define a GraphQL object for the user and a query that reads it from context:
 
-```typescript
-const UserRef = builder.objectRef<User>('User').implement({
-  fields: (t) => ({
-    id: t.exposeID('id'),
-    firstName: t.exposeString('firstName'),
-    username: t.exposeString('username'),
-  }),
-});
-
-builder.queryType({
-  fields: (t) => ({
-    currentUser: t.field({
-      type: UserRef,
-      nullable: true,
-      resolve: (_root, _args, context) => context.currentUser,
-    }),
-  }),
-});
-```
+<include cwd lang="typescript" meta='playground example="foundations-context"'>playground-examples/foundations-context/schema.ts#query</include>
 
 The resolver's `context` parameter has the type we provided to the builder. Clients can query the
 current user with:
 
-```graphql
-query {
-  currentUser {
-    id
-    username
-  }
-}
-```
+<include cwd lang="graphql" meta='playground example="foundations-context"'>playground-examples/foundations-context/01-Signed in.graphql</include>
+
+In the playground, select **01-Signed in** or **02-Signed out** and inspect **Context**. Change
+the signed-in fixture's `username` and run it again. These values simulate request data; the server
+setup below performs the actual user lookup.
 
 When there is no signed-in user, the response is `{ "data": { "currentUser": null } }`.
 
@@ -97,36 +62,11 @@ If your HTTP and WebSocket handlers provide different context properties, a
 [discriminated union](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions)
 lets resolvers check which properties are available:
 
-```typescript
-type Context =
-  | {
-      transport: 'http';
-      request: Request;
-    }
-  | {
-      transport: 'websocket';
-      connectionParams: { clientName: string };
-    };
+<include cwd lang="typescript" meta='playground example="foundations-context-transports"'>playground-examples/foundations-context-transports/schema.ts#transport</include>
 
-const builder = new SchemaBuilder<{
-  Context: Context;
-}>({});
-
-builder.queryType({
-  fields: (t) => ({
-    clientName: t.string({
-      nullable: true,
-      resolve: (_root, _args, context) => {
-        if (context.transport === 'http') {
-          return context.request.headers.get('x-client-name');
-        }
-
-        return context.connectionParams.clientName;
-      },
-    }),
-  }),
-});
-```
+The companion runs the WebSocket-shaped branch with a JSON context fixture. Its `Context` editor
+can represent `connectionParams`, but an HTTP `Request` must come from your server; editing the
+playground's **Headers** does not create one or start a WebSocket connection.
 
 Checking `transport` narrows the context type, so the resolver can access the properties for that
 transport. Set the discriminator and the corresponding properties when creating the context in each

--- a/website/content/docs/guide/fields.mdx
+++ b/website/content/docs/guide/fields.mdx
@@ -15,38 +15,16 @@ Scalar fields can be defined a couple of different ways:
 
 ### Field method
 
-```typescript
-builder.queryType({
-  fields: (t) => ({
-    name: t.field({
-      description: 'Name field',
-      type: 'String',
-      resolve: () => 'Gina',
-    }),
-  }),
-});
-```
+<include cwd lang="typescript" meta='playground example="foundations-field-scalars"'>playground-examples/foundations-field-scalars/schema.ts#field-method</include>
 
 ### Convenience methods
 
 Convenience methods are just wrappers around the `field` method that omit the `type` option.
 
-```typescript
-builder.queryType({
-  fields: (t) => ({
-    id: t.id({ resolve: () => '123' }),
-    int: t.int({ resolve: () => 123 }),
-    float: t.float({ resolve: () => 1.23 }),
-    boolean: t.boolean({ resolve: () => false }),
-    string: t.string({ resolve: () => 'abc' }),
-    idList: t.idList({ resolve: () => ['123'] }),
-    intList: t.intList({ resolve: () => [123] }),
-    floatList: t.floatList({ resolve: () => [1.23] }),
-    booleanList: t.booleanList({ resolve: () => [false] }),
-    stringList: t.stringList({ resolve: () => ['abc'] }),
-  }),
-});
-```
+<include cwd lang="typescript" meta='playground example="foundations-field-scalars"'>playground-examples/foundations-field-scalars/schema.ts#convenience-methods</include>
+
+Each Playground action opens a complete schema. In the scalar example, `queryFields` adds
+convenience fields to the `Query` type already defined with `queryType`.
 
 ## Other types
 
@@ -55,27 +33,7 @@ Fields for non-scalar fields can also be created with the `field` method.
 Some types like [Objects](./objects) and [Interfaces](./interfaces) can be referenced by name if
 they have a backing model defined in the schema builder.
 
-```typescript
-const builder = new SchemaBuilder<{
-  Objects: { Giraffe: { name: string } };
-}>({});
-
-builder.objectType('Giraffe', {
-  fields: (t) => ({
-    name: t.exposeString('name'),
-  }),
-});
-
-builder.queryType({
-  fields: (t) => ({
-    giraffe: t.field({
-      description: 'A giraffe',
-      type: 'Giraffe',
-      resolve: () => ({ name: 'Gina' }),
-    }),
-  }),
-});
-```
+<includeregions cwd lang="typescript" meta='playground example="foundations-field-types"'>playground-examples/foundations-field-types/schema.ts#model,object-query</includeregions>
 
 For types not described in the `SchemaTypes` type provided to the builder, including types that can
 not be added there like [Unions](./unions) and [Enums](./enums), you can use a `Ref` returned by the
@@ -85,38 +43,13 @@ enum, you can also use the `class` or `enum` that was used to define them.
 
 Here we add an enum field to the `Giraffe` type defined above:
 
-```typescript
-const LengthUnit = builder.enumType('LengthUnit', {
-  values: { Feet: {}, Meters: {} },
-});
-
-builder.objectField('Giraffe', 'preferredNeckLengthUnit', (t) =>
-  t.field({
-    type: LengthUnit,
-    resolve: () => 'Feet',
-  }),
-);
-```
+<include cwd lang="typescript" meta='playground example="foundations-field-types"'>playground-examples/foundations-field-types/schema.ts#enum</include>
 
 ## Lists
 
 To create a list field, you can wrap the type in an array
 
-```typescript
-builder.queryType({
-  fields: (t) => ({
-    giraffes: t.field({
-      description: 'multiple giraffes',
-      type: ['Giraffe'],
-      resolve: () => [{ name: 'Gina' }, { name: 'James' }],
-    }),
-    giraffeNames: t.field({
-      type: ['String'],
-      resolve: () => ['Gina', 'James'],
-    }),
-  }),
-});
-```
+<include cwd lang="typescript" meta='playground example="foundations-field-types"'>playground-examples/foundations-field-types/schema.ts#lists</include>
 
 ## NonNullable fields
 
@@ -124,34 +57,7 @@ Fields in Pothos are nullable by default, but fields can be made NonNullable by 
 `nullable` option to `false`. This default can also be changed in the SchemaBuilder constructor, see
 [Changing Default Nullability](./changing-default-nullability) for more details.
 
-```typescript
-builder.queryType({
-  fields: (t) => ({
-    nonNullableField: t.field({
-      type: 'String',
-      nullable: false,
-      resolve: () => 'Gina',
-    }),
-    nonNullableString: t.string({
-      nullable: false,
-      resolve: () => 'Gina',
-    }),
-    nonNullableList: t.field({
-      type: ['String'],
-      nullable: false,
-      resolve: () => ['Gina', 'James'],
-    }),
-    sparseList: t.field({
-      type: ['String'],
-      nullable: {
-        list: false,
-        items: true,
-      },
-      resolve: () => [null],
-    }),
-  }),
-});
-```
+<include cwd lang="typescript" meta='playground example="foundations-field-nullability"'>playground-examples/foundations-field-nullability/schema.ts#fields</include>
 
 Note that by default even if a list field is nullable, the items in that list are not. The last
 example above shows how you can make list items nullable.
@@ -165,17 +71,7 @@ need to be explicitly defined, but there are helper methods that make exposing f
 These helpers are not available for root types \(Query, Mutation and Subscription\), but will work
 on any other object type or interface.
 
-```typescript
-const builder = new SchemaBuilder<{
-  Objects: { Giraffe: { name: string } };
-}>({});
-
-builder.objectType('Giraffe', {
-  fields: (t) => ({
-    name: t.exposeString('name', {}),
-  }),
-});
-```
+<include cwd lang="typescript" meta='playground example="foundations-field-types"'>playground-examples/foundations-field-types/schema.ts#model</include>
 
 The available expose helpers are:
 
@@ -194,25 +90,7 @@ The available expose helpers are:
 
 Arguments for a field can be defined in the options for a field:
 
-```typescript
-builder.queryType({
-  fields: (t) => ({
-    giraffeByName: t.field({
-      type: 'Giraffe',
-      args: {
-        name: t.arg.string({ required: true }),
-      },
-      resolve: (root, args) => {
-        if (args.name !== 'Gina') {
-          throw new Error(`Unknown Giraffe ${args.name}`);
-        }
-
-        return { name: 'Gina' };
-      },
-    }),
-  }),
-});
-```
+<include cwd lang="typescript" meta='playground example="foundations-field-types"'>playground-examples/foundations-field-types/schema.ts#argument</include>
 
 For more information see the [Arguments Guide](./args).
 
@@ -223,41 +101,15 @@ independently. This is useful for breaking up types with a lot of fields into mu
 co-locating fields with their type \(e.g., add all query/mutation fields for a type in the same file
 where the type is defined\).
 
-```typescript
-builder.queryFields((t) => ({
-  giraffe: t.field({
-    type: 'Giraffe',
-    resolve: () => ({ name: 'James' }),
-  }),
-}));
-
-builder.objectField('Giraffe', 'nameLength', (t) =>
-  t.int({
-    resolve: (parent) => parent.name.length,
-  }),
-);
-```
+<include cwd lang="typescript" meta='playground example="foundations-field-types"'>playground-examples/foundations-field-types/schema.ts#additional-fields</include>
 
 To see all the methods available for defining fields see the [SchemaBuilder API](../api/schema-builder)
+
+The companion adds `newestGiraffe` separately from the original `giraffe` field. Query
+`newestGiraffe { name nameLength }` to see both the added root field and the computed object field.
 
 ## Nested Lists
 
 You can use `t.listRef` to create a list of lists
 
-```typescript
-const Query = builder.queryType({
-  fields: (t) => ({
-    example: t.field({
-      type: t.listRef(
-        t.listRef('String'),
-        // items are non-nullable by default, this can be overridden
-        // by passing `nullable: true`
-        { nullable: true },
-      ),
-      resolve: (parent, args) => {
-        return [['a', 'b'], ['c', 'd'], null];
-      },
-    }),
-  }),
-});
-```
+<include cwd lang="typescript" meta='playground example="foundations-field-nested-lists"'>playground-examples/foundations-field-nested-lists/schema.ts#fields</include>

--- a/website/content/docs/guide/index.mdx
+++ b/website/content/docs/guide/index.mdx
@@ -6,6 +6,9 @@ description: Install Pothos, build a schema, and run your first GraphQL query.
 Pothos builds a standard GraphQL schema from TypeScript. This guide creates a small schema, serves it
 with [GraphQL Yoga](https://the-guild.dev/graphql/yoga-server), and runs a query against it.
 
+You can try the schema immediately with its Playground action below. Follow the setup steps to run
+the same schema in your own server. [Using the playground](/docs/guide/playground) explains the editor controls.
+
 ## Installing
 
 Start in an empty directory with Node.js and npm installed:
@@ -52,24 +55,7 @@ Pothos to an existing project too.
 
 Create `schema.ts`:
 
-```typescript
-import SchemaBuilder from '@pothos/core';
-
-const builder = new SchemaBuilder({});
-
-builder.queryType({
-  fields: (t) => ({
-    hello: t.string({
-      args: {
-        name: t.arg.string(),
-      },
-      resolve: (parent, { name }) => `hello, ${name ?? 'World'}`,
-    }),
-  }),
-});
-
-export const schema = builder.toSchema();
-```
+<include cwd lang="typescript" meta='playground example="foundations-getting-started"'>playground-examples/foundations-getting-started/schema.ts</include>
 
 `queryType` defines the fields clients can query. Here, `hello` returns a string and accepts an
 optional `name` argument. Pothos infers the resolver's argument types from that definition.
@@ -108,11 +94,7 @@ npx tsx server.ts
 Open [http://localhost:4000/graphql](http://localhost:4000/graphql) to use Yoga's GraphiQL explorer.
 Run this query:
 
-```graphql
-query {
-  hello(name: "Pothos")
-}
-```
+<include cwd lang="graphql" meta='playground example="foundations-getting-started"'>playground-examples/foundations-getting-started/Hello.graphql</include>
 
 The response is:
 

--- a/website/content/docs/guide/inputs.mdx
+++ b/website/content/docs/guide/inputs.mdx
@@ -11,77 +11,25 @@ returned ref as an argument type. Pothos infers the input shape from its fields.
 The examples through “Recursive inputs” build on the same schema. Start with a backing model and
 an object ref for the mutation result:
 
-```typescript
-import SchemaBuilder from '@pothos/core';
-
-type Giraffe = {
-  name: string;
-  birthdate: string;
-  height: number;
-};
-
-const builder = new SchemaBuilder({});
-const giraffes: Giraffe[] = [];
-
-const GiraffeRef = builder.objectRef<Giraffe>('Giraffe').implement({
-  fields: (t) => ({
-    name: t.exposeString('name'),
-    birthdate: t.exposeString('birthdate'),
-    height: t.exposeFloat('height'),
-  }),
-});
-
-builder.queryType({
-  fields: (t) => ({
-    giraffes: t.field({ type: [GiraffeRef], resolve: () => giraffes }),
-  }),
-});
-```
+<include cwd lang="typescript" meta='playground example="foundations-inputs"'>playground-examples/foundations-inputs/schema.ts#model</include>
 
 Input objects and output objects are separate GraphQL types, even when they have the same fields.
 Here, `GiraffeInput` describes the argument and `Giraffe` describes the result. The array stores the
 created giraffes in memory for this example.
 
-```typescript
-const GiraffeInput = builder.inputType('GiraffeInput', {
-  fields: (t) => ({
-    name: t.string({ required: true }),
-    birthdate: t.string({ required: true }),
-    height: t.float({ required: true }),
-  }),
-});
-
-builder.mutationType({
-  fields: (t) => ({
-    createGiraffe: t.field({
-      type: GiraffeRef,
-      args: {
-        input: t.arg({ type: GiraffeInput, required: true }),
-      },
-      resolve: (_root, { input }) => {
-        giraffes.push(input);
-        return input;
-      },
-    }),
-  }),
-});
-```
+<include cwd lang="typescript" meta='playground example="foundations-inputs"'>playground-examples/foundations-inputs/schema.ts#input</include>
 
 `required: true` on the argument requires an input object. Each input field has its own
 requiredness; here all three fields must also be provided and cannot be `null`.
 
-```graphql
-mutation {
-  createGiraffe(input: { name: "Gina", birthdate: "2020-03-15", height: 4.8 }) {
-    name
-    height
-  }
-}
-```
+<include cwd lang="graphql" meta='playground example="foundations-inputs"'>playground-examples/foundations-inputs/01-Create.graphql</include>
 
 ```json
 { "data": { "createGiraffe": { "name": "Gina", "height": 4.8 } } }
 ```
+
+In the playground, run **01-Create**, then **03-Read** to inspect the
+array. Mutations accumulate data until you choose **Reset example**.
 
 ## Recursive inputs
 
@@ -91,75 +39,16 @@ Create the ref before implementing its fields.
 
 Add this input and mutation field to the builder above:
 
-```typescript
-interface RecursiveGiraffeInputShape {
-  name: string;
-  birthdate: string;
-  height: number;
-  friends?: RecursiveGiraffeInputShape[] | null;
-}
+<include cwd lang="typescript" meta='playground example="foundations-inputs"'>playground-examples/foundations-inputs/schema.ts#recursive-input</include>
 
-const RecursiveGiraffeInput = builder.inputRef<RecursiveGiraffeInputShape>(
-  'RecursiveGiraffeInput',
-);
-
-RecursiveGiraffeInput.implement({
-  fields: (t) => ({
-    name: t.string({ required: true }),
-    birthdate: t.string({ required: true }),
-    height: t.float({ required: true }),
-    friends: t.field({
-      type: [RecursiveGiraffeInput],
-      required: { list: false, items: true },
-    }),
-  }),
-});
-
-function createGiraffes(input: RecursiveGiraffeInputShape): Giraffe[] {
-  const giraffe: Giraffe = {
-    name: input.name,
-    birthdate: input.birthdate,
-    height: input.height,
-  };
-
-  return [giraffe, ...(input.friends ?? []).flatMap(createGiraffes)];
-}
-
-builder.mutationField('createGiraffeWithFriends', (t) =>
-  t.field({
-    type: [GiraffeRef],
-    args: {
-      input: t.arg({ type: RecursiveGiraffeInput, required: true }),
-    },
-    resolve: (_root, { input }) => {
-      const created = createGiraffes(input);
-      giraffes.push(...created);
-      return created;
-    },
-  }),
-);
-
-const schema = builder.toSchema();
-```
+Select **02-Friends** in the playground to run the recursive mutation below. Change a
+nested friend's height to see that each result comes from its own input.
 
 The `friends` list can be omitted or set to `null`, but its items cannot be `null`. The TypeScript
 shape includes both optionality and `null` to match those values. The resolver uses each friend's
 own fields and follows nested `friends` lists, returning the parent before its descendants.
 
-```graphql
-mutation {
-  createGiraffeWithFriends(input: {
-    name: "Gina", birthdate: "2020-03-15", height: 4.8
-    friends: [{
-      name: "George", birthdate: "2021-06-01", height: 4.5
-      friends: [{ name: "Gemma", birthdate: "2022-08-10", height: 3.9 }]
-    }]
-  }) {
-    name
-    height
-  }
-}
-```
+<include cwd lang="graphql" meta='playground example="foundations-inputs"'>playground-examples/foundations-inputs/02-Friends.graphql</include>
 
 ```json
 {
@@ -179,32 +68,16 @@ Alternatively, register input shapes in the builder's `Inputs` map to reference 
 To use this approach for `createGiraffe`, keep the import and `Giraffe` backing model from the first
 example and replace its builder declaration with:
 
-```typescript
-const builder = new SchemaBuilder<{
-  Inputs: {
-    GiraffeInput: Giraffe;
-  };
-}>({});
-```
+<include cwd lang="typescript" meta='playground example="foundations-inputs-named"'>playground-examples/foundations-inputs-named/schema.ts#builder</include>
 
 Keep the `giraffes` array, `GiraffeRef`, and query definition. Replace the `GiraffeInput` ref
 declaration with this definition; registering a shape alone does not create the GraphQL input type.
 
-```typescript
-builder.inputType('GiraffeInput', {
-  fields: (t) => ({
-    name: t.string({ required: true }),
-    birthdate: t.string({ required: true }),
-    height: t.float({ required: true }),
-  }),
-});
-```
+<include cwd lang="typescript" meta='playground example="foundations-inputs-named"'>playground-examples/foundations-inputs-named/schema.ts#input</include>
 
-In the `createGiraffe` mutation, replace the `input` argument's `t.arg(...)` expression with:
+In the `createGiraffe` mutation, the `input` argument now references that registered name:
 
-```typescript
-t.arg({ type: 'GiraffeInput', required: true })
-```
+<include cwd lang="typescript" meta='playground example="foundations-inputs-named"'>playground-examples/foundations-inputs-named/schema.ts#argument</include>
 
 Keep the rest of that mutation unchanged and call `builder.toSchema()` after defining it. The first
 mutation and result on this page also work with this schema; the recursive example is independent

--- a/website/content/docs/guide/queries-mutations-and-subscriptions.mdx
+++ b/website/content/docs/guide/queries-mutations-and-subscriptions.mdx
@@ -11,93 +11,35 @@ methods for defining the type, adding one field, and adding several fields.
 Use `builder.queryType()` to define the `Query` type. This example returns plain backing data through
 an [object reference](./objects):
 
-```typescript
-import SchemaBuilder from '@pothos/core';
-
-type Giraffe = { name: string };
-
-const builder = new SchemaBuilder({});
-const giraffes: Giraffe[] = [{ name: 'James' }];
-
-const GiraffeRef = builder.objectRef<Giraffe>('Giraffe').implement({
-  fields: (t) => ({
-    name: t.exposeString('name'),
-  }),
-});
-
-builder.queryType({
-  fields: (t) => ({
-    hello: t.string({
-      resolve: () => 'hello, world!',
-    }),
-    giraffes: t.field({
-      type: [GiraffeRef],
-      resolve: () => giraffes,
-    }),
-  }),
-});
-```
+<include cwd lang="typescript" meta='playground example="foundations-root-operations"'>playground-examples/foundations-root-operations/schema.ts#query</include>
 
 Define the `Query` type once. To split its fields across files, use `builder.queryField()` or
 `builder.queryFields()`. The following is an alternative to the `builder.queryType()` call above,
 using the same builder, object reference, and data:
 
-```typescript
-builder.queryType({});
-
-builder.queryField('hello', (t) =>
-  t.string({
-    resolve: () => 'hello, world!',
-  }),
-);
-
-builder.queryFields((t) => ({
-  giraffes: t.field({
-    type: [GiraffeRef],
-    resolve: () => giraffes,
-  }),
-}));
-```
+<include cwd lang="typescript" meta='playground example="foundations-root-operations-variant-separate"'>playground-examples/foundations-root-operations/variant-separate/schema.ts#query</include>
 
 ## Mutations
 
 Use `builder.mutationType()`, `builder.mutationField()`, and `builder.mutationFields()` in the same
 way. Continuing the query example, this mutation adds a giraffe to the array returned by `giraffes`:
 
-```typescript
-builder.mutationType({});
-
-builder.mutationField('createGiraffe', (t) =>
-  t.field({
-    type: GiraffeRef,
-    args: {
-      name: t.arg.string({ required: true }),
-    },
-    resolve: (_parent, args) => {
-      const giraffe = { name: args.name };
-      giraffes.push(giraffe);
-      return giraffe;
-    },
-  }),
-);
-
-const schema = builder.toSchema();
-```
+<include cwd lang="typescript" meta='playground example="foundations-root-operations"'>playground-examples/foundations-root-operations/schema.ts#mutation</include>
 
 The required argument provides a `string` for the backing model's `name`. This example stores data
 in memory; an application can perform its database write in the resolver instead.
 
-```graphql
-mutation {
-  createGiraffe(name: "Morgan") {
-    name
-  }
-}
-```
+<include cwd lang="graphql" meta='playground example="foundations-root-operations"'>playground-examples/foundations-root-operations/02-Create.graphql</include>
 
-A subsequent `{ giraffes { name } }` query returns both James and Morgan.
+In the playground, select **02-Create** to run that mutation, then **03-After**.
+The `{ giraffes { name } }` query now returns both James and Morgan. Repeating a mutation adds
+another entry; **Reset example** restores the initial data.
 
 ## Subscriptions
+
+Live subscription delivery requires a GraphQL server and event provider. The playground executes
+queries and mutations locally, so run the subscription example below in your server rather than
+the playground.
 
 Use `builder.subscriptionType()`, `builder.subscriptionField()`, and `builder.subscriptionFields()`
 to define subscription fields. Each field has a `subscribe` function that returns an async iterable

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -15,31 +15,7 @@ authorization, pagination, and ORM integration to the same builder.
 
 ## Build a schema from your data
 
-```typescript
-import SchemaBuilder from '@pothos/core';
-
-const builder = new SchemaBuilder({});
-
-const Giraffe = builder.objectRef<{ name: string; heightInMeters: number }>('Giraffe').implement({
-  fields: (t) => ({
-    name: t.exposeString('name'),
-    heightInFeet: t.float({
-      resolve: (giraffe) => giraffe.heightInMeters * 3.28084,
-    }),
-  }),
-});
-
-builder.queryType({
-  fields: (t) => ({
-    giraffe: t.field({
-      type: Giraffe,
-      resolve: () => ({ name: 'Gina', heightInMeters: 5 }),
-    }),
-  }),
-});
-
-export const schema = builder.toSchema();
-```
+<include cwd lang="typescript" meta='playground example="foundations-overview"'>playground-examples/foundations-overview/schema.ts</include>
 
 The backing data and the GraphQL type can have different shapes. Here, the resolver returns a height
 in meters, while clients query `heightInFeet`. Pothos checks the data returned by `giraffe` and infers

--- a/website/playground-examples/foundations-arguments/Arguments.graphql
+++ b/website/playground-examples/foundations-arguments/Arguments.graphql
@@ -1,0 +1,12 @@
+query Arguments {
+  greeting(name: "Gina")
+  repeat(text: "ha")
+  once: repeat(text: "ha", times: null)
+  knownGiraffes(names: ["Gina", "Unknown"], moreNames: ["James"])
+  nonNullNames(names: ["Gina", null, "James"])
+  giraffe {
+    meters: height
+    feet: height(unit: Feet)
+  }
+  countNames(groups: [["Gina", null], ["James"]])
+}

--- a/website/playground-examples/foundations-arguments/expected.json
+++ b/website/playground-examples/foundations-arguments/expected.json
@@ -1,0 +1,16 @@
+{
+  "Arguments.graphql": {
+    "data": {
+      "greeting": "Hello, Gina!",
+      "repeat": "haha",
+      "once": "ha",
+      "knownGiraffes": ["Gina", "James"],
+      "nonNullNames": ["Gina", "James"],
+      "giraffe": {
+        "meters": 5,
+        "feet": 16.405
+      },
+      "countNames": 2
+    }
+  }
+}

--- a/website/playground-examples/foundations-arguments/metadata.json
+++ b/website/playground-examples/foundations-arguments/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "foundations-arguments",
+  "title": "Field arguments",
+  "description": "Run the query to compare omitted defaults with explicit null, list arguments, and enum units. Change times or switch Feet to Meters and run again.",
+  "category": "core",
+  "relatedDocs": ["/docs/guide/args"],
+  "defaultActiveFile": "schema.ts"
+}

--- a/website/playground-examples/foundations-arguments/schema.ts
+++ b/website/playground-examples/foundations-arguments/schema.ts
@@ -1,0 +1,96 @@
+// #region greeting
+import SchemaBuilder from '@pothos/core';
+
+const builder = new SchemaBuilder({});
+
+builder.queryType({
+  fields: (t) => ({
+    greeting: t.string({
+      args: {
+        name: t.arg({ type: 'String', required: true }),
+      },
+      resolve: (_parent, args) => `Hello, ${args.name}!`,
+    }),
+  }),
+});
+// #endregion greeting
+
+// #region defaults
+builder.queryField('repeat', (t) =>
+  t.string({
+    args: {
+      text: t.arg.string({ required: true }),
+      times: t.arg.int({ defaultValue: 2 }),
+    },
+    resolve: (_parent, args) => args.text.repeat(Math.max(0, args.times ?? 1)),
+  }),
+);
+// #endregion defaults
+
+// #region lists
+builder.queryField('knownGiraffes', (t) =>
+  t.stringList({
+    args: {
+      names: t.arg.stringList({ required: true }),
+      moreNames: t.arg({ type: ['String'], required: true }),
+    },
+    resolve: (_parent, args) =>
+      [...args.names, ...args.moreNames].filter((name) => ['Gina', 'James'].includes(name)),
+  }),
+);
+// #endregion lists
+
+// #region nullable-items
+builder.queryField('nonNullNames', (t) =>
+  t.stringList({
+    args: {
+      names: t.arg.stringList({
+        required: { list: true, items: false },
+      }),
+    },
+    resolve: (_parent, args) => args.names.filter((name) => name != null),
+  }),
+);
+// #endregion nullable-items
+
+// #region enum
+const LengthUnit = builder.enumType('LengthUnit', {
+  values: { Feet: {}, Meters: {} },
+});
+
+const GiraffeRef = builder.objectRef<{ heightInMeters: number }>('Giraffe').implement({
+  fields: (t) => ({
+    height: t.float({
+      args: {
+        unit: t.arg({ type: LengthUnit, defaultValue: 'Meters' }),
+      },
+      resolve: (giraffe, args) =>
+        args.unit === 'Feet' ? giraffe.heightInMeters * 3.281 : giraffe.heightInMeters,
+    }),
+  }),
+});
+
+builder.queryField('giraffe', (t) =>
+  t.field({
+    type: GiraffeRef,
+    resolve: () => ({ heightInMeters: 5 }),
+  }),
+);
+// #endregion enum
+
+// #region nested-lists
+builder.queryField('countNames', (t) =>
+  t.int({
+    args: {
+      groups: t.arg({
+        type: t.arg.listRef(t.arg.listRef('String', { required: false })),
+        required: true,
+      }),
+    },
+    resolve: (_parent, args) =>
+      args.groups.reduce((count, group) => count + group.filter((name) => name != null).length, 0),
+  }),
+);
+
+export const schema = builder.toSchema();
+// #endregion nested-lists

--- a/website/playground-examples/foundations-context-transports/WebSocket context.context.json
+++ b/website/playground-examples/foundations-context-transports/WebSocket context.context.json
@@ -1,0 +1,6 @@
+{
+  "transport": "websocket",
+  "connectionParams": {
+    "clientName": "GraphiQL"
+  }
+}

--- a/website/playground-examples/foundations-context-transports/WebSocket context.graphql
+++ b/website/playground-examples/foundations-context-transports/WebSocket context.graphql
@@ -1,0 +1,3 @@
+query WebsocketContext {
+  clientName
+}

--- a/website/playground-examples/foundations-context-transports/expected.json
+++ b/website/playground-examples/foundations-context-transports/expected.json
@@ -1,0 +1,7 @@
+{
+  "WebSocket context.graphql": {
+    "data": {
+      "clientName": "GraphiQL"
+    }
+  }
+}

--- a/website/playground-examples/foundations-context-transports/metadata.json
+++ b/website/playground-examples/foundations-context-transports/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "foundations-context-transports",
+  "title": "Context transport narrowing",
+  "description": "Run the WebSocket-shaped fixture, then change connectionParams.clientName in Context and run again. The HTTP branch expects a real Request supplied by a server, not the playground Headers control.",
+  "category": "core",
+  "relatedDocs": ["/docs/guide/context"],
+  "defaultActiveFile": "schema.ts"
+}

--- a/website/playground-examples/foundations-context-transports/schema.ts
+++ b/website/playground-examples/foundations-context-transports/schema.ts
@@ -1,0 +1,34 @@
+import SchemaBuilder from '@pothos/core';
+
+// #region transport
+type Context =
+  | {
+      transport: 'http';
+      request: Request;
+    }
+  | {
+      transport: 'websocket';
+      connectionParams: { clientName: string };
+    };
+
+const builder = new SchemaBuilder<{
+  Context: Context;
+}>({});
+
+builder.queryType({
+  fields: (t) => ({
+    clientName: t.string({
+      nullable: true,
+      resolve: (_root, _args, context) => {
+        if (context.transport === 'http') {
+          return context.request.headers.get('x-client-name');
+        }
+
+        return context.connectionParams.clientName;
+      },
+    }),
+  }),
+});
+// #endregion transport
+
+export const schema = builder.toSchema();

--- a/website/playground-examples/foundations-context/01-Signed in.context.json
+++ b/website/playground-examples/foundations-context/01-Signed in.context.json
@@ -1,0 +1,7 @@
+{
+  "currentUser": {
+    "id": "1",
+    "firstName": "Gina",
+    "username": "gina"
+  }
+}

--- a/website/playground-examples/foundations-context/01-Signed in.graphql
+++ b/website/playground-examples/foundations-context/01-Signed in.graphql
@@ -1,0 +1,6 @@
+query SignedIn {
+  currentUser {
+    id
+    username
+  }
+}

--- a/website/playground-examples/foundations-context/02-Signed out.context.json
+++ b/website/playground-examples/foundations-context/02-Signed out.context.json
@@ -1,0 +1,3 @@
+{
+  "currentUser": null
+}

--- a/website/playground-examples/foundations-context/02-Signed out.graphql
+++ b/website/playground-examples/foundations-context/02-Signed out.graphql
@@ -1,0 +1,6 @@
+query SignedOut {
+  currentUser {
+    id
+    username
+  }
+}

--- a/website/playground-examples/foundations-context/expected.json
+++ b/website/playground-examples/foundations-context/expected.json
@@ -1,0 +1,15 @@
+{
+  "01-Signed in.graphql": {
+    "data": {
+      "currentUser": {
+        "id": "1",
+        "username": "gina"
+      }
+    }
+  },
+  "02-Signed out.graphql": {
+    "data": {
+      "currentUser": null
+    }
+  }
+}

--- a/website/playground-examples/foundations-context/metadata.json
+++ b/website/playground-examples/foundations-context/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "foundations-context",
+  "title": "Request context",
+  "description": "Run Signed in and Signed out. Open Context to inspect each request\u2019s currentUser, change its username, and run again. The resolver reads context rather than an argument.",
+  "category": "core",
+  "relatedDocs": ["/docs/guide/context"],
+  "defaultActiveFile": "schema.ts"
+}

--- a/website/playground-examples/foundations-context/schema.ts
+++ b/website/playground-examples/foundations-context/schema.ts
@@ -1,0 +1,37 @@
+// #region context
+import SchemaBuilder from '@pothos/core';
+
+interface User {
+  id: string;
+  firstName: string;
+  username: string;
+}
+
+const builder = new SchemaBuilder<{
+  Context: {
+    currentUser: User | null;
+  };
+}>({});
+// #endregion context
+
+// #region query
+const UserRef = builder.objectRef<User>('User').implement({
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    firstName: t.exposeString('firstName'),
+    username: t.exposeString('username'),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    currentUser: t.field({
+      type: UserRef,
+      nullable: true,
+      resolve: (_root, _args, context) => context.currentUser,
+    }),
+  }),
+});
+// #endregion query
+
+export const schema = builder.toSchema();

--- a/website/playground-examples/foundations-coverage.md
+++ b/website/playground-examples/foundations-coverage.md
@@ -1,0 +1,31 @@
+# Foundations companion coverage
+
+Base: `1beb40708` (the reviewed playground pilot on main). This pass covers the overview and six foundational guide pages, preserving the renewed explanations while replacing runnable fences with excerpts from complete, checked examples.
+
+## Page and example mapping
+
+| Page | Executable companion | Preserved coverage |
+| --- | --- | --- |
+| Overview | `foundations-overview` | Gina's backing height in meters, computed feet, inferred resolver types, standard `GraphQLSchema`, core peer dependency and all plugin cards. One file and one query. |
+| Getting started | `foundations-getting-started` | Optional `name`, nullish fallback, the same schema/query/response, installation, strict NodeNext config, Yoga server, separate type checking, execution and Ctrl+C cleanup. One file and one query. |
+| Fields: scalars | `foundations-field-scalars` | Generic `field`, scalar convenience methods and all five scalar list helpers. |
+| Fields: other types, lists, exposing, args, added fields | `foundations-field-types` | SchemaTypes object lookup, enum ref, object/scalar lists, exposed properties, required argument with unknown-name error, separately added root/object fields. Class/enum reference and interface applicability explanations remain. |
+| Fields: nullability and nested lists | `foundations-field-nullability`, `foundations-field-nested-lists` | Non-null fields/lists, nullable list items, default-nullability link, nested list refs and a nullable inner list. |
+| Arguments | `foundations-arguments` | Generic and convenience arg methods, required/default/null semantics, scalar lists, nullable items, enum unit arguments on object fields, nested lists, the complete existing query and result. |
+| Input objects | `foundations-inputs`, `foundations-inputs-named` | Separate output/input types, field and argument requiredness, in-memory create mutation, recursive input ref/explicit shape, each descendant's own data, optional/nullable friends list, and the complete SchemaTypes alternative. |
+| Context | `foundations-context`, `foundations-context-transports` | Typed current user, nullable signed-out result, request context creation, Yoga authentication hook, `initContextCache` identity/lifetime rules, and the HTTP/WebSocket discriminated union. |
+| Queries, mutations and subscriptions | `foundations-root-operations` plus `variant-separate` | Root type definition once; individual/plural field additions; stateful creation and subsequent read; complete alternative query-field registration. Subscription/provider/cleanup and event-type inference guidance remain. |
+
+The page examples keep their existing data and behavior. To make the Fields snippets form coherent schemas, later `queryType` declarations become `queryFields`; the prose explains that the root is already defined. The separately added root field becomes `newestGiraffe`, preserving its James result without overwriting the initial Gina field. The enum resolver preserves its literal type with `as const`. Unused resolver parameters are omitted or prefixed `_`. Query operations are named for the repository's GraphQL lint rule. Input-by-name excerpts now show the entire `input:` property rather than an unattached expression.
+
+## Browser versus server execution
+
+Three TypeScript fences intentionally remain local server examples: Getting started's Yoga server, Context's Yoga/auth context factory, and the subscription schema with an application-supplied event provider. Shell commands, configuration, expected JSON and live subscription operations remain documentation rather than playground actions. Their existing installation, ownership, transport and cleanup guidance is retained.
+
+The context transport companion executes the WebSocket-shaped JSON branch. Its guide and playground instructions explicitly distinguish that fixture from an actual connection and explain why the HTTP branch needs a real server-created `Request`. Context's primary companion checks both signed-in and signed-out data. No runtime, provider or HTTP transport was added to the playground.
+
+## Acceptance
+
+Every new operation has `expected.json` coverage, including the nullable-field error and ordered mutation/read scenarios. The bundle checker checks these responses in the production browser and checks both TypeScript worker diagnostics and actual editor markers. Source includes also select matching GraphQL operations through the existing snippet matching behavior.
+
+Validation records are reported in the PR alongside the production browser run, source checks, independent review and the selected reader edits. The source-derived overview and introduction continue passing the maintained docs assertions, including omitted/null/empty names, backing-property exclusion and printed SDL round trip.

--- a/website/playground-examples/foundations-field-nested-lists/Nested lists.graphql
+++ b/website/playground-examples/foundations-field-nested-lists/Nested lists.graphql
@@ -1,0 +1,3 @@
+query NestedLists {
+  example
+}

--- a/website/playground-examples/foundations-field-nested-lists/expected.json
+++ b/website/playground-examples/foundations-field-nested-lists/expected.json
@@ -1,0 +1,7 @@
+{
+  "Nested lists.graphql": {
+    "data": {
+      "example": [["a", "b"], ["c", "d"], null]
+    }
+  }
+}

--- a/website/playground-examples/foundations-field-nested-lists/metadata.json
+++ b/website/playground-examples/foundations-field-nested-lists/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "foundations-field-nested-lists",
+  "title": "Nested list fields",
+  "description": "Run the query to see two lists and one null list item. Change one inner list, then inspect its result and the generated GraphQL type.",
+  "category": "core",
+  "relatedDocs": ["/docs/guide/fields"],
+  "defaultActiveFile": "schema.ts"
+}

--- a/website/playground-examples/foundations-field-nested-lists/schema.ts
+++ b/website/playground-examples/foundations-field-nested-lists/schema.ts
@@ -1,0 +1,23 @@
+import SchemaBuilder from '@pothos/core';
+
+const builder = new SchemaBuilder({});
+
+// #region fields
+builder.queryType({
+  fields: (t) => ({
+    example: t.field({
+      type: t.listRef(
+        t.listRef('String'),
+        // items are non-nullable by default, this can be overridden
+        // by passing `nullable: true`
+        { nullable: true },
+      ),
+      resolve: () => {
+        return [['a', 'b'], ['c', 'd'], null];
+      },
+    }),
+  }),
+});
+// #endregion fields
+
+export const schema = builder.toSchema();

--- a/website/playground-examples/foundations-field-nullability/Nullability.graphql
+++ b/website/playground-examples/foundations-field-nullability/Nullability.graphql
@@ -1,0 +1,6 @@
+query Nullability {
+  nonNullableField
+  nonNullableString
+  nonNullableList
+  sparseList
+}

--- a/website/playground-examples/foundations-field-nullability/expected.json
+++ b/website/playground-examples/foundations-field-nullability/expected.json
@@ -1,0 +1,10 @@
+{
+  "Nullability.graphql": {
+    "data": {
+      "nonNullableField": "Gina",
+      "nonNullableString": "Gina",
+      "nonNullableList": ["Gina", "James"],
+      "sparseList": [null]
+    }
+  }
+}

--- a/website/playground-examples/foundations-field-nullability/metadata.json
+++ b/website/playground-examples/foundations-field-nullability/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "foundations-field-nullability",
+  "title": "Field and list nullability",
+  "description": "Run the query and inspect schema.graphql: fields and the sparse list are non-null, while sparse list items can be null. Replace the null item with a string and run again.",
+  "category": "core",
+  "relatedDocs": ["/docs/guide/fields"],
+  "defaultActiveFile": "schema.ts"
+}

--- a/website/playground-examples/foundations-field-nullability/schema.ts
+++ b/website/playground-examples/foundations-field-nullability/schema.ts
@@ -1,0 +1,34 @@
+import SchemaBuilder from '@pothos/core';
+
+const builder = new SchemaBuilder({});
+
+// #region fields
+builder.queryType({
+  fields: (t) => ({
+    nonNullableField: t.field({
+      type: 'String',
+      nullable: false,
+      resolve: () => 'Gina',
+    }),
+    nonNullableString: t.string({
+      nullable: false,
+      resolve: () => 'Gina',
+    }),
+    nonNullableList: t.field({
+      type: ['String'],
+      nullable: false,
+      resolve: () => ['Gina', 'James'],
+    }),
+    sparseList: t.field({
+      type: ['String'],
+      nullable: {
+        list: false,
+        items: true,
+      },
+      resolve: () => [null],
+    }),
+  }),
+});
+// #endregion fields
+
+export const schema = builder.toSchema();

--- a/website/playground-examples/foundations-field-scalars/Scalars.graphql
+++ b/website/playground-examples/foundations-field-scalars/Scalars.graphql
@@ -1,0 +1,13 @@
+query Scalars {
+  name
+  id
+  int
+  float
+  boolean
+  string
+  idList
+  intList
+  floatList
+  booleanList
+  stringList
+}

--- a/website/playground-examples/foundations-field-scalars/expected.json
+++ b/website/playground-examples/foundations-field-scalars/expected.json
@@ -1,0 +1,17 @@
+{
+  "Scalars.graphql": {
+    "data": {
+      "name": "Gina",
+      "id": "123",
+      "int": 123,
+      "float": 1.23,
+      "boolean": false,
+      "string": "abc",
+      "idList": ["123"],
+      "intList": [123],
+      "floatList": [1.23],
+      "booleanList": [false],
+      "stringList": ["abc"]
+    }
+  }
+}

--- a/website/playground-examples/foundations-field-scalars/metadata.json
+++ b/website/playground-examples/foundations-field-scalars/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "foundations-field-scalars",
+  "title": "Scalar fields",
+  "description": "Run the scalar fields. Change a resolver value and run again; inspect schema.graphql to compare the scalar and list types.",
+  "category": "core",
+  "relatedDocs": ["/docs/guide/fields"],
+  "defaultActiveFile": "schema.ts"
+}

--- a/website/playground-examples/foundations-field-scalars/schema.ts
+++ b/website/playground-examples/foundations-field-scalars/schema.ts
@@ -1,0 +1,32 @@
+import SchemaBuilder from '@pothos/core';
+
+const builder = new SchemaBuilder({});
+
+// #region field-method
+builder.queryType({
+  fields: (t) => ({
+    name: t.field({
+      description: 'Name field',
+      type: 'String',
+      resolve: () => 'Gina',
+    }),
+  }),
+});
+// #endregion field-method
+
+// #region convenience-methods
+builder.queryFields((t) => ({
+  id: t.id({ resolve: () => '123' }),
+  int: t.int({ resolve: () => 123 }),
+  float: t.float({ resolve: () => 1.23 }),
+  boolean: t.boolean({ resolve: () => false }),
+  string: t.string({ resolve: () => 'abc' }),
+  idList: t.idList({ resolve: () => ['123'] }),
+  intList: t.intList({ resolve: () => [123] }),
+  floatList: t.floatList({ resolve: () => [1.23] }),
+  booleanList: t.booleanList({ resolve: () => [false] }),
+  stringList: t.stringList({ resolve: () => ['abc'] }),
+}));
+// #endregion convenience-methods
+
+export const schema = builder.toSchema();

--- a/website/playground-examples/foundations-field-types/01-Fields.graphql
+++ b/website/playground-examples/foundations-field-types/01-Fields.graphql
@@ -1,0 +1,18 @@
+query Fields {
+  giraffe {
+    name
+    preferredNeckLengthUnit
+    nameLength
+  }
+  giraffes {
+    name
+  }
+  giraffeNames
+  giraffeByName(name: "Gina") {
+    name
+  }
+  newestGiraffe {
+    name
+    nameLength
+  }
+}

--- a/website/playground-examples/foundations-field-types/02-Missing giraffe.graphql
+++ b/website/playground-examples/foundations-field-types/02-Missing giraffe.graphql
@@ -1,0 +1,5 @@
+query MissingGiraffe {
+  giraffeByName(name: "Lucy") {
+    name
+  }
+}

--- a/website/playground-examples/foundations-field-types/expected.json
+++ b/website/playground-examples/foundations-field-types/expected.json
@@ -1,0 +1,38 @@
+{
+  "01-Fields.graphql": {
+    "data": {
+      "giraffe": {
+        "name": "Gina",
+        "preferredNeckLengthUnit": "Feet",
+        "nameLength": 4
+      },
+      "giraffes": [
+        {
+          "name": "Gina"
+        },
+        {
+          "name": "James"
+        }
+      ],
+      "giraffeNames": ["Gina", "James"],
+      "giraffeByName": {
+        "name": "Gina"
+      },
+      "newestGiraffe": {
+        "name": "James",
+        "nameLength": 5
+      }
+    }
+  },
+  "02-Missing giraffe.graphql": {
+    "errors": [
+      {
+        "message": "Unknown Giraffe Lucy",
+        "path": ["giraffeByName"]
+      }
+    ],
+    "data": {
+      "giraffeByName": null
+    }
+  }
+}

--- a/website/playground-examples/foundations-field-types/metadata.json
+++ b/website/playground-examples/foundations-field-types/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "foundations-field-types",
+  "title": "Object and list fields",
+  "description": "Run Fields to compare object, enum, list, and added fields. Try Missing giraffe to see a nullable field report an error. Change Gina in the query to an unknown name.",
+  "category": "core",
+  "relatedDocs": ["/docs/guide/fields"],
+  "defaultActiveFile": "schema.ts"
+}

--- a/website/playground-examples/foundations-field-types/schema.ts
+++ b/website/playground-examples/foundations-field-types/schema.ts
@@ -1,0 +1,87 @@
+import SchemaBuilder from '@pothos/core';
+
+// #region model
+const builder = new SchemaBuilder<{
+  Objects: { Giraffe: { name: string } };
+}>({});
+
+builder.objectType('Giraffe', {
+  fields: (t) => ({
+    name: t.exposeString('name', {}),
+  }),
+});
+// #endregion model
+
+// #region object-query
+builder.queryType({
+  fields: (t) => ({
+    giraffe: t.field({
+      description: 'A giraffe',
+      type: 'Giraffe',
+      resolve: () => ({ name: 'Gina' }),
+    }),
+  }),
+});
+// #endregion object-query
+
+// #region enum
+const LengthUnit = builder.enumType('LengthUnit', {
+  values: { Feet: {}, Meters: {} },
+});
+
+builder.objectField('Giraffe', 'preferredNeckLengthUnit', (t) =>
+  t.field({
+    type: LengthUnit,
+    resolve: () => 'Feet' as const,
+  }),
+);
+// #endregion enum
+
+// #region lists
+builder.queryFields((t) => ({
+  giraffes: t.field({
+    description: 'multiple giraffes',
+    type: ['Giraffe'],
+    resolve: () => [{ name: 'Gina' }, { name: 'James' }],
+  }),
+  giraffeNames: t.field({
+    type: ['String'],
+    resolve: () => ['Gina', 'James'],
+  }),
+}));
+// #endregion lists
+
+// #region argument
+builder.queryFields((t) => ({
+  giraffeByName: t.field({
+    type: 'Giraffe',
+    args: {
+      name: t.arg.string({ required: true }),
+    },
+    resolve: (_root, args) => {
+      if (args.name !== 'Gina') {
+        throw new Error(`Unknown Giraffe ${args.name}`);
+      }
+
+      return { name: 'Gina' };
+    },
+  }),
+}));
+// #endregion argument
+
+// #region additional-fields
+builder.queryFields((t) => ({
+  newestGiraffe: t.field({
+    type: 'Giraffe',
+    resolve: () => ({ name: 'James' }),
+  }),
+}));
+
+builder.objectField('Giraffe', 'nameLength', (t) =>
+  t.int({
+    resolve: (parent) => parent.name.length,
+  }),
+);
+// #endregion additional-fields
+
+export const schema = builder.toSchema();

--- a/website/playground-examples/foundations-getting-started/Hello.graphql
+++ b/website/playground-examples/foundations-getting-started/Hello.graphql
@@ -1,0 +1,3 @@
+query Hello {
+  hello(name: "Pothos")
+}

--- a/website/playground-examples/foundations-getting-started/expected.json
+++ b/website/playground-examples/foundations-getting-started/expected.json
@@ -1,0 +1,7 @@
+{
+  "Hello.graphql": {
+    "data": {
+      "hello": "hello, Pothos"
+    }
+  }
+}

--- a/website/playground-examples/foundations-getting-started/metadata.json
+++ b/website/playground-examples/foundations-getting-started/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "foundations-getting-started",
+  "title": "Your first schema",
+  "description": "Run hello, then remove its name argument to get hello, World. Edit the greeting in schema.ts and run again.",
+  "category": "core",
+  "relatedDocs": ["/docs/guide"],
+  "defaultActiveFile": "schema.ts"
+}

--- a/website/playground-examples/foundations-getting-started/schema.ts
+++ b/website/playground-examples/foundations-getting-started/schema.ts
@@ -1,0 +1,16 @@
+import SchemaBuilder from '@pothos/core';
+
+const builder = new SchemaBuilder({});
+
+builder.queryType({
+  fields: (t) => ({
+    hello: t.string({
+      args: {
+        name: t.arg.string(),
+      },
+      resolve: (_parent, { name }) => `hello, ${name ?? 'World'}`,
+    }),
+  }),
+});
+
+export const schema = builder.toSchema();

--- a/website/playground-examples/foundations-inputs-named/01-Create.graphql
+++ b/website/playground-examples/foundations-inputs-named/01-Create.graphql
@@ -1,0 +1,6 @@
+mutation CreateGiraffe {
+  createGiraffe(input: { name: "Gina", birthdate: "2020-03-15", height: 4.8 }) {
+    name
+    height
+  }
+}

--- a/website/playground-examples/foundations-inputs-named/02-Read.graphql
+++ b/website/playground-examples/foundations-inputs-named/02-Read.graphql
@@ -1,0 +1,6 @@
+query ReadStoredGiraffes {
+  giraffes {
+    name
+    height
+  }
+}

--- a/website/playground-examples/foundations-inputs-named/expected.json
+++ b/website/playground-examples/foundations-inputs-named/expected.json
@@ -1,0 +1,20 @@
+{
+  "01-Create.graphql": {
+    "data": {
+      "createGiraffe": {
+        "name": "Gina",
+        "height": 4.8
+      }
+    }
+  },
+  "02-Read.graphql": {
+    "data": {
+      "giraffes": [
+        {
+          "name": "Gina",
+          "height": 4.8
+        }
+      ]
+    }
+  }
+}

--- a/website/playground-examples/foundations-inputs-named/metadata.json
+++ b/website/playground-examples/foundations-inputs-named/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "foundations-inputs-named",
+  "title": "Input shapes registered by name",
+  "description": "Run Create, then Read. This schema uses the Inputs map and the name GiraffeInput instead of an input ref. Reset example empties the store.",
+  "category": "core",
+  "relatedDocs": ["/docs/guide/inputs"],
+  "defaultActiveFile": "schema.ts"
+}

--- a/website/playground-examples/foundations-inputs-named/schema.ts
+++ b/website/playground-examples/foundations-inputs-named/schema.ts
@@ -1,0 +1,58 @@
+import SchemaBuilder from '@pothos/core';
+
+type Giraffe = {
+  name: string;
+  birthdate: string;
+  height: number;
+};
+
+// #region builder
+const builder = new SchemaBuilder<{
+  Inputs: {
+    GiraffeInput: Giraffe;
+  };
+}>({});
+// #endregion builder
+const giraffes: Giraffe[] = [];
+
+const GiraffeRef = builder.objectRef<Giraffe>('Giraffe').implement({
+  fields: (t) => ({
+    name: t.exposeString('name'),
+    birthdate: t.exposeString('birthdate'),
+    height: t.exposeFloat('height'),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    giraffes: t.field({ type: [GiraffeRef], resolve: () => giraffes }),
+  }),
+});
+
+// #region input
+builder.inputType('GiraffeInput', {
+  fields: (t) => ({
+    name: t.string({ required: true }),
+    birthdate: t.string({ required: true }),
+    height: t.float({ required: true }),
+  }),
+});
+// #endregion input
+
+builder.mutationType({
+  fields: (t) => ({
+    createGiraffe: t.field({
+      type: GiraffeRef,
+      args: {
+        // #region argument
+        input: t.arg({ type: 'GiraffeInput', required: true }),
+        // #endregion argument
+      },
+      resolve: (_root, { input }) => {
+        giraffes.push(input);
+        return input;
+      },
+    }),
+  }),
+});
+export const schema = builder.toSchema();

--- a/website/playground-examples/foundations-inputs/01-Create.graphql
+++ b/website/playground-examples/foundations-inputs/01-Create.graphql
@@ -1,0 +1,6 @@
+mutation CreateGiraffe {
+  createGiraffe(input: { name: "Gina", birthdate: "2020-03-15", height: 4.8 }) {
+    name
+    height
+  }
+}

--- a/website/playground-examples/foundations-inputs/02-Friends.graphql
+++ b/website/playground-examples/foundations-inputs/02-Friends.graphql
@@ -1,0 +1,20 @@
+mutation CreateFriends {
+  createGiraffeWithFriends(
+    input: {
+      name: "Gina"
+      birthdate: "2020-03-15"
+      height: 4.8
+      friends: [
+        {
+          name: "George"
+          birthdate: "2021-06-01"
+          height: 4.5
+          friends: [{ name: "Gemma", birthdate: "2022-08-10", height: 3.9 }]
+        }
+      ]
+    }
+  ) {
+    name
+    height
+  }
+}

--- a/website/playground-examples/foundations-inputs/03-Read.graphql
+++ b/website/playground-examples/foundations-inputs/03-Read.graphql
@@ -1,0 +1,6 @@
+query ReadStoredGiraffes {
+  giraffes {
+    name
+    height
+  }
+}

--- a/website/playground-examples/foundations-inputs/expected.json
+++ b/website/playground-examples/foundations-inputs/expected.json
@@ -1,0 +1,50 @@
+{
+  "01-Create.graphql": {
+    "data": {
+      "createGiraffe": {
+        "name": "Gina",
+        "height": 4.8
+      }
+    }
+  },
+  "02-Friends.graphql": {
+    "data": {
+      "createGiraffeWithFriends": [
+        {
+          "name": "Gina",
+          "height": 4.8
+        },
+        {
+          "name": "George",
+          "height": 4.5
+        },
+        {
+          "name": "Gemma",
+          "height": 3.9
+        }
+      ]
+    }
+  },
+  "03-Read.graphql": {
+    "data": {
+      "giraffes": [
+        {
+          "name": "Gina",
+          "height": 4.8
+        },
+        {
+          "name": "Gina",
+          "height": 4.8
+        },
+        {
+          "name": "George",
+          "height": 4.5
+        },
+        {
+          "name": "Gemma",
+          "height": 3.9
+        }
+      ]
+    }
+  }
+}

--- a/website/playground-examples/foundations-inputs/metadata.json
+++ b/website/playground-examples/foundations-inputs/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "foundations-inputs",
+  "title": "Input objects and recursive inputs",
+  "description": "Run Create, then Friends. Read shows the stored giraffes. Change a nested friend\u2019s height in Friends and run again. Reset example empties the store.",
+  "category": "core",
+  "relatedDocs": ["/docs/guide/inputs"],
+  "defaultActiveFile": "schema.ts"
+}

--- a/website/playground-examples/foundations-inputs/schema.ts
+++ b/website/playground-examples/foundations-inputs/schema.ts
@@ -1,0 +1,100 @@
+// #region model
+import SchemaBuilder from '@pothos/core';
+
+type Giraffe = {
+  name: string;
+  birthdate: string;
+  height: number;
+};
+
+const builder = new SchemaBuilder({});
+const giraffes: Giraffe[] = [];
+
+const GiraffeRef = builder.objectRef<Giraffe>('Giraffe').implement({
+  fields: (t) => ({
+    name: t.exposeString('name'),
+    birthdate: t.exposeString('birthdate'),
+    height: t.exposeFloat('height'),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    giraffes: t.field({ type: [GiraffeRef], resolve: () => giraffes }),
+  }),
+});
+// #endregion model
+
+// #region input
+const GiraffeInput = builder.inputType('GiraffeInput', {
+  fields: (t) => ({
+    name: t.string({ required: true }),
+    birthdate: t.string({ required: true }),
+    height: t.float({ required: true }),
+  }),
+});
+
+builder.mutationType({
+  fields: (t) => ({
+    createGiraffe: t.field({
+      type: GiraffeRef,
+      args: {
+        input: t.arg({ type: GiraffeInput, required: true }),
+      },
+      resolve: (_root, { input }) => {
+        giraffes.push(input);
+        return input;
+      },
+    }),
+  }),
+});
+// #endregion input
+
+// #region recursive-input
+interface RecursiveGiraffeInputShape {
+  name: string;
+  birthdate: string;
+  height: number;
+  friends?: RecursiveGiraffeInputShape[] | null;
+}
+
+const RecursiveGiraffeInput = builder.inputRef<RecursiveGiraffeInputShape>('RecursiveGiraffeInput');
+
+RecursiveGiraffeInput.implement({
+  fields: (t) => ({
+    name: t.string({ required: true }),
+    birthdate: t.string({ required: true }),
+    height: t.float({ required: true }),
+    friends: t.field({
+      type: [RecursiveGiraffeInput],
+      required: { list: false, items: true },
+    }),
+  }),
+});
+
+function createGiraffes(input: RecursiveGiraffeInputShape): Giraffe[] {
+  const giraffe: Giraffe = {
+    name: input.name,
+    birthdate: input.birthdate,
+    height: input.height,
+  };
+
+  return [giraffe, ...(input.friends ?? []).flatMap(createGiraffes)];
+}
+
+builder.mutationField('createGiraffeWithFriends', (t) =>
+  t.field({
+    type: [GiraffeRef],
+    args: {
+      input: t.arg({ type: RecursiveGiraffeInput, required: true }),
+    },
+    resolve: (_root, { input }) => {
+      const created = createGiraffes(input);
+      giraffes.push(...created);
+      return created;
+    },
+  }),
+);
+
+export const schema = builder.toSchema();
+// #endregion recursive-input

--- a/website/playground-examples/foundations-overview/Giraffe.graphql
+++ b/website/playground-examples/foundations-overview/Giraffe.graphql
@@ -1,0 +1,6 @@
+query Giraffe {
+  giraffe {
+    name
+    heightInFeet
+  }
+}

--- a/website/playground-examples/foundations-overview/expected.json
+++ b/website/playground-examples/foundations-overview/expected.json
@@ -1,0 +1,10 @@
+{
+  "Giraffe.graphql": {
+    "data": {
+      "giraffe": {
+        "name": "Gina",
+        "heightInFeet": 16.4042
+      }
+    }
+  }
+}

--- a/website/playground-examples/foundations-overview/metadata.json
+++ b/website/playground-examples/foundations-overview/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "foundations-overview",
+  "title": "A schema from your data",
+  "description": "Run the query, then change heightInMeters in the backing data. The result changes in feet without exposing the original property.",
+  "category": "core",
+  "relatedDocs": ["/docs"],
+  "defaultActiveFile": "schema.ts"
+}

--- a/website/playground-examples/foundations-overview/schema.ts
+++ b/website/playground-examples/foundations-overview/schema.ts
@@ -1,0 +1,23 @@
+import SchemaBuilder from '@pothos/core';
+
+const builder = new SchemaBuilder({});
+
+const Giraffe = builder.objectRef<{ name: string; heightInMeters: number }>('Giraffe').implement({
+  fields: (t) => ({
+    name: t.exposeString('name'),
+    heightInFeet: t.float({
+      resolve: (giraffe) => giraffe.heightInMeters * 3.28084,
+    }),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    giraffe: t.field({
+      type: Giraffe,
+      resolve: () => ({ name: 'Gina', heightInMeters: 5 }),
+    }),
+  }),
+});
+
+export const schema = builder.toSchema();

--- a/website/playground-examples/foundations-root-operations/01-Before.graphql
+++ b/website/playground-examples/foundations-root-operations/01-Before.graphql
@@ -1,0 +1,6 @@
+query ReadGiraffes {
+  hello
+  giraffes {
+    name
+  }
+}

--- a/website/playground-examples/foundations-root-operations/02-Create.graphql
+++ b/website/playground-examples/foundations-root-operations/02-Create.graphql
@@ -1,0 +1,5 @@
+mutation CreateGiraffe {
+  createGiraffe(name: "Morgan") {
+    name
+  }
+}

--- a/website/playground-examples/foundations-root-operations/03-After.graphql
+++ b/website/playground-examples/foundations-root-operations/03-After.graphql
@@ -1,0 +1,5 @@
+query ReadAgain {
+  giraffes {
+    name
+  }
+}

--- a/website/playground-examples/foundations-root-operations/expected.json
+++ b/website/playground-examples/foundations-root-operations/expected.json
@@ -1,0 +1,31 @@
+{
+  "01-Before.graphql": {
+    "data": {
+      "hello": "hello, world!",
+      "giraffes": [
+        {
+          "name": "James"
+        }
+      ]
+    }
+  },
+  "02-Create.graphql": {
+    "data": {
+      "createGiraffe": {
+        "name": "Morgan"
+      }
+    }
+  },
+  "03-After.graphql": {
+    "data": {
+      "giraffes": [
+        {
+          "name": "James"
+        },
+        {
+          "name": "Morgan"
+        }
+      ]
+    }
+  }
+}

--- a/website/playground-examples/foundations-root-operations/metadata.json
+++ b/website/playground-examples/foundations-root-operations/metadata.json
@@ -1,0 +1,19 @@
+{
+  "id": "foundations-root-operations",
+  "title": "Query and mutation root fields",
+  "description": "Run Before, then Create, then After to observe the stored mutation. Change Morgan in Create and run again. Reset example restores the original James entry.",
+  "category": "core",
+  "relatedDocs": ["/docs/guide/queries-mutations-and-subscriptions"],
+  "defaultActiveFile": "schema.ts",
+  "variants": [
+    {
+      "id": "inline",
+      "title": "Fields on queryType",
+      "default": true
+    },
+    {
+      "id": "separate",
+      "title": "Separate field definitions"
+    }
+  ]
+}

--- a/website/playground-examples/foundations-root-operations/schema.ts
+++ b/website/playground-examples/foundations-root-operations/schema.ts
@@ -1,0 +1,46 @@
+// #region query
+import SchemaBuilder from '@pothos/core';
+
+type Giraffe = { name: string };
+
+const builder = new SchemaBuilder({});
+const giraffes: Giraffe[] = [{ name: 'James' }];
+
+const GiraffeRef = builder.objectRef<Giraffe>('Giraffe').implement({
+  fields: (t) => ({
+    name: t.exposeString('name'),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    hello: t.string({
+      resolve: () => 'hello, world!',
+    }),
+    giraffes: t.field({
+      type: [GiraffeRef],
+      resolve: () => giraffes,
+    }),
+  }),
+});
+// #endregion query
+
+// #region mutation
+builder.mutationType({});
+
+builder.mutationField('createGiraffe', (t) =>
+  t.field({
+    type: GiraffeRef,
+    args: {
+      name: t.arg.string({ required: true }),
+    },
+    resolve: (_parent, args) => {
+      const giraffe = { name: args.name };
+      giraffes.push(giraffe);
+      return giraffe;
+    },
+  }),
+);
+
+export const schema = builder.toSchema();
+// #endregion mutation

--- a/website/playground-examples/foundations-root-operations/variant-separate/expected.json
+++ b/website/playground-examples/foundations-root-operations/variant-separate/expected.json
@@ -1,0 +1,31 @@
+{
+  "01-Before.graphql": {
+    "data": {
+      "hello": "hello, world!",
+      "giraffes": [
+        {
+          "name": "James"
+        }
+      ]
+    }
+  },
+  "02-Create.graphql": {
+    "data": {
+      "createGiraffe": {
+        "name": "Morgan"
+      }
+    }
+  },
+  "03-After.graphql": {
+    "data": {
+      "giraffes": [
+        {
+          "name": "James"
+        },
+        {
+          "name": "Morgan"
+        }
+      ]
+    }
+  }
+}

--- a/website/playground-examples/foundations-root-operations/variant-separate/schema.ts
+++ b/website/playground-examples/foundations-root-operations/variant-separate/schema.ts
@@ -1,0 +1,49 @@
+import SchemaBuilder from '@pothos/core';
+
+type Giraffe = { name: string };
+
+const builder = new SchemaBuilder({});
+const giraffes: Giraffe[] = [{ name: 'James' }];
+
+const GiraffeRef = builder.objectRef<Giraffe>('Giraffe').implement({
+  fields: (t) => ({
+    name: t.exposeString('name'),
+  }),
+});
+
+// #region query
+builder.queryType({});
+
+builder.queryField('hello', (t) =>
+  t.string({
+    resolve: () => 'hello, world!',
+  }),
+);
+
+builder.queryFields((t) => ({
+  giraffes: t.field({
+    type: [GiraffeRef],
+    resolve: () => giraffes,
+  }),
+}));
+// #endregion query
+
+// #region mutation
+builder.mutationType({});
+
+builder.mutationField('createGiraffe', (t) =>
+  t.field({
+    type: GiraffeRef,
+    args: {
+      name: t.arg.string({ required: true }),
+    },
+    resolve: (_parent, args) => {
+      const giraffe = { name: args.name };
+      giraffes.push(giraffe);
+      return giraffe;
+    },
+  }),
+);
+
+export const schema = builder.toSchema();
+// #endregion mutation

--- a/website/scripts/type-playground-examples.mjs
+++ b/website/scripts/type-playground-examples.mjs
@@ -1,44 +1,72 @@
 import { execFileSync } from 'node:child_process';
-import { readdir, unlink, writeFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { loadPlaygroundCases } from './playground-cases.mjs';
 
-await loadPlaygroundCases();
-const files = [];
-async function collect(directory) {
-  for (const entry of await readdir(directory, { withFileTypes: true })) {
-    const path = join(directory, entry.name);
-    if (entry.isDirectory()) {
-      await collect(path);
-    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
-      files.push(resolve(path));
+// Each example is a separate application. Plugin declaration merging must stay
+// within its own program, just as it does in a fresh playground project.
+export async function typecheckPlaygroundCases(examples, root = process.cwd()) {
+  const fixture = await mkdtemp(join(root, '.playground-typecheck-'));
+  let sourceCount = 0;
+  try {
+    for (const [index, example] of examples.entries()) {
+      const directory = join(fixture, String(index));
+      await mkdir(directory);
+      const files = [];
+      for (const file of example.bundle.files) {
+        const path = resolve(directory, file.filename);
+        if (!path.startsWith(`${directory}${sep}`)) {
+          throw new Error(`${example.id}: source path escapes its bundle: ${file.filename}`);
+        }
+        await mkdir(dirname(path), { recursive: true });
+        await writeFile(path, file.content);
+        if (file.filename.endsWith('.ts')) {
+          files.push(path);
+        }
+      }
+      if (!files.length) {
+        throw new Error(`${example.id}: no TypeScript source files`);
+      }
+      const config = join(directory, 'tsconfig.json');
+      await writeFile(
+        config,
+        JSON.stringify({
+          compilerOptions: {
+            target: 'ES2022',
+            module: 'ESNext',
+            moduleResolution: 'Bundler',
+            strict: true,
+            noEmit: true,
+            skipLibCheck: true,
+            esModuleInterop: true,
+            resolveJsonModule: true,
+          },
+          files,
+        }),
+      );
+      try {
+        execFileSync('pnpm', ['exec', 'tsc', '-p', config], { cwd: root, stdio: 'pipe' });
+      } catch (error) {
+        throw new Error(
+          `${example.id}: TypeScript check failed\n${error.stdout ?? ''}${error.stderr ?? ''}`,
+          {
+            cause: error,
+          },
+        );
+      }
+      sourceCount += files.length;
     }
+  } finally {
+    await rm(fixture, { recursive: true, force: true });
   }
+  return sourceCount;
 }
-await collect('playground-examples');
-if (!files.length) {
-  throw new Error('No playground source files found');
-}
-const config = resolve(`.playground-typecheck-${process.pid}.json`);
-try {
-  await writeFile(
-    config,
-    JSON.stringify({
-      compilerOptions: {
-        target: 'ES2022',
-        module: 'ESNext',
-        moduleResolution: 'Bundler',
-        strict: true,
-        noEmit: true,
-        skipLibCheck: true,
-        esModuleInterop: true,
-        resolveJsonModule: true,
-      },
-      files,
-    }),
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const examples = await loadPlaygroundCases();
+  const sourceCount = await typecheckPlaygroundCases(examples);
+  console.log(
+    `PASS ${sourceCount} playground source files in ${examples.length} isolated programs`,
   );
-  execFileSync('pnpm', ['exec', 'tsc', '-p', config], { stdio: 'inherit' });
-  console.log(`PASS ${files.length} playground source files type-checked`);
-} finally {
-  await unlink(config);
 }

--- a/website/scripts/type-playground-examples.test.js
+++ b/website/scripts/type-playground-examples.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { typecheckPlaygroundCases } from './type-playground-examples.mjs';
+
+const schema = (content) => ({ filename: 'schema.ts', content });
+
+describe('playground TypeScript programs', () => {
+  it('keeps plugin declarations isolated while checking nested bundle files', async () => {
+    const count = await typecheckPlaygroundCases([
+      {
+        id: 'with-plugin',
+        bundle: {
+          files: [
+            schema(`import SchemaBuilder from '@pothos/core';
+import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
+import { name } from './models/user';
+const builder = new SchemaBuilder({ plugins: [ScopeAuthPlugin], scopeAuth: { authScopes: () => ({}) } });
+builder.queryType({ fields: (t) => ({ name: t.string({ resolve: () => name }) }) });
+export const schema = builder.toSchema();`),
+            { filename: 'models/user.ts', content: "export const name = 'Alex';" },
+          ],
+        },
+      },
+      {
+        id: 'core-only',
+        bundle: {
+          files: [
+            schema(
+              "import SchemaBuilder from '@pothos/core'; const builder = new SchemaBuilder({});",
+            ),
+          ],
+        },
+      },
+    ]);
+    expect(count).toBe(3);
+  }, 30000);
+
+  it('still rejects a strict type error in a bundle', async () => {
+    await expect(
+      typecheckPlaygroundCases([
+        {
+          id: 'invalid',
+          bundle: { files: [schema('const count: number = null; export { count };')] },
+        },
+      ]),
+    ).rejects.toThrow(/invalid: TypeScript check failed[\s\S]*TS2322/);
+  }, 30000);
+});


### PR DESCRIPTION
The overview and foundational guides now open complete, executable playground companions. Readers can run the code they are reading, edit it, and observe the result; source excerpts and GraphQL operations come from checked example files.

Covers Overview, Getting started, Fields, Arguments, Input Objects, Context, and Queries/Mutations/Subscriptions. Adds 12 families with 13 executable cases and 22 operations, including the complete alternate root-field definitions and SchemaTypes input setup. First examples stay one source file and one query. Context appears only where it is the subject.

The existing server installation/configuration/Yoga workflows, authentication context factory, and subscription provider/cleanup contract remain. Server-only snippets are explicitly distinguished from browser execution. [The coverage map](https://github.com/hayes/pothos/blob/codex/playground-foundations/website/playground-examples/foundations-coverage.md) records every original example and alternative, including the small field-name/registration changes needed to compose complete schemas.

Validation:

- Frozen dependency install and dependent workspace package builds.
- `build-ci`, source docs assertions, reference checks, and 33 unit tests passed.
- Production browser matrix passed all 19 cases and 29 operations (including existing pilot examples), with both actual editor markers and fresh TypeScript diagnostics; all 78 rendered documentation pages passed link/anchor checks.
- Reader checks passed overview/source edits, optional argument defaults and explicit null, recursive descendant edits, named inputs, context edits, precise mutation operation selection, and mutation-store reset.
- Server-only TypeScript fences are unchanged from main; browser-only fixtures do not pretend to start an HTTP/WebSocket server.

The shared TypeScript checker isolation correction is included so example families cannot leak plugin augmentations into each other.

PR #1729 merged content at `2c93b02ce` before the subsequent shared UI fixes were pushed. Those fixes (reachable operation tabs and mobile Run/Close controls) are **not part of this merged PR**; they follow in the types/architecture PRs. The later branch head `99cd5e4fc` passed the full production matrix plus Run/result/Close at 320px, 390px and 1024px, mobile operation keyboard/add/close checks, and removal of obsolete editor files on step transitions. The production preview at http://localhost:4331/docs/guide includes those follow-up fixes.
