### PR TITLE
docs: keep playground controls in guide metadata

### DIFF
--- a/website/content/docs/guide/app-layout.mdx
+++ b/website/content/docs/guide/app-layout.mdx
@@ -43,8 +43,6 @@ the parent field figure out how to return an object of the right shape.
 
 ## Backing models
 
-Run the example, then change `Alex` in `schema/user.ts` and run the query again.
-
 You can use your application's TypeScript types as backing models with `objectRef`. For example,
 keep the user data type in `src/types.ts` and define its GraphQL fields in `src/schema/user.ts`:
 

--- a/website/content/docs/guide/changing-default-nullability.mdx
+++ b/website/content/docs/guide/changing-default-nullability.mdx
@@ -51,7 +51,6 @@ existing optional argument or input field can break client requests. Non-null ou
 change error propagation: if a resolver returns null or throws, GraphQL propagates the null to the
 nearest nullable parent, potentially making the entire response's `data` null.
 
-To observe this in the playground, replace `nickname`'s resolver with
-`() => { throw new Error('Nickname unavailable'); }`. With `nullable: true`, only `nickname` is
-null. Remove that override and run again: the builder's non-null default makes the whole response's
-`data` null. Reset the example to restore the original resolver.
+For example, if `nickname`'s resolver throws `new Error('Nickname unavailable')`,
+`nullable: true` makes only `nickname` null. Without that override, the builder's non-null default
+makes the whole response's `data` null.

--- a/website/content/docs/guide/circular-references.mdx
+++ b/website/content/docs/guide/circular-references.mdx
@@ -28,7 +28,7 @@ until its field callback runs. The backing types use type-only imports, which do
 
 <include cwd lang="typescript" meta='playground example="architecture-circular"'>playground-examples/architecture-circular/schema.ts</include>
 
-Change the post title in `schema.ts`, then run the query again. The schema supports queries that follow the relationship in both directions:
+The schema supports queries that follow the relationship in both directions:
 
 ```graphql
 {

--- a/website/content/docs/guide/context.mdx
+++ b/website/content/docs/guide/context.mdx
@@ -19,9 +19,8 @@ current user with:
 
 <include cwd lang="graphql" meta='playground example="foundations-context"'>playground-examples/foundations-context/01-Signed in.graphql</include>
 
-In the playground, select **01-Signed in** or **02-Signed out** and inspect **Context**. Change
-the signed-in fixture's `username` and run it again. These values simulate request data; the server
-setup below performs the actual user lookup.
+The example context values simulate request data; the server setup below performs the actual
+user lookup.
 
 When there is no signed-in user, the response is `{ "data": { "currentUser": null } }`.
 

--- a/website/content/docs/guide/enums.mdx
+++ b/website/content/docs/guide/enums.mdx
@@ -28,8 +28,7 @@ in a separate variable, use `as const` to retain those literal types.
 ```
 
 Enum literals in a query are unquoted names. When passing an enum in JSON variables, use a string
-such as `"Meters"`. Select the example's `variables` operation, change the unit to `"Feet"`
-in its Variables tab, and run again.
+such as `"Meters"` or `"Feet"`.
 
 ## Descriptions and internal values
 
@@ -70,5 +69,5 @@ use `SEDAN`, `SUV`, `TRUCK`, and `MOTORCYCLE`.
 **Keys as names** uses `Object.keys(VehicleType)` for both. TypeScript types `Object.keys` as
 `string[]`, so the assertion preserves the known keys of this local object.
 
-Open each tab in the playground and compare `vehicle` with `internalValue`: the first is the
-GraphQL enum name, while the second exposes the value the argument resolver receives.
+In each variant, `vehicle` returns the GraphQL enum name, while `internalValue` exposes the value
+the argument resolver receives.

--- a/website/content/docs/guide/generating-client-types.mdx
+++ b/website/content/docs/guide/generating-client-types.mdx
@@ -15,7 +15,7 @@ can also be the schema you use in your server.
 
 <include cwd lang="typescript" meta='playground example="architecture-client-types"'>playground-examples/architecture-client-types/schema.ts</include>
 
-Run `UserPosts` in the playground, then add `id` to the post selection and run it again. Save the example as `src/schema.ts` and the operation as `src/queries.graphql` to use them with the local Codegen configuration below. Codegen runs in your project, not in the playground.
+Save the example as `src/schema.ts` and the operation as `src/queries.graphql` to use them with the local Codegen configuration below. Codegen runs in your project, not in the playground.
 
 In a larger application, this entry point can import your builder and type-definition modules before exporting `builder.toSchema()`. Keep server startup separate so Codegen can import the schema without opening a listening port.
 

--- a/website/content/docs/guide/inferring-types.mdx
+++ b/website/content/docs/guide/inferring-types.mdx
@@ -32,8 +32,8 @@ multiple builder instances.
 <include cwd lang="typescript" meta='playground example="types-inference"'>playground-examples/types-inference/schema.ts#pagination</include>
 
 The example uses the inferred input shape in `toUser` and returns real users from `getUsers`.
-Run the query, then change `limit` from `1` to `2`. Hover `input` and `parent` in the source to
-inspect their types. In `MyInput`, change `name: t.string({ required: true })` to
-`name: t.int({ required: true })`. The inferred input now has a numeric name, so returning it from
+A `limit` of `1` returns one user; `2` returns both. If `MyInput.name` is defined with
+`t.int({ required: true })` instead of `t.string({ required: true })`, the inferred input has a
+numeric name, so returning it from
 `toUser` produces a TypeScript error: `UserType` still requires a string. The GraphQL input field
 also changes from `String!` to `Int!`.

--- a/website/content/docs/guide/inputs.mdx
+++ b/website/content/docs/guide/inputs.mdx
@@ -28,8 +28,7 @@ requiredness; here all three fields must also be provided and cannot be `null`.
 { "data": { "createGiraffe": { "name": "Gina", "height": 4.8 } } }
 ```
 
-In the playground, run **01-Create**, then **03-Read** to inspect the
-array. Mutations accumulate data until you choose **Reset example**.
+The mutation appends each created giraffe to the in-memory array, which the `giraffes` query returns.
 
 ## OneOf inputs
 
@@ -74,9 +73,6 @@ Continue with the builder from [Creating input objects](#creating-input-objects)
 and mutation field:
 
 <include cwd lang="typescript" meta='playground example="foundations-inputs"'>playground-examples/foundations-inputs/schema.ts#recursive-input</include>
-
-Select **02-Friends** in the playground to run the recursive mutation below. Change a
-nested friend's height to see that each result comes from its own input.
 
 The `friends` list can be omitted or set to `null`, but its items cannot be `null`. The TypeScript
 shape includes both optionality and `null` to match those values. The resolver uses each friend's

--- a/website/content/docs/guide/patterns.mdx
+++ b/website/content/docs/guide/patterns.mdx
@@ -11,7 +11,7 @@ for you.
 
 ### Objects and Interfaces
 
-Run the query to compare the shared fields on both types. Change an ID in a query resolver and run again to see `idLength` change.
+The shared `idLength` resolver computes the length of each object's ID.
 
 <include cwd lang="typescript" meta='playground example="architecture-shared-fields"'>playground-examples/architecture-shared-fields/schema.ts#helper</include>
 
@@ -29,7 +29,7 @@ accepts both, you can differentiate the refs by using `ref.kind` which will be e
 
 ### Args
 
-The example mutation passes a reason to one field and omits it from the other. Add a reason to `mutation2` and run again.
+The example mutation passes a reason to one field and omits it from the other.
 
 Args are a little more complicated than fields on objects and interfaces. Pothos infers the shape of args
 for your resolvers, so you can't just add on more args later. Instead, we can define a helper that
@@ -49,7 +49,7 @@ that accepts different builders.
 
 ### Input fields
 
-Run the query, then change either input's reason to see both input types use the helper.
+Both input types use the helper to define their `reason` field.
 
 Input fields are similar to args, and also all need to be present when the type is defined so that
 Pothos can infer the correct types.

--- a/website/content/docs/guide/printing-schemas.mdx
+++ b/website/content/docs/guide/printing-schemas.mdx
@@ -3,7 +3,7 @@ title: Printing Schemas
 description: Guide for printing a Pothos schema to an SDL schema file
 ---
 
-The [playground example](/playground?example=architecture-printing) runs the schema below and shows its SDL in `schema.graphql`. Add a `description` to the `hello` field options to see it appear in the SDL. Writing the result to a file is a Node.js task.
+The [playground example](/playground?example=architecture-printing) runs the schema below and shows its SDL in `schema.graphql`. Field descriptions appear in the SDL. Writing the result to a file is a Node.js task.
 
 Sometimes it's useful to have an SDL version of your schema. To do this, you can use some tools from
 the `graphql` package to write your schema out as SDL to a file.

--- a/website/content/docs/guide/queries-mutations-and-subscriptions.mdx
+++ b/website/content/docs/guide/queries-mutations-and-subscriptions.mdx
@@ -31,9 +31,8 @@ in memory; an application can perform its database write in the resolver instead
 
 <include cwd lang="graphql" meta='playground example="foundations-root-operations"'>playground-examples/foundations-root-operations/02-Create.graphql</include>
 
-In the playground, select **02-Create** to run that mutation, then **03-After**.
-The `{ giraffes { name } }` query now returns both James and Morgan. Repeating a mutation adds
-another entry; **Reset example** restores the initial data.
+After this mutation, `{ giraffes { name } }` returns both James and Morgan. Each mutation adds
+another entry to the in-memory store.
 
 ## Subscriptions
 

--- a/website/content/docs/guide/scalars.mdx
+++ b/website/content/docs/guide/scalars.mdx
@@ -36,9 +36,7 @@ This example explicitly rejects string and float literals, even when they repres
 }
 ```
 
-Use the playground operation tabs to compare a valid variable with zero, a negative variable,
-a float literal, and a string literal. The invalid-output operation doubles the largest safe
-integer, so input parsing succeeds but output serialization rejects the result.
+Doubling the largest safe integer passes input parsing, but output serialization rejects the result.
 
 Passing `0`, `-1`, `1.5`, or `"3"` is an error. An output outside the scalar's accepted range is
 also an error; GraphQL applies the field's nullability rules when reporting it.

--- a/website/content/docs/guide/schema-builder.mdx
+++ b/website/content/docs/guide/schema-builder.mdx
@@ -19,8 +19,8 @@ The constructor's options object configures runtime behavior. It can include plu
 options, as described in [Using plugins](./using-plugins), and
 [default nullability](./changing-default-nullability) settings.
 
-The playground supplies a sample request ID in its **Context** tab. Change it and run the query
-again to see the resolver receive that value.
+The `requestId` resolver returns the value supplied in the runtime context. Declaring its
+TypeScript type does not supply that value.
 
 ## Building the schema
 

--- a/website/content/docs/guide/troubleshooting.mdx
+++ b/website/content/docs/guide/troubleshooting.mdx
@@ -15,7 +15,7 @@ package versions, and a minimal reproduction when [reporting it](https://github.
 
 <include cwd lang="typescript" meta='playground example="architecture-troubleshooting"'>playground-examples/architecture-troubleshooting/schema.ts#builder</include>
 
-The example query reads `user.id` from **Context**. Change that value and run again. Adapt the named interface and query into a small reproduction of your own issue. The playground uses strict TypeScript settings; it does not reproduce your application's package installation or editor configuration.
+The example query reads `user.id` from the request context. Adapt the named interface and query into a small reproduction of your own issue. The playground uses strict TypeScript settings; it does not reproduce your application's package installation or editor configuration.
 
 ## Slow VS Code or TypeScript performance
 

--- a/website/content/docs/guide/using-plugins.mdx
+++ b/website/content/docs/guide/using-plugins.mdx
@@ -33,7 +33,7 @@ types in through the Generic SchemaTypes used by the Schema builder:
 
 <include cwd lang="typescript" meta='playground example="architecture-plugin-scopes"'>playground-examples/architecture-plugin-scopes/schema.ts#setup</include>
 
-Run the second example to compare `allowed` and `denied`. Change the denied field's scope from `blocked` to `allowed` and run again.
+The second example permits the `allowed` field and denies the `denied` field according to their scopes.
 
 These types can then be used in other parts of the API \(eg. defining the scopes on a field\), but
 the details of how these types are used will be specific to each plugin, and should be covered in

--- a/website/content/docs/guide/writing-plugins.mdx
+++ b/website/content/docs/guide/writing-plugins.mdx
@@ -142,7 +142,7 @@ optional \(`newProp?: TypeOfProp`\) is recommended for most use cases.
 
 ### Run a complete plugin
 
-The example adds a `logLabel` builder option, registers a local plugin, and wraps each resolver. Run the query and open **Console** to see two field resolutions. Run it again: the request counter starts at one because each execution receives a fresh context. Change `logLabel` in `schema.ts` to label the messages.
+The example adds a `logLabel` builder option, registers a local plugin, and wraps each resolver. The query logs two field resolutions. The request counter starts at one for each execution because it receives a fresh context; `logLabel` labels the messages.
 
 <include cwd lang="typescript" meta='playground example="architecture-writing-plugin"'>playground-examples/architecture-writing-plugin/plugin.ts#plugin</include>
 
@@ -202,7 +202,7 @@ builder\), even if multiple instances of the plugin are created. To help with th
 `runUnique` helper on the base plugin class, which accepts a key, and a callback, and will only run
 a callback once per builder for the given key, even across multiple `toSchema` calls.
 
-The example calls `toSchema()` twice. Open **Console** to see the preparation callback run once:
+The example calls `toSchema()` twice, but the preparation callback runs only once:
 
 <include cwd lang="typescript" meta='playground example="architecture-plugin-hooks"'>playground-examples/architecture-plugin-hooks/plugin.ts#before-build</include>
 
@@ -234,7 +234,7 @@ Extending this interface will allow the user to pass in these new options when c
 of `SchemaBuilder`.
 
 You can then access the options through `this.builder.options` in your plugin, with everything
-correctly typed. Run **01-Inspect** to see these options reflected in the object description. Change `nestedOptionsObject.exampleOption` in `schema.ts` and run again:
+correctly typed. The example reflects `nestedOptionsObject.exampleOption` in the object description:
 
 <include cwd lang="typescript" meta='playground example="architecture-plugin-hooks"'>playground-examples/architecture-plugin-hooks/plugin.ts#constructor-options</include>
 
@@ -349,7 +349,7 @@ plugin\). In these cases, the `afterBuild` hook can be used. It receives the bui
 expected to return either the schema it was passed, or a completely new schema. This allows plugins
 to use 3rd party libraries like `graphql-tools` to arbitrarily transform schemas if desired.
 
-This example returns a new schema with a changed description. Run **01-Inspect** to see `__schema.description`:
+This example returns a new schema with a changed description. The changed description is available through `__schema.description`:
 
 <include cwd lang="typescript" meta='playground example="architecture-plugin-hooks"'>playground-examples/architecture-plugin-hooks/plugin.ts#after-build</include>
 
@@ -425,7 +425,7 @@ utility functions that can make this easier:
 - `createInputValueMapper`: Creates a mapping function that uses the result of `mapInputFields` to
   map inputs in an args object to new values.
 
-The relay plugin uses these methods to decode `globalID` inputs. This example uses the same utilities to trim marked strings, including strings inside a nested input list. Remove a `trimInput` extension in `schema.ts` and run again to compare the result:
+The relay plugin uses these methods to decode `globalID` inputs. This example uses the same utilities to trim marked strings, including strings inside a nested input list. Fields without the `trimInput` extension retain their whitespace:
 
 <include cwd lang="typescript" meta='playground example="architecture-plugin-inputs"'>playground-examples/architecture-plugin-inputs/plugin.ts#mapping</include>
 
@@ -471,7 +471,7 @@ from enums. To do this, simply return null from the corresponding on\*Config plu
 
 <include cwd lang="typescript" meta='playground example="architecture-plugin-hooks"'>playground-examples/architecture-plugin-hooks/plugin.ts#remove-input-enum</include>
 
-Run **01-Inspect** to verify that `removeMe` output and input fields and the enum value backed by `removeMe` are absent. The other fields and enum values remain.
+Introspection omits the `removeMe` output and input fields and the enum value backed by `removeMe`. The other fields and enum values remain.
 
 Removing whole types from the schema needs to be done by transforming the schema during the
 `afterBuild` hook. See the `sub-graph` plugin for a more complete example of removing types.

--- a/website/playground-examples/architecture-plugin-hooks/metadata.json
+++ b/website/playground-examples/architecture-plugin-hooks/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "architecture-plugin-hooks",
   "title": "Plugin configuration hooks",
-  "description": "Run 01-Inspect to see descriptions and remaining fields and enum values. Change the options in schema.ts, then run again. Run 02-Values to try the added builder method.",
+  "description": "Run 01-Inspect to see descriptions and confirm removeMe fields and enum values are absent. Change nestedOptionsObject.exampleOption in schema.ts and run again. Open Console: preparation runs once despite two toSchema calls. Run 02-Values to try the added builder method.",
   "category": "patterns",
   "relatedDocs": ["/docs/guide/writing-plugins"]
 }

--- a/website/playground-examples/types-enums/metadata.json
+++ b/website/playground-examples/types-enums/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "types-enums",
   "title": "Enum values and arguments",
-  "description": "Run the query. Change unit(value: Meters) to unit(value: Feet) and run again; enum values in a query are unquoted.",
+  "description": "Run the query. Change unit(value: Meters) to unit(value: Feet); query enum values are unquoted. Select variables, change unit to \"Feet\" in Variables, and run again.",
   "category": "core",
   "relatedDocs": ["/docs/guide/enums"],
   "defaultActiveFile": "schema.ts"

--- a/website/playground-examples/types-inference/metadata.json
+++ b/website/playground-examples/types-inference/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "types-inference",
   "title": "Inferring types for helpers",
-  "description": "Run user and getUsers. Change limit from 1 to 2 to see both users. Hover input in toUser and parent in createObjectWithId to inspect the inferred types.",
+  "description": "Run user and getUsers. Change limit from 1 to 2. Hover input in toUser and parent in createObjectWithId to inspect types. Change MyInput.name from t.string to t.int: toUser now returns a numeric name where UserType requires a string, and the schema input changes to Int!.",
   "category": "core",
   "relatedDocs": ["/docs/guide/inferring-types"]
 }

--- a/website/playground-examples/types-nullability/metadata.json
+++ b/website/playground-examples/types-nullability/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "types-nullability",
   "title": "Default nullability",
-  "description": "Run the valid request, then Missing name. Add title: \"Dr\" to the valid input and run again. Inspect schema.graphql for the required fields.",
+  "description": "Run the valid request, then Missing name. Add title: \"Dr\" to the valid input. Inspect schema.graphql for required fields. Make the nickname resolver throw an Error: only nickname becomes null. Remove nullable: true and run again to see data become null. Reset example restores the resolver.",
   "category": "core",
   "relatedDocs": ["/docs/guide/changing-default-nullability"],
   "defaultActiveFile": "schema.ts"


### PR DESCRIPTION
Core guides still mix API explanations with directions for operating the playground. Move those directions into existing guide-panel metadata so the 16 affected guides remain useful without opening the editor.

Preservation review: input/mutation persistence, recursive input outcomes, context provisioning, inferred-type errors, null propagation, plugin hooks/mapping behavior, and local Codegen/server setup remain in prose. Run/select/reset/change/hover directions already existed in the corresponding metadata for most examples; supplement plugin-hooks, enum, inference, and nullability descriptions for the missing directions. Preserve the instructional Using the playground page and every source excerpt, operation, and expected response.

Validation: regenerated all 75 example bundles; all 157 playground references pass; Fumadocs generation and git diff --check pass. No executable example or UI code changed.

Rendered all 16 changed documentation routes through the Next.js webpack server: HTTP 200 with compiled HTML. No production build or new interactive browser/runtime checks were run for this prose-only change.

Independent content and preservation review completed; addressed remaining editor instructions in circular-reference, scalar, enum, and printing guides.
