### PR TITLE
docs: explain argument mapping lifecycle and error boundaries

### DIFF
--- a/website/content/docs/guide/writing-plugins.mdx
+++ b/website/content/docs/guide/writing-plugins.mdx
@@ -177,6 +177,8 @@ For the exact function signature, see the `index.ts` of the example plugin.
 - `afterBuild`: Invoked with the fully built Schema.
 - `wrapResolve`: Invoked when creating the resolver for each field
 - `wrapSubscribe`: Invoked for each field in the `Subscriptions` object.
+- `wrapArgMappers`: Wraps outside argument mapping for resolvers and subscription setup; see
+  [Argument mapping and errors](#argument-mapping-and-errors).
 - `wrapResolveType`: Invoked for each Union and Interface.
 - `wrapIsTypeOf`: Invoked for each Object, including objects without an `isTypeOf` function.
 
@@ -413,9 +415,10 @@ identify the current request.
 
 ### Wrapping arguments and inputs
 
-The plugin API does not directly have a method for wrapping input fields, instead, the `wrapResolve`
-and `wrapSubscribe` methods can be used to modify the `args` object before passing it down to the
-original resolver.
+The plugin API does not directly wrap individual input fields. `wrapResolve` and `wrapSubscribe`
+can transform the `args` object before passing it to the original function. These wrappers receive
+arguments after any registered argument mappers have run; use `fieldConfig.argMappers` when the
+transformation needs to happen before resolver or subscription wrappers.
 
 Figuring out how to wrap inputs can be a little complex, especially when dealing with recursive
 inputs, and optimizing to wrap as little as possible. To help with this, Pothos has a couple of
@@ -461,6 +464,59 @@ interface InputTypeFieldsMapping<Types extends SchemaTypes, T> {
 Both the root map and nested `fields.map` maps contain fields with non-null mappings and
 input objects with mapped descendants. If the mapping function returned null for all fields, the
 `mapInputFields` will return null instead of returning a map to indicate no wrapping should occur
+
+### Argument mapping and errors
+
+Register an argument mapper in `onOutputFieldConfig` by returning a config with an updated
+`argMappers` array. Each mapper receives `(args, context, info)` and returns the next argument object,
+or a promise of it. `args` is a `Record<string, unknown>`; `info` is Pothos's `PartialResolveInfo`.
+Preserve existing mappers when appending your own. Mappers run sequentially in array order, awaiting
+each result before passing it to the next mapper.
+
+For a resolver call, execution enters these layers in order:
+
+1. `wrapArgMappers` wrappers, which see the arguments before mapping.
+2. The field's `argMappers`.
+3. `wrapResolve` wrappers, which see the mapped arguments.
+4. The application's resolver.
+
+Subscription setup follows the same order with `wrapSubscribe` and the application's subscribe
+function in the last two positions. The subscription's event resolver has its own resolver path;
+do not assume mapping runs only once per subscription. Within each wrapper hook, the first plugin
+in the builder's `plugins` array is outermost. Configuration hooks run from the last plugin to the
+first, so appending in `onOutputFieldConfig` determines the final mapper-array order at build time.
+
+A `try/catch` inside `wrapResolve` cannot catch a mapper failure: mapping happens before that wrapper
+is entered. Use `wrapArgMappers` for an outer error boundary. The example below appends a synchronous
+normalizer and an asynchronous validator for fields marked with `extensions: { normalizeName: true }`.
+The boundary converts their `NameInputError` failures to a GraphQL error with a `BAD_USER_INPUT` code.
+
+<include cwd lang="typescript" meta='playground example="architecture-arg-mappers"'>playground-examples/architecture-arg-mappers/plugin.ts</include>
+
+The `await` inside `try` catches both a synchronous throw and an asynchronous rejection. Returning
+the promise without awaiting it would let its rejection escape that `catch`. Preserve an absent
+function by returning `undefined` unchanged: this hook is also called when a field has no subscribe
+function. It should not accidentally manufacture one.
+
+The boundary also encloses resolver/subscriber wrappers and the application function, so it can
+receive their errors too. Handle only errors belonging to the policy you intend to implement;
+this example rethrows every error other than `NameInputError`. It does not catch GraphQL document
+validation or variable-coercion errors, which occur before field execution, or errors thrown by a
+subscription's async iterable while producing events.
+
+Use the registered plugin and opt in on the field in a separate `schema.ts`:
+
+<include cwd lang="typescript" meta='playground example="architecture-arg-mappers"'>playground-examples/architecture-arg-mappers/schema.ts</include>
+
+`greeting(name: "  Gina  ")` returns `"Hello, Gina!"`. A blank name throws synchronously; `"reserved"`
+rejects from the asynchronous mapper, even when surrounded by whitespace. Both failures prevent the
+resolver from running. `"broken"` reaches the resolver and retains the `"Greeting unavailable"` error
+without a `BAD_USER_INPUT` code.
+
+These mappers preserve the schema's string argument shape. Registering a mapper does not itself
+change the TypeScript argument types inferred from field definitions. The earlier trim example
+remains a valid `wrapResolve` transformation; moving its mapper into `argMappers` would make it run
+before all resolver wrappers instead of inside that plugin's wrapper.
 
 ### Removing fields and enum values
 

--- a/website/playground-examples/architecture-arg-mappers/01-Valid.graphql
+++ b/website/playground-examples/architecture-arg-mappers/01-Valid.graphql
@@ -1,0 +1,3 @@
+query Valid {
+  greeting(name: "  Gina  ")
+}

--- a/website/playground-examples/architecture-arg-mappers/02-Blank.graphql
+++ b/website/playground-examples/architecture-arg-mappers/02-Blank.graphql
@@ -1,0 +1,3 @@
+query Blank {
+  greeting(name: "   ")
+}

--- a/website/playground-examples/architecture-arg-mappers/03-Reserved.graphql
+++ b/website/playground-examples/architecture-arg-mappers/03-Reserved.graphql
@@ -1,0 +1,3 @@
+query Reserved {
+  greeting(name: " reserved ")
+}

--- a/website/playground-examples/architecture-arg-mappers/04-Resolver-failure.graphql
+++ b/website/playground-examples/architecture-arg-mappers/04-Resolver-failure.graphql
@@ -1,0 +1,3 @@
+query ResolverFailure {
+  greeting(name: "broken")
+}

--- a/website/playground-examples/architecture-arg-mappers/expected.json
+++ b/website/playground-examples/architecture-arg-mappers/expected.json
@@ -1,0 +1,27 @@
+{
+  "01-Valid.graphql": { "data": { "greeting": "Hello, Gina!" } },
+  "02-Blank.graphql": {
+    "data": { "greeting": null },
+    "errors": [
+      {
+        "message": "Name must not be blank",
+        "path": ["greeting"],
+        "extensions": { "code": "BAD_USER_INPUT" }
+      }
+    ]
+  },
+  "03-Reserved.graphql": {
+    "data": { "greeting": null },
+    "errors": [
+      {
+        "message": "Name is reserved",
+        "path": ["greeting"],
+        "extensions": { "code": "BAD_USER_INPUT" }
+      }
+    ]
+  },
+  "04-Resolver-failure.graphql": {
+    "data": { "greeting": null },
+    "errors": [{ "message": "Greeting unavailable", "path": ["greeting"] }]
+  }
+}

--- a/website/playground-examples/architecture-arg-mappers/metadata.json
+++ b/website/playground-examples/architecture-arg-mappers/metadata.json
@@ -1,0 +1,8 @@
+{
+  "id": "architecture-arg-mappers",
+  "title": "Argument mapping and error boundaries",
+  "description": "Run Valid to see a trimmed name. Blank throws in the first mapper; Reserved rejects in the async mapper. Both return BAD_USER_INPUT. Resolver failure keeps its original error without that code.",
+  "category": "patterns",
+  "relatedDocs": ["/docs/guide/writing-plugins"],
+  "defaultActiveFile": "plugin.ts"
+}

--- a/website/playground-examples/architecture-arg-mappers/plugin.ts
+++ b/website/playground-examples/architecture-arg-mappers/plugin.ts
@@ -1,0 +1,67 @@
+import SchemaBuilder, {
+  BasePlugin,
+  type PothosOutputFieldConfig,
+  type SchemaTypes,
+} from '@pothos/core';
+import { GraphQLError, type GraphQLFieldResolver } from 'graphql';
+
+declare global {
+  namespace PothosSchemaTypes {
+    interface Plugins<Types extends SchemaTypes> {
+      architectureArgMappers: NameInputPlugin<Types>;
+    }
+  }
+}
+
+class NameInputError extends Error {}
+
+export class NameInputPlugin<Types extends SchemaTypes> extends BasePlugin<Types> {
+  override onOutputFieldConfig(fieldConfig: PothosOutputFieldConfig<Types>) {
+    if (!fieldConfig.extensions?.normalizeName) {
+      return fieldConfig;
+    }
+
+    return {
+      ...fieldConfig,
+      argMappers: [
+        ...fieldConfig.argMappers,
+        (args: Record<string, unknown>) => {
+          if (typeof args.name !== 'string' || !args.name.trim()) {
+            throw new NameInputError('Name must not be blank');
+          }
+          return { ...args, name: args.name.trim() };
+        },
+        async (args: Record<string, unknown>) => {
+          // A real plugin could await a lookup or asynchronous validator here.
+          if (args.name === 'reserved') {
+            throw new NameInputError('Name is reserved');
+          }
+          return args;
+        },
+      ],
+    };
+  }
+
+  override wrapArgMappers(
+    resolver: GraphQLFieldResolver<unknown, Types['Context'], object> | undefined,
+    fieldConfig: PothosOutputFieldConfig<Types>,
+  ): GraphQLFieldResolver<unknown, Types['Context'], object> | undefined {
+    if (!resolver || !fieldConfig.extensions?.normalizeName) {
+      return resolver;
+    }
+
+    return async (parent, args, context, info) => {
+      try {
+        return await resolver(parent, args, context, info);
+      } catch (error) {
+        if (error instanceof NameInputError) {
+          throw new GraphQLError(error.message, { extensions: { code: 'BAD_USER_INPUT' } });
+        }
+        throw error;
+      }
+    };
+  }
+}
+
+export const pluginName = 'architectureArgMappers';
+SchemaBuilder.registerPlugin(pluginName, NameInputPlugin);

--- a/website/playground-examples/architecture-arg-mappers/schema.test.ts
+++ b/website/playground-examples/architecture-arg-mappers/schema.test.ts
@@ -1,0 +1,227 @@
+import { readFileSync } from 'node:fs';
+import SchemaBuilder, {
+  BasePlugin,
+  type PothosOutputFieldConfig,
+  type SchemaTypes,
+} from '@pothos/core';
+import { type GraphQLFieldResolver, graphql, parse, subscribe } from 'graphql';
+import { describe, expect, it } from 'vitest';
+import { pluginName } from './plugin';
+import { schema } from './schema';
+
+declare global {
+  namespace PothosSchemaTypes {
+    interface Plugins<Types extends SchemaTypes> {
+      argMapperProbe: ProbePlugin<Types>;
+    }
+  }
+}
+
+// The probe observes real Pothos composition, rather than invoking hooks by hand.
+const events: string[] = [];
+class ProbePlugin<Types extends SchemaTypes> extends BasePlugin<Types> {
+  override onOutputFieldConfig(config: PothosOutputFieldConfig<Types>) {
+    if (!config.extensions?.normalizeName) {
+      return config;
+    }
+    return {
+      ...config,
+      argMappers: [
+        ...config.argMappers,
+        (args: Record<string, unknown>) => {
+          events.push(`mapped:${args.name}`);
+          return args;
+        },
+      ],
+    };
+  }
+
+  override wrapArgMappers(
+    next: GraphQLFieldResolver<unknown, Types['Context'], object> | undefined,
+    config: PothosOutputFieldConfig<Types>,
+  ) {
+    if (!next || !config.extensions?.normalizeName) {
+      return next;
+    }
+    return async (
+      parent: unknown,
+      args: object,
+      context: Types['Context'],
+      info: Parameters<NonNullable<typeof next>>[3],
+    ) => {
+      events.push(`outer:${(args as Record<string, unknown>).name}`);
+      try {
+        return await next(parent, args, context, info);
+      } catch (error) {
+        events.push('outer-error');
+        throw error;
+      }
+    };
+  }
+
+  override wrapResolve(
+    next: GraphQLFieldResolver<unknown, Types['Context'], object>,
+    config: PothosOutputFieldConfig<Types>,
+  ): GraphQLFieldResolver<unknown, Types['Context'], object> {
+    if (!config.extensions?.normalizeName) {
+      return next;
+    }
+    return async (parent, args, context, info) => {
+      events.push(`resolve:${(args as Record<string, unknown>).name}`);
+      try {
+        return await next(parent, args, context, info);
+      } catch (error) {
+        events.push('resolve-error');
+        throw error;
+      }
+    };
+  }
+
+  override wrapSubscribe(
+    next: GraphQLFieldResolver<unknown, Types['Context'], object> | undefined,
+    config: PothosOutputFieldConfig<Types>,
+  ): GraphQLFieldResolver<unknown, Types['Context'], object> | undefined {
+    if (!next || !config.extensions?.normalizeName) {
+      return next;
+    }
+    return (parent, args, context, info) => {
+      events.push(`subscribe:${(args as Record<string, unknown>).name}`);
+      return next(parent, args, context, info);
+    };
+  }
+}
+SchemaBuilder.registerPlugin('argMapperProbe', ProbePlugin);
+
+function observedSchema() {
+  const builder = new SchemaBuilder({ plugins: ['argMapperProbe', pluginName] });
+  builder.queryType({
+    fields: (t) => ({
+      greeting: t.string({
+        extensions: { normalizeName: true },
+        args: { name: t.arg.string({ required: true }) },
+        resolve: (_parent, { name }) => {
+          events.push(`application:${name}`);
+          if (name === 'broken') {
+            throw new Error('Application failure');
+          }
+          return name;
+        },
+      }),
+    }),
+  });
+  builder.subscriptionType({
+    fields: (t) => ({
+      greeting: t.string({
+        extensions: { normalizeName: true },
+        args: { name: t.arg.string({ required: true }) },
+        subscribe: async function* (_parent, { name }) {
+          events.push(`stream:${name}`);
+          yield name;
+        },
+        resolve: (value, { name }) => {
+          events.push(`event:${name}`);
+          return String(value);
+        },
+      }),
+    }),
+  });
+  return builder.toSchema();
+}
+
+const observed = observedSchema();
+
+describe('argument mapper guide', () => {
+  const expected = JSON.parse(readFileSync(new URL('./expected.json', import.meta.url), 'utf8'));
+  it.each(Object.keys(expected))('matches the authored operation %s', async (file) => {
+    const source = readFileSync(new URL(file, import.meta.url), 'utf8');
+    const result = await graphql({ schema, source });
+    const json = JSON.parse(JSON.stringify(result));
+    if (json.errors) {
+      json.errors = json.errors.map(
+        ({ locations: _locations, ...error }: { locations: unknown }) => error,
+      );
+    }
+    expect(json).toEqual(expected[file]);
+  });
+
+  it('orders outer wrappers, sequential mappers, inner wrappers, and application', async () => {
+    events.length = 0;
+    expect(await graphql({ schema: observed, source: '{ greeting(name: " Gina ") }' })).toEqual({
+      data: { greeting: 'Gina' },
+    });
+    expect(events).toEqual(['outer: Gina ', 'mapped:Gina', 'resolve:Gina', 'application:Gina']);
+  });
+
+  it.each([
+    ' ',
+    ' reserved ',
+  ])('handles mapper failure before the resolver wrappers: %j', async (name) => {
+    events.length = 0;
+    const result = await graphql({
+      schema: observed,
+      source: `{ greeting(name: ${JSON.stringify(name)}) }`,
+    });
+    expect(result.errors?.[0].extensions.code).toBe('BAD_USER_INPUT');
+    expect(events).toEqual([`outer:${name}`, 'outer-error']);
+  });
+
+  it('retains application errors, which can also reach the outer boundary', async () => {
+    events.length = 0;
+    const result = await graphql({ schema: observed, source: '{ greeting(name: "broken") }' });
+    expect(result.errors?.[0].message).toBe('Application failure');
+    expect(result.errors?.[0].extensions.code).toBeUndefined();
+    expect(events).toEqual([
+      'outer:broken',
+      'mapped:broken',
+      'resolve:broken',
+      'application:broken',
+      'resolve-error',
+      'outer-error',
+    ]);
+  });
+
+  it('preserves absent subscribe functions', () => {
+    expect(observed.getQueryType()!.getFields().greeting.subscribe).toBeUndefined();
+  });
+
+  it('maps subscription setup and the subsequent event resolver separately', async () => {
+    events.length = 0;
+    const result = await subscribe({
+      schema: observed,
+      document: parse('subscription { greeting(name: " Gina ") }'),
+    });
+    if (!('next' in result)) {
+      throw new Error(JSON.stringify(result));
+    }
+    expect(events).toEqual(['outer: Gina ', 'mapped:Gina', 'subscribe:Gina']);
+    expect((await result.next()).value).toEqual({ data: { greeting: 'Gina' } });
+    expect(events).toEqual([
+      'outer: Gina ',
+      'mapped:Gina',
+      'subscribe:Gina',
+      'stream:Gina',
+      'outer: Gina ',
+      'mapped:Gina',
+      'resolve:Gina',
+      'event:Gina',
+    ]);
+    await result.return?.();
+  });
+
+  it.each([
+    ' ',
+    ' reserved ',
+  ])('handles subscription mapper errors before setup: %j', async (name) => {
+    events.length = 0;
+    const result = await subscribe({
+      schema: observed,
+      document: parse(`subscription { greeting(name: ${JSON.stringify(name)}) }`),
+    });
+    if ('next' in result) {
+      await result.return?.();
+      throw new Error('Invalid input must not start the subscription');
+    }
+    expect(result.errors?.[0].extensions.code).toBe('BAD_USER_INPUT');
+    expect(events).toEqual([`outer:${name}`, 'outer-error']);
+  });
+});

--- a/website/playground-examples/architecture-arg-mappers/schema.ts
+++ b/website/playground-examples/architecture-arg-mappers/schema.ts
@@ -1,0 +1,21 @@
+import SchemaBuilder from '@pothos/core';
+import { pluginName } from './plugin';
+
+const builder = new SchemaBuilder({ plugins: [pluginName] });
+
+builder.queryType({
+  fields: (t) => ({
+    greeting: t.string({
+      extensions: { normalizeName: true },
+      args: { name: t.arg.string({ required: true }) },
+      resolve: (_parent, { name }) => {
+        if (name === 'broken') {
+          throw new Error('Greeting unavailable');
+        }
+        return `Hello, ${name}!`;
+      },
+    }),
+  }),
+});
+
+export const schema = builder.toSchema();


### PR DESCRIPTION
Plugin authors can now distinguish argument mapping from resolver wrapping and handle mapping failures at the right boundary. The Writing plugins guide documents `fieldConfig.argMappers`, sequential asynchronous mapping, `wrapArgMappers` ordering, subscription setup and event resolution, preserving absent subscribe functions, and selectively handling synchronous throws and promise rejections.

Adds a complete runnable plugin example that trims names, rejects blank/reserved values, and keeps application errors distinct. The existing trim-input wrapper example and its mapping utilities remain intact; its introduction now explains where that wrapper executes relative to registered mappers.

Validation: 12 focused tests exercise the authored operations and real Pothos composition, including resolver/subscription ordering, mapping failures before inner wrappers, application errors, absent subscribe preservation, and per-event mapping. Strict TypeScript check, full repository Biome, production website build, and playground reference validation pass. Browser checks passed both docs actions, all four operations, reset, desktop/mobile launch, editor diagnostics, and Markdown/LLM source preservation. Independent content/correctness and preservation review passed.

The browser example demonstrates query execution; actual subscription behavior is exercised by the Node tests because the playground does not execute subscriptions.
