### PR TITLE
fix(docs): resolve database documentation CI lint failures

### DIFF
--- a/website/content/docs/plugins/scope-auth/meta.json
+++ b/website/content/docs/plugins/scope-auth/meta.json
@@ -1,7 +1,4 @@
 {
   "title": "Scope auth",
-  "pages": [
-    "index",
-    "relay-nodes"
-  ]
+  "pages": ["index", "relay-nodes"]
 }

--- a/website/local-examples/prisma/check.ts
+++ b/website/local-examples/prisma/check.ts
@@ -1,9 +1,9 @@
 import assert from 'node:assert/strict';
 import { readdir, readFile } from 'node:fs/promises';
 import { graphql } from 'graphql';
+import { checkMediaConnections } from './connections-check';
 import { createDatabase } from './db';
 import { createSchema } from './schema';
-import { checkMediaConnections } from './connections-check';
 
 async function check() {
   const { prisma, statements, close } = await createDatabase();

--- a/website/local-examples/prisma/connections-check.ts
+++ b/website/local-examples/prisma/connections-check.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { graphql, type GraphQLSchema } from 'graphql';
+import { type GraphQLSchema, graphql } from 'graphql';
 
 export async function checkMediaConnections(schema: GraphQLSchema) {
   const run = async (source: string, variableValues?: Record<string, unknown>) => {

--- a/website/local-examples/prisma/schema.ts
+++ b/website/local-examples/prisma/schema.ts
@@ -1,7 +1,7 @@
 import { queryFromInfo } from '@pothos/plugin-prisma';
-import type { Post as PostRow, PrismaClient } from './generated/client/client';
 import { createSchemaBuilder } from './builder';
 import { addMediaConnection, createMediaType } from './connections';
+import type { Post as PostRow, PrismaClient } from './generated/client/client';
 
 export function createSchema(prisma: PrismaClient) {
   const builder = createSchemaBuilder(prisma);

--- a/website/scripts/check-playground-references.ts
+++ b/website/scripts/check-playground-references.ts
@@ -158,7 +158,9 @@ async function main() {
           ref.error = 'cannot check operation; run build-examples first';
         }
       }
-      if (ref.error) failures.push(ref);
+      if (ref.error) {
+        failures.push(ref);
+      }
     }
   }
 


### PR DESCRIPTION
The database documentation merge failed Node CI on five Biome diagnostics after all 116 build, generation, test, and type-check tasks passed. Sort the Prisma example imports, format the scope-auth navigation metadata, and wrap the playground reference check's conditional body in braces.

Validation: reproduced the import/block failures locally; the full repository Biome check now passes across 1,674 files, and `git diff --check` passes. These are formatting-only changes; existing CI provides runtime coverage.
