### PR TITLE
Refresh landing page with an interactive playground

### DIFF
--- a/website/app/(docs)/docs/[[...slug]]/page.tsx
+++ b/website/app/(docs)/docs/[[...slug]]/page.tsx
@@ -50,14 +50,9 @@ export default async function Page({ params }: { params: Promise<{ slug?: string
         // Tighten the header rhythm: pull the eyebrow/title/description closer
         // together (gap-3) and trim the top padding below the sticky header
         // (xl:pt-10) so real content starts meaningfully higher.
-        className="gap-3 xl:pt-10"
-        // Below xl the sticky mobile TOC pill (grid-area:toc-popover) has a
-        // collapsed row (`--fd-toc-popover-height` resolves to 0 in this
-        // custom layout), so it overlaps and hides the breadcrumb at
-        // scroll-top instead of sitting above it. The pill renders ~40px
-        // tall; push the breadcrumb down far enough to clear it (with a
-        // small gap) on those viewports. xl+ shows no pill and no margin.
-        breadcrumb={{ className: 'max-xl:mt-14' }}
+        className="gap-3 max-xl:pt-20 xl:pt-10"
+        // Reserve room above the article for the floating contents bar, including
+        // root pages that have no breadcrumb to provide that spacing.
         // Page utilities live at the bottom of the TOC (desktop) and the TOC
         // popover (mobile) rather than in the header.
         tableOfContent={{ footer: pageActions }}

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -3,14 +3,15 @@ import { Header } from '../components/marketing/Header';
 import { Hero } from '../components/marketing/Hero';
 import { HeroBody } from '../components/marketing/HeroBody';
 import { PluginGarden } from '../components/marketing/PluginGarden';
+import { SchemaDesign } from '../components/marketing/SchemaDesign';
 import { TrustedBy } from '../components/marketing/TrustedBy';
 
 export const metadata: Metadata = {
   // `absolute` opts out of the root `%s — Pothos` template — this title
   // already leads with "Pothos GraphQL" and shouldn't gain a suffix.
-  title: { absolute: 'Pothos GraphQL — Schemas that grow with your code' },
+  title: { absolute: 'Pothos GraphQL: Schemas that grow with your code' },
   description:
-    'A plugin-based GraphQL schema builder for TypeScript. Define your types once and they flow into every resolver without codegen or decorators.',
+    'Pothos is a GraphQL schema builder for TypeScript with type safety built into every field. Write most of your schema without manual type annotations, with inference that extends to integrations like Prisma, Drizzle, and Zod.',
 };
 
 export default function HomePage() {
@@ -19,6 +20,7 @@ export default function HomePage() {
       <Header />
       <Hero />
       <HeroBody />
+      <SchemaDesign />
       <PluginGarden />
       <TrustedBy />
     </main>

--- a/website/app/playground/page.tsx
+++ b/website/app/playground/page.tsx
@@ -110,6 +110,7 @@ export default function PlaygroundPage() {
       </div>
 
       <PlaygroundLayout
+        hideSidebar={ui.embed}
         sidebar={
           <SchemaSidebar
             files={ui.files}
@@ -126,6 +127,7 @@ export default function PlaygroundPage() {
         }
         editor={
           <SchemaEditor
+            showTabs={ui.embed}
             files={ui.files}
             activeIndex={ui.activeFileIndex}
             sdlActive={ui.sdlActive}

--- a/website/components/marketing/CodeWindow.tsx
+++ b/website/components/marketing/CodeWindow.tsx
@@ -27,7 +27,7 @@ export function CodeWindow({ filename, language = 'TypeScript', children }: Prop
       </div>
       {/* Long lines (e.g. the objectRef backing-model generic) scroll within
           the window rather than clipping under its rounded right edge. */}
-      <div className="px-6 py-5 overflow-x-auto">{children}</div>
+      <div className="px-3 sm:px-6 py-5 overflow-x-auto">{children}</div>
     </div>
   );
 }

--- a/website/components/marketing/Hero.tsx
+++ b/website/components/marketing/Hero.tsx
@@ -3,7 +3,7 @@ import { BotanicalSpray } from './BotanicalSpray';
 
 export function Hero() {
   return (
-    <section className="max-w-[1280px] mx-auto px-10 pt-[88px] pb-20 relative">
+    <section className="max-w-[1280px] mx-auto px-6 sm:px-10 pt-12 md:pt-[88px] pb-12 md:pb-20 relative">
       {/* Trailing pothos vines hanging from the header line. Shown at xl (not
           md): from 768 up to ~1279 the headline reflows to "…grow with your /
           code." and runs under the right-anchored vine, so the leaves crowd

--- a/website/components/marketing/Hero.tsx
+++ b/website/components/marketing/Hero.tsx
@@ -1,24 +1,7 @@
-'use client';
-
 import Link from 'next/link';
-import { useState } from 'react';
-import { copyToClipboard } from '@/lib/clipboard';
 import { BotanicalSpray } from './BotanicalSpray';
 
-const INSTALL_CMD = 'npm i @pothos/core';
-
 export function Hero() {
-  const [copied, setCopied] = useState(false);
-
-  const onCopy = async () => {
-    const ok = await copyToClipboard(INSTALL_CMD);
-    if (!ok) {
-      return;
-    }
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1400);
-  };
-
   return (
     <section className="max-w-[1280px] mx-auto px-10 pt-[88px] pb-20 relative">
       {/* Trailing pothos vines hanging from the header line. Shown at xl (not
@@ -32,7 +15,7 @@ export function Hero() {
       {/* Eyebrow */}
       <div className="inline-flex items-center gap-2 mb-5 text-[12px] uppercase tracking-[0.08em] text-bm-ink-muted">
         <span className="w-[18px] h-px bg-bm-accent" aria-hidden="true" />
-        Type-safe · v4.0
+        GraphQL schema builder for TypeScript
       </div>
 
       {/* H1 — clamps from a comfortable phone size up to the design's 88px */}
@@ -45,7 +28,18 @@ export function Hero() {
           maxWidth: 980,
         }}
       >
-        Schemas that <em className="text-bm-accent">grow</em> with your code.
+        Schemas that{' '}
+        <em
+          className="italic text-bm-accent"
+          // The Fraunces italic 'w' at opsz 144 overshoots its advance box on
+          // the right; combined with the h1's -0.035em tracking it swallowed
+          // the word-space so "grow" and "with" touched. A small right margin
+          // restores a clear gap without adding literal whitespace.
+          style={{ fontVariationSettings: '"opsz" 144', marginRight: '0.12em' }}
+        >
+          grow
+        </em>{' '}
+        with your code
       </h1>
 
       {/* Lede */}
@@ -58,32 +52,19 @@ export function Hero() {
           letterSpacing: '-0.01em',
         }}
       >
-        Pothos is a plugin-based GraphQL schema builder for TypeScript. Define your types once and
-        they flow into every resolver without codegen or decorators. At the scale of Airbnb,
-        Netflix, and your weekend project.
+        Pothos is a GraphQL schema builder for TypeScript with type safety built into every field.
+        Write most of your schema without manual type annotations, with inference that extends to
+        integrations like Prisma, Drizzle, and Zod.
       </p>
 
       {/* CTAs */}
       <div className="flex flex-wrap gap-3 items-center">
         <Link
-          href="/docs"
+          href="/docs/guide"
           className="inline-flex items-center gap-2.5 rounded-lg text-[15px] font-medium px-6 py-3 bg-bm-ink text-bm-bg hover:opacity-90 transition-opacity"
         >
-          Read the guide <span aria-hidden="true">→</span>
+          Get started <span aria-hidden="true">→</span>
         </Link>
-        <button
-          type="button"
-          onClick={onCopy}
-          aria-label={copied ? 'Copied install command' : 'Copy install command'}
-          title={copied ? 'Copied!' : 'Copy to clipboard'}
-          className="inline-flex items-center gap-2.5 rounded-lg text-[14px] px-5 py-2.5 border border-bm-line text-bm-ink font-mono bg-transparent hover:bg-bm-surface-alt transition-colors cursor-pointer"
-        >
-          <code>{INSTALL_CMD}</code>
-          <span className="text-bm-ink-muted ml-2.5" aria-hidden="true">
-            {copied ? '✓' : '⧉'}
-          </span>
-        </button>
-        <span className="text-[13px] text-bm-ink-muted ml-2">MIT · open source</span>
       </div>
     </section>
   );

--- a/website/components/marketing/HeroBody.tsx
+++ b/website/components/marketing/HeroBody.tsx
@@ -1,23 +1,15 @@
-'use client';
-
-import dynamic from 'next/dynamic';
-
-const LandingPlayground = dynamic(
-  () => import('./LandingPlayground').then((module) => module.LandingPlayground),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="h-[640px] rounded-xl border border-bm-line p-6 text-bm-ink-muted">
-        Loading playground…
-      </div>
-    ),
-  },
-);
+import { CodeWindow } from './CodeWindow';
+import { HeroCodeBlock } from './HeroCodeBlock';
+import { ResponsivePlayground } from './ResponsivePlayground';
 
 export function HeroBody() {
   return (
-    <section className="max-w-[1280px] mx-auto px-6 sm:px-10 pb-24">
-      <LandingPlayground />
+    <section className="max-w-[1280px] mx-auto px-6 sm:px-10 pb-16 md:pb-24">
+      <ResponsivePlayground>
+        <CodeWindow filename="schema.ts">
+          <HeroCodeBlock />
+        </CodeWindow>
+      </ResponsivePlayground>
     </section>
   );
 }

--- a/website/components/marketing/HeroBody.tsx
+++ b/website/components/marketing/HeroBody.tsx
@@ -1,43 +1,23 @@
-import { CodeWindow } from './CodeWindow';
-import { HeroCodeBlock } from './HeroCodeBlock';
-import { StatsRow } from './StatsRow';
+'use client';
 
-/**
- * Below the hero copy: a 2-column block with the Pothos snippet on the
- * left and a short value-prop paragraph + stats on the right.
- */
+import dynamic from 'next/dynamic';
+
+const LandingPlayground = dynamic(
+  () => import('./LandingPlayground').then((module) => module.LandingPlayground),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="h-[640px] rounded-xl border border-bm-line p-6 text-bm-ink-muted">
+        Loading playground…
+      </div>
+    ),
+  },
+);
+
 export function HeroBody() {
   return (
-    <section className="max-w-[1280px] mx-auto px-10 pb-24 grid lg:grid-cols-[1.4fr_1fr] gap-14 items-start">
-      <CodeWindow filename="schema/user.ts">
-        <HeroCodeBlock />
-      </CodeWindow>
-
-      <div>
-        {/* h2 (not h3) so the landing page heading order is H1 → H2 → H2 with
-            no skipped level (WCAG 1.3.1). Visual size stays 28px via inline
-            style — the docs `article#nd-page h2` override doesn't apply here. */}
-        <h2
-          className="font-serif font-normal mt-0 mb-4"
-          style={{ fontSize: 28, letterSpacing: '-0.02em' }}
-        >
-          Where the types come from.
-        </h2>
-        <p className="text-bm-ink-soft text-[16px] leading-[1.6] mt-0 mb-7">
-          You write two type annotations here: your context on the builder, and the model backing{' '}
-          <code className="bg-bm-surface-alt px-1.5 py-0.5 rounded text-[13px] font-mono">
-            User
-          </code>
-          . In the last resolver,{' '}
-          <code className="bg-bm-surface-alt px-1.5 py-0.5 rounded text-[13px] font-mono">
-            user
-          </code>{' '}
-          and{' '}
-          <code className="bg-bm-surface-alt px-1.5 py-0.5 rounded text-[13px] font-mono">ctx</code>{' '}
-          are typed from those, without annotations of their own.
-        </p>
-        <StatsRow />
-      </div>
+    <section className="max-w-[1280px] mx-auto px-6 sm:px-10 pb-24">
+      <LandingPlayground />
     </section>
   );
 }

--- a/website/components/marketing/HeroCodeBlock.tsx
+++ b/website/components/marketing/HeroCodeBlock.tsx
@@ -5,107 +5,93 @@
 
 const LINES: ReadonlyArray<readonly [string, string][]> = [
   [
-    ['kw', 'import '],
+    ['kw', 'import'],
+    ['v', ' '],
     ['v', 'SchemaBuilder'],
-    ['p', ' from '],
+    ['v', ' '],
+    ['kw', 'from'],
+    ['v', ' '],
     ['s', "'@pothos/core'"],
-    ['p', ';'],
+    ['v', ';'],
   ],
   [],
   [
-    ['kw', 'const '],
+    ['kw', 'const'],
+    ['v', ' '],
     ['v', 'builder'],
-    ['p', ' = '],
-    ['kw', 'new '],
-    ['fn', 'SchemaBuilder'],
-    ['t', '<{ Context: Context }>'],
-    ['p', '();'],
+    ['v', ' = '],
+    ['kw', 'new'],
+    ['v', ' '],
+    ['v', 'SchemaBuilder'],
+    ['v', '({});'],
   ],
   [],
-  [['c', '// Type the object by its backing model.']],
   [
-    ['kw', 'const '],
-    ['v', 'User'],
-    ['p', ' = '],
     ['v', 'builder'],
-    ['m', '.objectRef'],
-    ['t', '<{ id: string; name: string }>'],
-    ['p', '('],
-    ['s', "'User'"],
-    ['p', ');'],
-  ],
-  [],
-  [
-    ['v', 'User'],
-    ['m', '.implement'],
-    ['p', '({'],
+    ['v', '.'],
+    ['fn', 'queryType'],
+    ['v', '({'],
   ],
   [
-    ['p', '  '],
+    ['v', '  '],
     ['v', 'fields'],
-    ['p', ': ('],
+    ['v', ': ('],
     ['v', 't'],
-    ['p', ') => ({'],
+    ['v', ') => ({'],
   ],
   [
-    ['p', '    '],
-    ['v', 'id'],
-    ['p', ':   '],
+    ['v', '    '],
+    ['v', 'hello'],
+    ['v', ': '],
     ['v', 't'],
-    ['m', '.exposeID'],
-    ['p', '('],
-    ['s', "'id'"],
-    ['p', '),'],
+    ['v', '.'],
+    ['fn', 'string'],
+    ['v', '({'],
   ],
   [
-    ['p', '    '],
+    ['v', '      '],
+    ['v', 'args'],
+    ['v', ': { '],
     ['v', 'name'],
-    ['p', ': '],
+    ['v', ': '],
     ['v', 't'],
-    ['m', '.exposeString'],
-    ['p', '('],
-    ['s', "'name'"],
-    ['p', '),'],
+    ['v', '.'],
+    ['v', 'arg'],
+    ['v', '.'],
+    ['fn', 'string'],
+    ['v', '() },'],
   ],
   [
-    ['p', '    '],
-    ['c', '// user and ctx arrive typed — no annotations.'],
-  ],
-  [
-    ['p', '    '],
-    ['v', 'posts'],
-    ['p', ': '],
-    ['v', 't'],
-    ['m', '.field'],
-    ['p', '({'],
-  ],
-  [
-    ['p', '      '],
-    ['v', 'type'],
-    ['p', ': ['],
-    ['t', 'Post'],
-    ['p', '],'],
-  ],
-  [
-    ['p', '      '],
+    ['v', '      '],
     ['v', 'resolve'],
-    ['p', ': ('],
-    ['v', 'user'],
-    ['p', ', '],
-    ['v', '_args'],
-    ['p', ', '],
-    ['v', 'ctx'],
-    ['p', ') => '],
-    ['fn', 'loadPosts'],
-    ['p', '('],
-    ['v', 'user'],
-    ['p', '.id, '],
-    ['v', 'ctx'],
-    ['p', '),'],
+    ['v', ': ('],
+    ['v', '_'],
+    ['v', ', { '],
+    ['v', 'name'],
+    ['v', ' }) =>'],
   ],
-  [['p', '    }),']],
-  [['p', '  }),']],
-  [['p', '});']],
+  [
+    ['v', '        '],
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: literal code displayed in the example
+    ['s', "`Hello, ${name ?? 'World'}!`"],
+    ['v', ','],
+  ],
+  [['v', '    }),']],
+  [['v', '  }),']],
+  [['v', '});']],
+  [],
+  [
+    ['kw', 'export'],
+    ['v', ' '],
+    ['kw', 'const'],
+    ['v', ' '],
+    ['v', 'schema'],
+    ['v', ' = '],
+    ['v', 'builder'],
+    ['v', '.'],
+    ['fn', 'toSchema'],
+    ['v', '();'],
+  ],
 ];
 
 const COLOR_VAR: Record<string, string> = {
@@ -122,7 +108,7 @@ const COLOR_VAR: Record<string, string> = {
 export function HeroCodeBlock() {
   return (
     <pre
-      className="m-0 font-mono text-[13px] text-[var(--bm-syntax-text)]"
+      className="m-0 font-mono text-[12px] sm:text-[13px] text-[var(--bm-syntax-text)]"
       style={{ lineHeight: 1.7 }}
     >
       {LINES.map((tokens, i) => (
@@ -132,13 +118,13 @@ export function HeroCodeBlock() {
           className="flex"
         >
           <span
-            className="select-none w-7 text-right mr-4 shrink-0 tabular-nums"
+            className="hidden sm:block select-none w-7 text-right mr-4 shrink-0 tabular-nums"
             style={{ color: 'var(--bm-syntax-lineno)' }}
             aria-hidden="true"
           >
             {i + 1}
           </span>
-          <span className="flex-1 whitespace-pre">
+          <span className="min-w-0 flex-1 whitespace-pre-wrap break-words sm:whitespace-pre">
             {tokens.length === 0
               ? ' '
               : tokens.map(([kind, text], j) => (

--- a/website/components/marketing/LandingPlayground.tsx
+++ b/website/components/marketing/LandingPlayground.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useTheme } from '@/components/Providers';
+
+export function LandingPlayground() {
+  const { resolvedTheme } = useTheme();
+  const cleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  const connectScrolling = (iframe: HTMLIFrameElement) => {
+    cleanupRef.current?.();
+    const child = iframe.contentWindow;
+    const document = iframe.contentDocument;
+    if (!child || !document) {
+      return;
+    }
+    const onWheel = (event: WheelEvent) => {
+      // Preserve browser zoom and normal scrolling in an editor the visitor is using.
+      if (event.ctrlKey) {
+        return;
+      }
+      const target = event.target as Element | null;
+      const editor = target?.closest?.('.monaco-editor');
+      if (editor && document.activeElement && editor.contains(document.activeElement)) {
+        return;
+      }
+      // A wheel gesture over an unfocused embed belongs to the surrounding page.
+      // Only intercept wheel events, leaving hover, selection and clicks intact.
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      const scale = event.deltaMode === 1 ? 16 : event.deltaMode === 2 ? window.innerHeight : 1;
+      window.scrollBy({
+        left: event.deltaX * scale,
+        top: event.deltaY * scale,
+        behavior: 'instant',
+      });
+    };
+    child.addEventListener('wheel', onWheel, { capture: true, passive: false });
+    cleanupRef.current = () => child.removeEventListener('wheel', onWheel, true);
+  };
+
+  return (
+    <figure className="m-0 rounded-xl border border-bm-line overflow-hidden bg-bm-editor-bg">
+      <iframe
+        onLoad={(event) => connectScrolling(event.currentTarget)}
+        src={`/playground?embed=1&theme=${encodeURIComponent(resolvedTheme)}`}
+        aria-describedby="landing-playground-caption"
+        title="Pothos playground: edit a schema and run GraphQL queries"
+        className="block w-full h-[900px] md:h-[680px] border-0"
+        allow="clipboard-write"
+      />
+      <figcaption
+        id="landing-playground-caption"
+        className="border-t border-bm-line bg-bm-surface px-4 py-3 text-[13px] leading-relaxed text-bm-ink-muted"
+      >
+        Change the greeting, add an argument, or write another field. The editor checks your
+        TypeScript as you work; run the query to see what your API returns.
+      </figcaption>
+    </figure>
+  );
+}

--- a/website/components/marketing/PluginGarden.tsx
+++ b/website/components/marketing/PluginGarden.tsx
@@ -1,49 +1,72 @@
 import Link from 'next/link';
-import { PLUGINS, type PluginEntry } from '../plugins/plugins';
-import { HOMEPAGE_PLUGINS } from './plugins';
+
+const FEATURES = [
+  {
+    title: 'Database integration',
+    description:
+      'Build fields backed by Prisma or Drizzle, with queries shaped by the requested GraphQL fields.',
+    links: [
+      { label: 'Prisma', slug: 'prisma' },
+      { label: 'Drizzle', slug: 'drizzle' },
+    ],
+  },
+  {
+    title: 'Authorization',
+    description: 'Define access checks on your types and fields using request context.',
+    links: [{ label: 'Scope Auth', slug: 'scope-auth' }],
+  },
+  {
+    title: 'Pagination',
+    description: 'Add cursor-based connections and globally identifiable nodes.',
+    links: [{ label: 'Relay', slug: 'relay' }],
+  },
+  {
+    title: 'Batching',
+    description: 'Batch data loading across resolvers to avoid fetching each item separately.',
+    links: [{ label: 'Dataloader', slug: 'dataloader' }],
+  },
+];
 
 export function PluginGarden() {
   return (
-    <section className="max-w-[1280px] mx-auto px-10 py-24 border-t border-bm-line">
-      <div className="flex items-end justify-between mb-9 flex-wrap gap-4">
-        <div>
-          <div className="text-[12px] uppercase tracking-[0.08em] text-bm-accent mb-2">
-            The plugin garden
-          </div>
-          <h2
-            className="font-serif font-normal m-0"
-            style={{ fontSize: 48, letterSpacing: '-0.025em' }}
-          >
-            Plugins that feel built in.
-          </h2>
+    <section className="max-w-[1280px] mx-auto px-6 sm:px-10 pb-20">
+      <div className="border-t border-bm-line pt-12">
+        <h2 className="font-serif font-normal m-0 mb-5 text-[clamp(32px,4vw,48px)] leading-tight tracking-tight">
+          Plugins extend the builder
+        </h2>
+        <p className="text-bm-ink-soft text-[17px] leading-relaxed max-w-3xl mt-0 mb-10">
+          Add authorization, pagination, or database integration where you define your fields.
+          Plugin options have access to the same parent, argument, and context types as your
+          resolvers.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 border-t border-l border-bm-line">
+          {FEATURES.map((feature) => (
+            <div key={feature.title} className="p-8 border-r border-b border-bm-line">
+              <h3 className="font-medium text-[19px] m-0 mb-3">{feature.title}</h3>
+              <p className="text-bm-ink-soft text-[16px] leading-relaxed m-0 mb-5 max-w-md">
+                {feature.description}
+              </p>
+              <div className="flex gap-6">
+                {feature.links.map((link) => (
+                  <Link
+                    key={link.slug}
+                    href={`/docs/plugins/${link.slug}`}
+                    className="text-bm-accent text-[15px] hover:underline"
+                  >
+                    {link.label} <span aria-hidden="true">→</span>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ))}
         </div>
         <Link
           href="/docs/plugins"
-          className="text-bm-ink-soft hover:text-bm-ink text-[14px] transition-colors"
+          className="inline-block mt-7 text-bm-ink-soft hover:text-bm-ink text-[15px]"
         >
-          Browse all {PLUGINS.length} plugins →
+          Explore all plugins <span aria-hidden="true">→</span>
         </Link>
       </div>
-
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 border-t border-l border-bm-line">
-        {HOMEPAGE_PLUGINS.map((p) => (
-          <PluginCard key={p.slug} plugin={p} />
-        ))}
-      </div>
     </section>
-  );
-}
-
-function PluginCard({ plugin }: { plugin: PluginEntry }) {
-  return (
-    <Link href={`/docs/plugins/${plugin.slug}`} className="block">
-      <div className="px-6 py-6 border-r border-b border-bm-line transition-colors hover:bg-bm-surface group h-full">
-        <div className="flex items-center justify-center size-8 rounded-lg bg-bm-accent-soft text-bm-accent text-[16px] mb-3.5">
-          {plugin.icon}
-        </div>
-        <div className="font-medium text-[15px] mb-1.5">{plugin.name}</div>
-        <p className="text-bm-ink-muted text-[13px] leading-[1.5] m-0">{plugin.description}</p>
-      </div>
-    </Link>
   );
 }

--- a/website/components/marketing/ResponsivePlayground.tsx
+++ b/website/components/marketing/ResponsivePlayground.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { type ReactNode, useSyncExternalStore } from 'react';
+
+const LandingPlayground = dynamic(
+  () => import('./LandingPlayground').then((module) => module.LandingPlayground),
+  { ssr: false },
+);
+
+function subscribe(onChange: () => void) {
+  const query = window.matchMedia('(min-width: 768px)');
+  query.addEventListener('change', onChange);
+  return () => query.removeEventListener('change', onChange);
+}
+
+export function ResponsivePlayground({ children }: { children: ReactNode }) {
+  const desktop = useSyncExternalStore(
+    subscribe,
+    () => window.matchMedia('(min-width: 768px)').matches,
+    () => false,
+  );
+  return desktop ? <LandingPlayground /> : children;
+}

--- a/website/components/marketing/SchemaDesign.tsx
+++ b/website/components/marketing/SchemaDesign.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+
+export function SchemaDesign() {
+  return (
+    <section className="max-w-[1280px] mx-auto px-6 sm:px-10 pb-12 grid md:grid-cols-2 gap-10 md:gap-16">
+      <div>
+        <h2 className="font-serif font-normal text-[30px] leading-tight mt-0 mb-4">
+          Design your own schema
+        </h2>
+        <p className="text-bm-ink-soft text-[17px] leading-relaxed mt-0 mb-5">
+          Define your GraphQL schema independently of how your data is stored. Pothos checks that
+          your data matches the schema and makes it easy to write resolvers where it doesn’t. Expose
+          a property directly, compute a value, or load related data.
+        </p>
+        <p className="text-bm-ink-soft text-[17px] leading-relaxed mt-0 mb-5">
+          The result is a standard GraphQL schema you can use with Yoga, Apollo Server, or any
+          server that accepts a GraphQL.js schema.
+        </p>
+        <Link href="/docs/guide/objects" className="text-bm-accent text-[15px] hover:underline">
+          Defining object types →
+        </Link>
+      </div>
+      <div>
+        <h2 className="font-serif font-normal text-[30px] leading-tight mt-0 mb-4">
+          Write fewer type annotations
+        </h2>
+        <p className="text-bm-ink-soft text-[17px] leading-relaxed mt-0 mb-5">
+          Pothos infers resolver types from your schema, so most fields need no manual type
+          annotations. Arguments are typed from their definitions, parent values from the type they
+          belong to, and context from your builder configuration.
+        </p>
+        <p className="text-bm-ink-soft text-[17px] leading-relaxed mt-0 mb-5">
+          You get autocomplete inside each resolver, and TypeScript checks its return value against
+          the field’s GraphQL type. These checks stay in place as your schema and data change.
+        </p>
+        <Link href="/docs/guide/fields" className="text-bm-accent text-[15px] hover:underline">
+          Defining fields →
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/website/components/marketing/TrustedBy.tsx
+++ b/website/components/marketing/TrustedBy.tsx
@@ -2,8 +2,8 @@ const COMPANIES = ['Airbnb', 'Netflix'];
 
 export function TrustedBy() {
   return (
-    <section className="border-t border-bm-line bg-bm-surface-alt py-14 px-10">
-      <div className="max-w-[1280px] mx-auto flex items-center gap-14 flex-wrap">
+    <section className="border-t border-bm-line bg-bm-surface-alt py-14 px-6 sm:px-10">
+      <div className="max-w-[1280px] mx-auto flex items-center gap-6 sm:gap-14 flex-wrap">
         <span className="text-[12px] uppercase tracking-[0.08em] text-bm-ink-muted">
           In use at some of the largest tech companies, including
         </span>

--- a/website/components/playground/OperationPane/ContextEditor.tsx
+++ b/website/components/playground/OperationPane/ContextEditor.tsx
@@ -53,7 +53,11 @@ export function ContextEditor({ value, onChange, onRun }: Props) {
         tabSize: 2,
         wordWrap: 'on',
         padding: { top: 16, bottom: 16 },
-        scrollbar: { verticalScrollbarSize: 10, horizontalScrollbarSize: 10 },
+        scrollbar: {
+          alwaysConsumeMouseWheel: false,
+          verticalScrollbarSize: 10,
+          horizontalScrollbarSize: 10,
+        },
         fixedOverflowWidgets: true,
       }}
     />

--- a/website/components/playground/OperationPane/QueryEditor.tsx
+++ b/website/components/playground/OperationPane/QueryEditor.tsx
@@ -59,7 +59,11 @@ export function QueryEditor({ value, onChange, onRun }: Props) {
         tabSize: 2,
         wordWrap: 'on',
         padding: { top: 16, bottom: 16 },
-        scrollbar: { verticalScrollbarSize: 10, horizontalScrollbarSize: 10 },
+        scrollbar: {
+          alwaysConsumeMouseWheel: false,
+          verticalScrollbarSize: 10,
+          horizontalScrollbarSize: 10,
+        },
       }}
     />
   );

--- a/website/components/playground/OperationPane/VariablesEditor.tsx
+++ b/website/components/playground/OperationPane/VariablesEditor.tsx
@@ -38,7 +38,11 @@ export function VariablesEditor({ value, onChange, onRun }: Props) {
         tabSize: 2,
         wordWrap: 'on',
         padding: { top: 16, bottom: 16 },
-        scrollbar: { verticalScrollbarSize: 10, horizontalScrollbarSize: 10 },
+        scrollbar: {
+          alwaysConsumeMouseWheel: false,
+          verticalScrollbarSize: 10,
+          horizontalScrollbarSize: 10,
+        },
       }}
     />
   );

--- a/website/components/playground/ResponsePane/PanelView.tsx
+++ b/website/components/playground/ResponsePane/PanelView.tsx
@@ -92,7 +92,11 @@ function CodeView({ content, language }: { content: string; language: string }) 
         folding: true,
         renderLineHighlight: 'none',
         padding: { top: 16, bottom: 16 },
-        scrollbar: { verticalScrollbarSize: 10, horizontalScrollbarSize: 10 },
+        scrollbar: {
+          alwaysConsumeMouseWheel: false,
+          verticalScrollbarSize: 10,
+          horizontalScrollbarSize: 10,
+        },
       }}
     />
   );

--- a/website/components/playground/ResponsePane/ResponseEditor.tsx
+++ b/website/components/playground/ResponsePane/ResponseEditor.tsx
@@ -28,7 +28,11 @@ export function ResponseEditor({ body }: Props) {
         folding: true,
         renderLineHighlight: 'none',
         padding: { top: 16, bottom: 16 },
-        scrollbar: { verticalScrollbarSize: 10, horizontalScrollbarSize: 10 },
+        scrollbar: {
+          alwaysConsumeMouseWheel: false,
+          verticalScrollbarSize: 10,
+          horizontalScrollbarSize: 10,
+        },
       }}
     />
   );

--- a/website/components/playground/SchemaEditor/SchemaEditor.tsx
+++ b/website/components/playground/SchemaEditor/SchemaEditor.tsx
@@ -6,12 +6,13 @@ import { SourceEditor } from './SourceEditor';
 
 interface Props {
   files: PlaygroundFile[];
+  showTabs?: boolean;
+  onSelectFile: (index: number) => void;
+  onSelectSdl: () => void;
   activeIndex: number;
   /** When true, the active view is the read-only generated SDL. */
   sdlActive: boolean;
   schemaSDL: string | null;
-  onSelectFile: (index: number) => void;
-  onSelectSdl: () => void;
   onChange: (index: number, content: string) => void;
 }
 
@@ -21,6 +22,7 @@ export function SchemaEditor({
   sdlActive,
   schemaSDL,
   onChange,
+  showTabs = false,
   onSelectFile,
   onSelectSdl,
 }: Props) {
@@ -37,39 +39,100 @@ export function SchemaEditor({
 
   return (
     <section className="grid grid-rows-[auto_1fr] min-w-0 min-h-0 border-r border-bm-line bg-bm-editor-bg">
-      <header className="flex items-center gap-2 px-3 md:px-6 h-11 border-b border-bm-line bg-bm-bg">
-        <select
-          aria-label="Source file"
-          className="md:hidden min-w-0 flex-1 bg-bm-bg text-bm-ink font-mono text-[13px] focus-visible:outline focus-visible:outline-2"
-          value={sdlActive ? 'sdl' : String(activeIndex)}
-          onChange={(event) => {
-            if (event.target.value === 'sdl') {
-              onSelectSdl();
-            } else {
-              onSelectFile(Number(event.target.value));
-            }
-          }}
+      {showTabs ? (
+        <div
+          role="tablist"
+          aria-label="Schema files"
+          className="flex overflow-x-auto border-b border-bm-line bg-bm-bg"
         >
-          {files.map((file, index) => (
-            <option key={file.filename} value={String(index)}>
-              {file.filename}
-            </option>
-          ))}
-          <option value="sdl">schema.graphql (generated SDL)</option>
-        </select>
-        <span
-          className={`hidden md:block font-mono text-[13px] tracking-[-0.01em] text-bm-ink ${
-            sdlActive || generated ? 'italic' : ''
-          }`}
-        >
-          {headerName}
-        </span>
-        <div className="hidden md:block flex-1" />
-        <span className="hidden md:block text-[11px] uppercase tracking-[0.04em] text-bm-ink-muted">
-          {meta}
-        </span>
-      </header>
-      <div className="min-h-0">
+          {[...files.map((file) => file.filename), 'schema.graphql'].map((name, index) => {
+            const selected =
+              index === files.length ? sdlActive : !sdlActive && index === activeIndex;
+            const select = (next: number) => {
+              if (next === files.length) {
+                onSelectSdl();
+              } else {
+                onSelectFile(next);
+              }
+            };
+            return (
+              <button
+                key={index === files.length ? 'generated-sdl' : `file-${name}`}
+                type="button"
+                role="tab"
+                id={`schema-file-tab-${index}`}
+                aria-selected={selected}
+                aria-controls="schema-file-panel"
+                tabIndex={selected ? 0 : -1}
+                onClick={() => select(index)}
+                onKeyDown={(event) => {
+                  if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
+                    return;
+                  }
+                  event.preventDefault();
+                  const count = files.length + 1;
+                  const next =
+                    event.key === 'Home'
+                      ? 0
+                      : event.key === 'End'
+                        ? files.length
+                        : (index + (event.key === 'ArrowRight' ? 1 : -1) + count) % count;
+                  select(next);
+                  document.getElementById(`schema-file-tab-${next}`)?.focus();
+                }}
+                className={`shrink-0 cursor-pointer px-4 h-11 border-b-2 font-mono text-[12px] ${selected ? 'border-bm-accent text-bm-ink bg-bm-editor-bg' : 'border-transparent text-bm-ink-muted hover:text-bm-ink'}`}
+              >
+                {name}
+                {index === files.length && (
+                  <span className="ml-2 font-sans text-[11px]">(generated)</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <header className="flex items-center gap-2 px-3 md:px-6 h-11 border-b border-bm-line bg-bm-bg">
+          <select
+            aria-label="Source file"
+            className="md:hidden min-w-0 flex-1 bg-bm-bg text-bm-ink font-mono text-[13px] focus-visible:outline focus-visible:outline-2"
+            value={sdlActive ? 'sdl' : String(activeIndex)}
+            onChange={(event) => {
+              if (event.target.value === 'sdl') {
+                onSelectSdl();
+              } else {
+                onSelectFile(Number(event.target.value));
+              }
+            }}
+          >
+            {files.map((file, index) => (
+              <option key={file.filename} value={String(index)}>
+                {file.filename}
+              </option>
+            ))}
+            <option value="sdl">schema.graphql (generated SDL)</option>
+          </select>
+          <span
+            className={`hidden md:block font-mono text-[13px] tracking-[-0.01em] text-bm-ink ${
+              sdlActive || generated ? 'italic' : ''
+            }`}
+          >
+            {headerName}
+          </span>
+          <div className="hidden md:block flex-1" />
+          <span className="hidden md:block text-[11px] uppercase tracking-[0.04em] text-bm-ink-muted">
+            {meta}
+          </span>
+        </header>
+      )}
+      {/* biome-ignore lint/a11y/useAriaPropsSupportedByRole: both conditional roles support aria-labelledby */}
+      <div
+        className="min-h-0"
+        role={showTabs ? 'tabpanel' : 'region'}
+        id="schema-file-panel"
+        aria-labelledby={
+          showTabs ? `schema-file-tab-${sdlActive ? files.length : activeIndex}` : undefined
+        }
+      >
         {sdlActive ? (
           <SdlPane schemaSDL={schemaSDL} />
         ) : activeFile ? (

--- a/website/components/playground/SchemaEditor/SdlPane.tsx
+++ b/website/components/playground/SchemaEditor/SdlPane.tsx
@@ -7,11 +7,6 @@ interface Props {
   schemaSDL: string | null;
 }
 
-const HEADER = `# Generated from schema.ts — do not edit
-# Pothos prints this from the runtime schema.
-
-`;
-
 export function SdlPane({ schemaSDL }: Props) {
   const { theme: editorTheme, beforeMount: registerThemes } = useEditorTheme();
 
@@ -27,7 +22,7 @@ export function SdlPane({ schemaSDL }: Props) {
     <Editor
       height="100%"
       language="graphql"
-      value={`${HEADER}${schemaSDL}`}
+      value={schemaSDL}
       theme={editorTheme}
       beforeMount={registerThemes}
       options={{
@@ -42,7 +37,11 @@ export function SdlPane({ schemaSDL }: Props) {
         folding: false,
         renderLineHighlight: 'none',
         padding: { top: 16, bottom: 16 },
-        scrollbar: { verticalScrollbarSize: 10, horizontalScrollbarSize: 10 },
+        scrollbar: {
+          alwaysConsumeMouseWheel: false,
+          verticalScrollbarSize: 10,
+          horizontalScrollbarSize: 10,
+        },
       }}
     />
   );

--- a/website/components/playground/SchemaEditor/SourceEditor.tsx
+++ b/website/components/playground/SchemaEditor/SourceEditor.tsx
@@ -164,6 +164,7 @@ export function SourceEditor({
         quickSuggestions: !readOnly,
         suggestOnTriggerCharacters: !readOnly,
         scrollbar: {
+          alwaysConsumeMouseWheel: false,
           verticalScrollbarSize: 10,
           horizontalScrollbarSize: 10,
         },

--- a/website/components/playground/shell/PlaygroundLayout.tsx
+++ b/website/components/playground/shell/PlaygroundLayout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 interface Props {
   /** Schema sidebar pane (md+ only). */
   sidebar: ReactNode;
+  hideSidebar?: boolean;
   /** Schema editor pane (Monaco TS / SDL viewer). */
   editor: ReactNode;
   /** Operation pane (query/variables/headers/context tabs). */
@@ -33,18 +34,22 @@ interface Props {
  * `height="100%"` resolving against an auto-height block child,
  * collapsing the editors to 0.
  */
-export function PlaygroundLayout({ sidebar, editor, ops, response }: Props) {
+export function PlaygroundLayout({ sidebar, editor, ops, response, hideSidebar = false }: Props) {
   return (
     <div
-      className="
+      className={`
         grid min-w-0 min-h-0
         grid-cols-1 grid-rows-[minmax(0,1.1fr)_minmax(0,1fr)_minmax(0,0.9fr)]
         [grid-template-areas:'editor''ops''response']
-        md:grid-cols-[280px_1fr_1fr] md:grid-rows-1
-        md:[grid-template-areas:'sidebar_editor_ops']
-      "
+        md:grid-rows-1
+        ${hideSidebar ? "md:grid-cols-2 md:[grid-template-areas:'editor_ops']" : "md:grid-cols-[280px_1fr_1fr] md:[grid-template-areas:'sidebar_editor_ops']"}
+      `}
     >
-      <div className="hidden md:grid md:grid-rows-[1fr] min-h-0 [grid-area:sidebar]">{sidebar}</div>
+      {!hideSidebar && (
+        <div className="hidden md:grid md:grid-rows-[1fr] min-h-0 [grid-area:sidebar]">
+          {sidebar}
+        </div>
+      )}
 
       <div className="grid grid-rows-[1fr] min-w-0 min-h-0 [grid-area:editor]">{editor}</div>
 

--- a/website/scripts/check-landing-mobile.mjs
+++ b/website/scripts/check-landing-mobile.mjs
@@ -10,7 +10,7 @@ export async function checkLandingMobile(browser, origin) {
     page.setDefaultTimeout(60000);
     let loadedPlayground = false;
     page.on('request', (request) => {
-      if (new URL(request.url()).pathname === '/playground') {
+      if (request.isNavigationRequest() && new URL(request.url()).pathname === '/playground') {
         loadedPlayground = true;
       }
     });
@@ -24,7 +24,7 @@ export async function checkLandingMobile(browser, origin) {
         0,
         'Mobile homepage must not mount the playground',
       );
-      assert.equal(loadedPlayground, false, 'Mobile homepage must not request the playground');
+      assert.equal(loadedPlayground, false, 'Mobile homepage must not load a playground document');
       assert.equal(
         await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth),
         false,

--- a/website/scripts/check-landing-mobile.mjs
+++ b/website/scripts/check-landing-mobile.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+
+export async function checkLandingMobile(browser, origin) {
+  for (const width of [320, 390, 767]) {
+    const page = await browser.newPage({
+      viewport: { width, height: 844 },
+      isMobile: true,
+      hasTouch: true,
+    });
+    page.setDefaultTimeout(60000);
+    let loadedPlayground = false;
+    page.on('request', (request) => {
+      if (new URL(request.url()).pathname === '/playground') {
+        loadedPlayground = true;
+      }
+    });
+    try {
+      await page.goto(origin);
+      await page.locator('pre').waitFor();
+      await page.getByRole('button', { name: 'Open menu', exact: true }).click();
+      await page.getByRole('button', { name: 'Close menu', exact: true }).click();
+      assert.equal(
+        await page.locator('iframe').count(),
+        0,
+        'Mobile homepage must not mount the playground',
+      );
+      assert.equal(loadedPlayground, false, 'Mobile homepage must not request the playground');
+      assert.equal(
+        await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth),
+        false,
+        'Homepage overflows',
+      );
+      await page.getByRole('link', { name: 'Get started', exact: true }).click();
+      await page.locator('h1').waitFor();
+      assert.equal(
+        await page.locator('h1').evaluate((heading) => {
+          const rect = heading.getBoundingClientRect();
+          const element = document.elementFromPoint(
+            rect.left + rect.width / 2,
+            rect.top + rect.height / 2,
+          );
+          return element === heading || heading.contains(element);
+        }),
+        true,
+        'Docs title must not be covered by the contents bar',
+      );
+      assert.equal(
+        await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth),
+        false,
+        'Docs overflow',
+      );
+      await page.getByRole('button', { name: 'Open documentation menu', exact: true }).click();
+      await page
+        .getByRole('complementary', { name: 'Documentation' })
+        .getByRole('link', { name: 'Objects', exact: true })
+        .click();
+      await page.getByRole('heading', { name: 'Objects', exact: true }).waitFor();
+      assert.equal(
+        await page.evaluate(() => document.body.style.overflow === 'hidden'),
+        false,
+        'Docs menu must release scrolling after navigation',
+      );
+      console.log(`PASS ${width}px static homepage, navigation, and docs layout`);
+    } finally {
+      await page.close();
+    }
+  }
+}

--- a/website/scripts/check-landing-mobile.mjs
+++ b/website/scripts/check-landing-mobile.mjs
@@ -31,19 +31,23 @@ export async function checkLandingMobile(browser, origin) {
         'Homepage overflows',
       );
       await page.getByRole('link', { name: 'Get started', exact: true }).click();
-      await page.locator('h1').waitFor();
-      assert.equal(
-        await page.locator('h1').evaluate((heading) => {
-          const rect = heading.getBoundingClientRect();
-          const element = document.elementFromPoint(
-            rect.left + rect.width / 2,
-            rect.top + rect.height / 2,
-          );
-          return element === heading || heading.contains(element);
-        }),
-        true,
-        'Docs title must not be covered by the contents bar',
-      );
+      await page.waitForURL(/\/docs(?:\/guide)?$/);
+      await page.getByRole('heading', { name: 'Getting started', exact: true }).waitFor();
+      // Client navigation can paint the heading before scroll restoration and
+      // the floating contents bar settle. Require the intended page and wait
+      // for its title to be unobscured rather than inspecting one transient frame.
+      await page.waitForFunction(() => {
+        const heading = document.querySelector('h1');
+        if (heading?.textContent !== 'Getting started') {
+          return false;
+        }
+        const rect = heading.getBoundingClientRect();
+        const element = document.elementFromPoint(
+          rect.left + rect.width / 2,
+          rect.top + rect.height / 2,
+        );
+        return element === heading || heading.contains(element);
+      });
       assert.equal(
         await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth),
         false,

--- a/website/scripts/check-landing-playground.mjs
+++ b/website/scripts/check-landing-playground.mjs
@@ -1,4 +1,5 @@
 import { chromium } from 'playwright';
+import { checkLandingMobile } from './check-landing-mobile.mjs';
 
 (async () => {
   const browser = await chromium.launch({
@@ -102,6 +103,7 @@ import { chromium } from 'playwright';
       throw Error('Scroll boundary trapped');
     }
     console.log('Page scrolls at editor boundary');
+    await checkLandingMobile(browser, process.argv[2] ?? 'http://localhost:3000');
   } finally {
     await browser.close();
   }

--- a/website/scripts/check-landing-playground.mjs
+++ b/website/scripts/check-landing-playground.mjs
@@ -1,0 +1,111 @@
+import { chromium } from 'playwright';
+
+(async () => {
+  const browser = await chromium.launch({
+    headless: true,
+    ...(process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE
+      ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE }
+      : {}),
+  });
+  try {
+    const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+    page.setDefaultTimeout(60000);
+    await page.goto(process.argv[2] ?? 'http://localhost:3000');
+    const embedded = page.frameLocator('iframe');
+    await embedded.getByRole('button', { name: /schema synced/ }).waitFor();
+    await embedded.getByRole('button', { name: /Run query/ }).click();
+    await embedded.getByText('Hello, Pothos!', { exact: false }).first().waitFor();
+    await embedded.getByRole('tab', { name: /schema.graphql/ }).click();
+    await page
+      .frames()
+      .find((frame) => frame.url().includes('/playground'))
+      .waitForFunction(() =>
+        window.monaco.editor
+          .getEditors()
+          .some(
+            (editor) =>
+              editor.getModel()?.getLanguageId() === 'graphql' &&
+              editor.getValue().includes('type Query'),
+          ),
+      );
+    await embedded.getByRole('tab', { name: 'schema.ts', exact: true }).click();
+    if (await embedded.getByRole('button', { name: 'Files', exact: true }).count()) {
+      throw Error('Embedded playground sidebar should be hidden');
+    }
+    await page
+      .locator('iframe')
+      .evaluate((el) => window.scrollTo(0, el.getBoundingClientRect().top + window.scrollY - 100));
+    const frame = page.frames().find((embedded) => embedded.url().includes('/playground'));
+    await embedded
+      .locator('.monaco-editor .view-line')
+      .filter({ hasText: 'const builder' })
+      .locator('span')
+      .filter({ hasText: /^builder$/ })
+      .last()
+      .hover();
+    await embedded
+      .locator('.monaco-hover')
+      .filter({ hasText: 'SchemaBuilder' })
+      .first()
+      .waitFor({ timeout: 15000 });
+    console.log('Type hover works');
+    await frame.evaluate(() => {
+      const editor = window.monaco.editor
+        .getEditors()
+        .find((editor) => editor.getModel()?.uri.path.endsWith('/schema.ts'));
+      editor
+        .getModel()
+        .setValue(`${editor.getValue()}\n${Array(100).fill('// scroll check').join('\n')}`);
+      editor.setScrollTop(0);
+    });
+    await page.waitForTimeout(500);
+    const rect = await embedded.locator('.monaco-editor').first().boundingBox();
+    await page.mouse.move(rect.x + 150, rect.y + 100);
+    const before = await page.evaluate(() => window.scrollY);
+    await page.mouse.wheel(0, 250);
+    await page.waitForTimeout(400);
+    const internal = await frame.evaluate(() =>
+      window.monaco.editor
+        .getEditors()
+        .find((editor) => editor.getModel()?.uri.path.endsWith('/schema.ts'))
+        .getScrollTop(),
+    );
+    if (internal || (await page.evaluate(() => window.scrollY)) <= before) {
+      throw Error('Unfocused editor trapped page scrolling');
+    }
+    console.log('Unfocused editor allows page scrolling');
+    await page
+      .locator('iframe')
+      .evaluate((el) => window.scrollTo(0, el.getBoundingClientRect().top + window.scrollY - 100));
+    await frame.evaluate(() =>
+      window.monaco.editor
+        .getEditors()
+        .find((editor) => editor.getModel()?.uri.path.endsWith('/schema.ts'))
+        .focus(),
+    );
+    await page.mouse.move(rect.x + 150, rect.y + 100);
+    await page.mouse.wheel(0, 250);
+    await page.waitForTimeout(400);
+    if ((await page.evaluate(() => window.scrollY)) !== before) {
+      throw Error('Focused editor did not retain scrolling');
+    }
+    console.log('Focused editor retains scrolling');
+    await frame.evaluate(() => {
+      const editor = window.monaco.editor
+        .getEditors()
+        .find((editor) => editor.getModel()?.uri.path.endsWith('/schema.ts'));
+      editor.setScrollTop(editor.getScrollHeight());
+    });
+    await page.mouse.wheel(0, 250);
+    await page.waitForTimeout(400);
+    if ((await page.evaluate(() => window.scrollY)) <= before) {
+      throw Error('Scroll boundary trapped');
+    }
+    console.log('Page scrolls at editor boundary');
+  } finally {
+    await browser.close();
+  }
+})().catch((editor) => {
+  console.error(editor);
+  process.exit(1);
+});

--- a/website/scripts/check-playground-mobile.mjs
+++ b/website/scripts/check-playground-mobile.mjs
@@ -77,7 +77,8 @@ export async function checkPlaygroundMobileFiles(browser, origin) {
           .getEditors()
           .some(
             (editor) =>
-              editor.getModel()?.getValue().startsWith('# Generated from schema.ts') &&
+              editor.getModel()?.getLanguageId() === 'graphql' &&
+              editor.getOption(window.monaco.editor.EditorOption.readOnly) &&
               editor.getModel()?.getValue().includes('type Giraffe'),
           ),
       );

--- a/website/scripts/run-playground-tests.mjs
+++ b/website/scripts/run-playground-tests.mjs
@@ -26,7 +26,11 @@ try {
   if (!ready) {
     throw new Error('Website did not become ready');
   }
-  for (const script of ['check-playground.mjs', 'check-doc-links.mjs']) {
+  for (const script of [
+    'check-playground.mjs',
+    'check-landing-playground.mjs',
+    'check-doc-links.mjs',
+  ]) {
     const test = spawn(process.execPath, [`scripts/${script}`, origin], { stdio: 'inherit' });
     const code = await new Promise((resolve, reject) => {
       test.on('error', reject);


### PR DESCRIPTION
The landing page now explains Pothos through an editable schema and query instead of static code and numerical claims. The copy focuses on designing a schema independently of stored data, inferred resolver types, and typed plugin integrations, while preserving the original headline and company closing.

Embedded playgrounds use source-file and generated SDL tabs in place of the sidebar. On the landing page, wheel gestures scroll the page until an editor is focused, preserving type hovers and normal editing. Generated SDL no longer includes redundant read-only comments.

Validation:
- Website type checking, example reference checks, and 36 unit tests pass.
- Production Next.js build passes.
- Browser checks cover query execution, source/SDL tabs, hover, page scrolling, focused editor scrolling, and boundary scrolling.
- Internal links and anchors checked across 78 documentation pages.

The numerical claims and full plugin grid were removed in favor of specific capabilities and a link to the full catalog. Schema organization remains covered in the application-layout guide. No documentation pages were removed.
