### PR TITLE
docs: explain deferred selection execution prerequisites

### DIFF
--- a/packages/plugin-drizzle/README.md
+++ b/packages/plugin-drizzle/README.md
@@ -136,6 +136,15 @@ plugins: [RelayPlugin, WithInputPlugin, DrizzlePlugin],
   by default, and the fragment's fields are loaded through [fallback queries](https://pothos-graphql.dev/docs/plugins/drizzle/relations#fallback-queries)
   when it resolves. Set this to `false` to plan deferred selections with the rest of the query.
 
+`skipDeferredFragments` controls query planning; it does not enable incremental execution. The application
+must register the defer directive and use an executor, server transport, and client that support
+the same incremental delivery protocol. With GraphQL.js 17, ordinary `execute` rejects schemas
+containing `@defer` or `@stream`; incremental execution uses `experimentalExecuteIncrementally`.
+For a server integration, see [GraphQL Yoga's defer and stream setup](https://the-guild.dev/graphql/yoga-server/docs/features/defer-stream),
+which uses `@graphql-yoga/plugin-defer-stream`. Check the integration's supported versions when
+choosing an executor and client; adding directives or changing `skipDeferredFragments` alone is
+not sufficient.
+
 ## Drizzle Objects
 
 Use the [configured builder](https://pothos-graphql.dev/docs/plugins/drizzle/setup) to map a Drizzle table to a GraphQL type. Defining a type

--- a/packages/plugin-prisma/README.md
+++ b/packages/plugin-prisma/README.md
@@ -277,6 +277,15 @@ It's recommended to enable this check in development to more quickly find potent
 
 ### Deferred fragments
 
+`skipDeferredFragments` controls query planning; it does not enable incremental execution. The application
+must register the defer directive and use an executor, server transport, and client that support
+the same incremental delivery protocol. With GraphQL.js 17, ordinary `execute` rejects schemas
+containing `@defer` or `@stream`; incremental execution uses `experimentalExecuteIncrementally`.
+For a server integration, see [GraphQL Yoga's defer and stream setup](https://the-guild.dev/graphql/yoga-server/docs/features/defer-stream),
+which uses `@graphql-yoga/plugin-defer-stream`. Check the integration's supported versions when
+choosing an executor and client; adding directives or changing `skipDeferredFragments` alone is
+not sufficient.
+
 Selections inside a `@defer` fragment are left out of the planned query by default, so the initial
 payload is not delayed by data the client has agreed to wait for. When the deferred fragment
 resolves, its fields are loaded through [fallback queries](https://pothos-graphql.dev/docs/plugins/prisma/relations#fallback-queries), batched as

--- a/website/content/docs/plugins/drizzle/setup.mdx
+++ b/website/content/docs/plugins/drizzle/setup.mdx
@@ -83,3 +83,12 @@ plugins: [RelayPlugin, WithInputPlugin, DrizzlePlugin],
 - `skipDeferredFragments`: selections inside a `@defer` fragment are left out of the planned query
   by default, and the fragment's fields are loaded through [fallback queries](./relations#fallback-queries)
   when it resolves. Set this to `false` to plan deferred selections with the rest of the query.
+
+`skipDeferredFragments` controls query planning; it does not enable incremental execution. The application
+must register the defer directive and use an executor, server transport, and client that support
+the same incremental delivery protocol. With GraphQL.js 17, ordinary `execute` rejects schemas
+containing `@defer` or `@stream`; incremental execution uses `experimentalExecuteIncrementally`.
+For a server integration, see [GraphQL Yoga's defer and stream setup](https://the-guild.dev/graphql/yoga-server/docs/features/defer-stream),
+which uses `@graphql-yoga/plugin-defer-stream`. Check the integration's supported versions when
+choosing an executor and client; adding directives or changing `skipDeferredFragments` alone is
+not sufficient.

--- a/website/content/docs/plugins/prisma/setup.mdx
+++ b/website/content/docs/plugins/prisma/setup.mdx
@@ -150,6 +150,15 @@ It's recommended to enable this check in development to more quickly find potent
 
 ## Deferred fragments
 
+`skipDeferredFragments` controls query planning; it does not enable incremental execution. The application
+must register the defer directive and use an executor, server transport, and client that support
+the same incremental delivery protocol. With GraphQL.js 17, ordinary `execute` rejects schemas
+containing `@defer` or `@stream`; incremental execution uses `experimentalExecuteIncrementally`.
+For a server integration, see [GraphQL Yoga's defer and stream setup](https://the-guild.dev/graphql/yoga-server/docs/features/defer-stream),
+which uses `@graphql-yoga/plugin-defer-stream`. Check the integration's supported versions when
+choosing an executor and client; adding directives or changing `skipDeferredFragments` alone is
+not sufficient.
+
 Selections inside a `@defer` fragment are left out of the planned query by default, so the initial
 payload is not delayed by data the client has agreed to wait for. When the deferred fragment
 resolves, its fields are loaded through [fallback queries](./relations#fallback-queries), batched as


### PR DESCRIPTION
Prisma and Drizzle's deferred-selection options describe query planning without explaining what makes deferred payloads execute and reach clients. Add the execution prerequisite beside both options and synchronize the package READMEs: schema directives, an incremental executor, and compatible server/client transport are required. Explain the GraphQL.js 17 ordinary-execute rejection and link Yoga's official defer/stream integration without prescribing a version combination.

Validation: regenerated 75 example bundles; all 157 playground references pass; Fumadocs generation passes; git diff --check passes. Confirmed the executor behavior against installed GraphQL.js 17 source and checked the official Yoga setup. This adds prose only; existing option descriptions, fallback behavior, examples, and setup remain intact.

Rendered all 2 changed documentation routes through the Next.js webpack server: HTTP 200 with compiled HTML. No production build or new interactive browser/runtime checks were run for this prose-only change.

Independent content and preservation review completed; clarified the option name in the new prerequisite.
