### PR TITLE
Clarify playground guide context and operation tips

### DIFF
--- a/website/app/playground/page.tsx
+++ b/website/app/playground/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ConsoleDrawer } from '@/components/playground/ConsoleDrawer/ConsoleDrawer';
+import { GuideDescription } from '@/components/playground/GuideDescription';
 import { OperationPane } from '@/components/playground/OperationPane/OperationPane';
 import { ResponsePane } from '@/components/playground/ResponsePane/ResponsePane';
 import { SchemaEditor } from '@/components/playground/SchemaEditor/SchemaEditor';
@@ -69,17 +70,19 @@ export default function PlaygroundPage() {
         {ui.loadedExample && (
           <aside
             aria-label="Example guide"
-            className="flex flex-wrap items-baseline gap-x-4 gap-y-1 border-b border-bm-line bg-bm-surface-alt px-4 py-2 text-sm"
+            className="flex flex-wrap items-start gap-x-6 gap-y-2 border-b border-bm-line bg-bm-surface-alt px-4 py-2 text-sm"
           >
-            <p className="min-w-0 flex-[1_1_32rem] leading-relaxed">
-              {ui.loadedExample.steps.length > 1 && (
-                <strong className="sm:hidden">
-                  {ui.loadedExample.steps[ui.stepIndex]?.title}.{' '}
-                </strong>
-              )}
-              {ui.loadedExample.steps[ui.stepIndex]?.description ??
-                ui.loadedExample.metadata.description}
-            </p>
+            <GuideDescription
+              description={
+                ui.loadedExample.steps[ui.stepIndex]?.description ??
+                ui.loadedExample.metadata.description
+              }
+              stepTitle={
+                ui.loadedExample.steps.length > 1
+                  ? ui.loadedExample.steps[ui.stepIndex]?.title
+                  : undefined
+              }
+            />
             <div className="flex shrink-0 gap-3 text-xs">
               {ui.loadedExample.metadata.relatedDocs?.[0] && (
                 <a

--- a/website/components/playground/GuideDescription.tsx
+++ b/website/components/playground/GuideDescription.tsx
@@ -1,0 +1,28 @@
+interface Props {
+  description: string;
+  stepTitle?: string;
+}
+
+export function GuideDescription({ description, stepTitle }: Props) {
+  const instructions = description
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  return (
+    <div className="min-w-0 flex-[1_1_32rem] leading-relaxed">
+      {stepTitle && <strong className="sm:hidden">{stepTitle}. </strong>}
+      {instructions.length > 1 ? (
+        <ul className="grid list-disc gap-x-8 gap-y-1 pl-4 md:grid-cols-2">
+          {instructions.map((instruction) => (
+            <li key={instruction} className="min-w-0 break-words">
+              {instruction}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>{description}</p>
+      )}
+    </div>
+  );
+}

--- a/website/playground-examples/AUTHORING.md
+++ b/website/playground-examples/AUTHORING.md
@@ -12,7 +12,7 @@ Read this before adding playground links, writing a guide, changing an example, 
 
 Completion means the reader can follow the explanation, run the corresponding code, make the suggested edit, and observe the promised effect. A compiling schema, valid query, working URL, or shorter page alone does not establish that.
 
-Write docs for readers who will read and copy the code without opening the playground. Keep API explanations, relevant outcomes, and complete local workflows in the docs. Put operation-tab selection, suggested edits, and run/reset instructions in `metadata.description` or the current step’s `description`, which the playground guide panel displays. Keep this guidance concise. Package READMEs contain code snippets and API explanations. Omit links and references to browser or local example projects, repository test commands, and instructions for running or editing those projects.
+Write docs for readers who will read and copy the code without opening the playground. Keep API explanations, relevant outcomes, and complete local workflows in the docs. Use `metadata.description` to introduce the example and explain what the reader can observe. Keep it concise and understandable before opening any operation. Put operation-specific suggestions in comments beside the relevant GraphQL operation, or in the current step’s `description` when they belong to that step. Package READMEs contain code snippets and API explanations. Omit links and references to browser or local example projects, repository test commands, and instructions for running or editing those projects.
 
 Start introductory examples with one source file and one useful query. Add variables, context, helper files, steps, or variants when they teach the page's concept, not to demonstrate the toolkit. Keep trivial resolvers inline. Choose `defaultActiveFile` so a step opens on the code the reader needs; verify the initial file in the actual playground. Follow the full step sequence, including moving backward and resetting, rather than checking only isolated step URLs.
 
@@ -42,7 +42,7 @@ objects/
 
 Keep the ID equal to the directory name. `schema.ts` exports a named `schema`, built with `builder.toSchema()`. Use actual current package APIs. `category` accepts `core`, `plugins`, `examples`, or `patterns`; optional `subcategory`, `tags`, `difficulty` and `order` support catalog organization. `difficulty` accepts `beginner`, `intermediate`, or `advanced`. Metadata is not a curriculum engine: `prerequisites` is carried in the bundle but does not load dependencies or enforce completion.
 
-The guide area displays the example description, or the current step description, as **plain text**, with the first `relatedDocs` link and a reset action. Write short actionable instructions. For several independent tasks, separate them with newlines (`\n` in JSON); the guide renders each nonempty line as a list item. A single-line description stays a paragraph. Markdown, rich guide blocks, and additional related links are not rendered there.
+The guide area displays the example description, or the current step description, as **plain text**, with the first `relatedDocs` link and a reset action. Write a short contextual introduction, not a checklist of operation filenames. When a step needs several short instructions, newlines (`\n` in JSON) render as list items. A single-line description stays a paragraph. Markdown, rich guide blocks, and additional related links are not rendered there.
 
 ## Excerpts, literal fences and playground actions
 

--- a/website/playground-examples/AUTHORING.md
+++ b/website/playground-examples/AUTHORING.md
@@ -42,7 +42,7 @@ objects/
 
 Keep the ID equal to the directory name. `schema.ts` exports a named `schema`, built with `builder.toSchema()`. Use actual current package APIs. `category` accepts `core`, `plugins`, `examples`, or `patterns`; optional `subcategory`, `tags`, `difficulty` and `order` support catalog organization. `difficulty` accepts `beginner`, `intermediate`, or `advanced`. Metadata is not a curriculum engine: `prerequisites` is carried in the bundle but does not load dependencies or enforce completion.
 
-The guide area displays the example description, or the current step description, as **plain text**, with the first `relatedDocs` link and a reset action. Write short actionable instructions; Markdown, rich guide blocks, and additional related links are not rendered there.
+The guide area displays the example description, or the current step description, as **plain text**, with the first `relatedDocs` link and a reset action. Write short actionable instructions. For several independent tasks, separate them with newlines (`\n` in JSON); the guide renders each nonempty line as a list item. A single-line description stays a paragraph. Markdown, rich guide blocks, and additional related links are not rendered there.
 
 ## Excerpts, literal fences and playground actions
 

--- a/website/playground-examples/plugin-drizzle/02-aliases.graphql
+++ b/website/playground-examples/plugin-drizzle/02-aliases.graphql
@@ -1,3 +1,4 @@
+# Compare the newest and oldest selections in Queries, then inspect their SQL in Console.
 query Aliases {
   author(id: 1) {
     newest: posts {

--- a/website/playground-examples/plugin-drizzle/03-viewer.graphql
+++ b/website/playground-examples/plugin-drizzle/03-viewer.graphql
@@ -1,3 +1,4 @@
+# Change userId to 2 in Context to see the other viewer and their drafts.
 query Viewer {
   me {
     __typename

--- a/website/playground-examples/plugin-drizzle/04-pagination.graphql
+++ b/website/playground-examples/plugin-drizzle/04-pagination.graphql
@@ -1,3 +1,4 @@
+# To load the next page, copy pageInfo.endCursor into after in Variables and run again.
 query Pagination($after: String) {
   posts(first: 2, after: $after) {
     totalCount

--- a/website/playground-examples/plugin-drizzle/09-variant.graphql
+++ b/website/playground-examples/plugin-drizzle/09-variant.graphql
@@ -1,3 +1,4 @@
+# Change userId to 2 in Context to see which author exposes private viewer fields.
 query PrivateVariant {
   own: author(id: 1) {
     viewer {

--- a/website/playground-examples/plugin-drizzle/10-attachments.graphql
+++ b/website/playground-examples/plugin-drizzle/10-attachments.graphql
@@ -1,3 +1,5 @@
+# Set hasCaption to true in Variables to keep only captioned attachments.
+# To load the next attachment page, copy its pageInfo.endCursor into after in Variables.
 query Attachments($after: String, $hasCaption: Boolean = false) {
   author(id: 1) {
     postsConnection(first: 1) {

--- a/website/playground-examples/plugin-drizzle/metadata.json
+++ b/website/playground-examples/plugin-drizzle/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "plugin-drizzle",
   "title": "A publishing API with Drizzle",
-  "description": "04-pagination: paste endCursor into Variables.after.\n10-attachments: set hasCaption to true, or paste endCursor into after.\n02-aliases: compare query options in Queries and SQL in Console.\n03-viewer or 09-variant: change Context userId to 2.\nReset restores the seed.",
+  "description": "Explore how Pothos turns GraphQL selections into Drizzle queries, with related records, pagination, and private fields. Run a query, then inspect the options in Queries and the SQL in Console.",
   "category": "plugins",
   "difficulty": "intermediate",
   "relatedDocs": ["/docs/plugins/drizzle"],

--- a/website/playground-examples/plugin-drizzle/metadata.json
+++ b/website/playground-examples/plugin-drizzle/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "plugin-drizzle",
   "title": "A publishing API with Drizzle",
-  "description": "Continue 04-pagination with endCursor as Variables.after. In 10-attachments, set hasCaption to true or use endCursor as after. Compare 02-aliases SQL in Console. Change Context userId to 2 in 03-viewer or 09-variant. Reset restores the seed.",
+  "description": "04-pagination: paste endCursor into Variables.after.\n10-attachments: set hasCaption to true, or paste endCursor into after.\n02-aliases: compare SQL in Console.\n03-viewer or 09-variant: change Context userId to 2.\nReset restores the seed.",
   "category": "plugins",
   "difficulty": "intermediate",
   "relatedDocs": ["/docs/plugins/drizzle"],

--- a/website/scripts/check-playground-guide.mjs
+++ b/website/scripts/check-playground-guide.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+
+export async function checkPlaygroundGuide(browser, origin) {
+  for (const width of [1440, 390, 320]) {
+    const page = await browser.newPage({ viewport: { width, height: 900 } });
+    page.setDefaultTimeout(60000);
+    try {
+      await page.goto(`${origin}/playground?example=plugin-drizzle`);
+      const guide = page.getByRole('complementary', { name: 'Example guide' });
+      await guide.waitFor();
+      const instructions = guide.getByRole('listitem');
+      assert.equal(
+        await instructions.count(),
+        5,
+        'Show each Drizzle task as a separate instruction',
+      );
+      const text = await guide.innerText();
+      for (const instruction of [
+        '04-pagination',
+        'Variables.after',
+        '10-attachments',
+        'hasCaption',
+        '02-aliases',
+        '03-viewer',
+        '09-variant',
+        'userId',
+        'Reset restores the seed',
+      ]) {
+        assert.ok(text.includes(instruction), `Preserve ${instruction}`);
+      }
+      for (const element of [
+        guide,
+        ...(await instructions.all()),
+        guide.getByRole('link'),
+        guide.getByRole('button'),
+      ]) {
+        const box = await element.boundingBox();
+        assert.ok(
+          box && box.x >= 0 && box.x + box.width <= width,
+          `${width}px: guide content stays inside the viewport`,
+        );
+      }
+      assert.equal(
+        await guide.getByRole('link', { name: 'Read the guide' }).getAttribute('href'),
+        '/docs/plugins/drizzle',
+      );
+      await Promise.all([
+        page.waitForEvent('load'),
+        guide.getByRole('button', { name: 'Reset example' }).click(),
+      ]);
+      await guide.waitFor();
+      assert.equal(await guide.getByRole('listitem').count(), 5, 'Reset preserves the guide');
+      console.log(`PASS ${width}px guide instructions, actions, and reset`);
+    } finally {
+      await page.close();
+    }
+  }
+  const page = await browser.newPage({ viewport: { width: 390, height: 900 } });
+  page.setDefaultTimeout(60000);
+  try {
+    await page.goto(`${origin}/playground?example=playground-tour`);
+    const guide = page.getByRole('complementary', { name: 'Example guide' });
+    await guide.getByText('Run and edit.', { exact: true }).waitFor();
+    assert.equal(
+      await guide.getByRole('listitem').count(),
+      0,
+      'Keep single-line descriptions as paragraphs',
+    );
+    await page.getByRole('button', { name: /schema synced/ }).waitFor();
+    await page.getByRole('button', { name: 'Next →', exact: true }).click();
+    await guide.getByText('Explore a schema.', { exact: true }).waitFor();
+    assert.ok((await guide.innerText()).includes('Change minimumHeight in Variables'));
+    await page.getByRole('button', { name: '← Prev', exact: true }).click();
+    await guide.getByText('Run and edit.', { exact: true }).waitFor();
+    assert.ok((await guide.innerText()).includes('Change Sam in the query'));
+    console.log('PASS mobile single-line guide and step navigation');
+  } finally {
+    await page.close();
+  }
+}

--- a/website/scripts/check-playground-guide.mjs
+++ b/website/scripts/check-playground-guide.mjs
@@ -8,29 +8,16 @@ export async function checkPlaygroundGuide(browser, origin) {
       await page.goto(`${origin}/playground?example=plugin-drizzle`);
       const guide = page.getByRole('complementary', { name: 'Example guide' });
       await guide.waitFor();
-      const instructions = guide.getByRole('listitem');
-      assert.equal(
-        await instructions.count(),
-        5,
-        'Show each Drizzle task as a separate instruction',
-      );
-      const text = await guide.innerText();
-      for (const instruction of [
-        '04-pagination',
-        'Variables.after',
-        '10-attachments',
-        'hasCaption',
-        '02-aliases',
-        '03-viewer',
-        '09-variant',
-        'userId',
-        'Reset restores the seed',
-      ]) {
-        assert.ok(text.includes(instruction), `Preserve ${instruction}`);
-      }
+      const description = guide.locator('p');
+      assert.equal(await description.count(), 1, 'Introduce the example in one paragraph');
+      assert.equal(await guide.getByRole('listitem').count(), 0, 'Avoid a task checklist');
+      const descriptionText = await description.innerText();
+      assert.ok(descriptionText.length < 250, 'Keep the introduction concise');
+      assert.ok(!/\b\d{2}-[a-z]/.test(descriptionText), 'Avoid unexplained operation filenames');
+      assert.ok(/GraphQL/.test(descriptionText) && /Drizzle/.test(descriptionText));
       for (const element of [
         guide,
-        ...(await instructions.all()),
+        description,
         guide.getByRole('link'),
         guide.getByRole('button'),
       ]) {
@@ -49,8 +36,12 @@ export async function checkPlaygroundGuide(browser, origin) {
         guide.getByRole('button', { name: 'Reset example' }).click(),
       ]);
       await guide.waitFor();
-      assert.equal(await guide.getByRole('listitem').count(), 5, 'Reset preserves the guide');
-      console.log(`PASS ${width}px guide instructions, actions, and reset`);
+      assert.equal(
+        await guide.locator('p').innerText(),
+        descriptionText,
+        'Reset preserves the guide',
+      );
+      console.log(`PASS ${width}px guide introduction, actions, and reset`);
     } finally {
       await page.close();
     }

--- a/website/scripts/check-playground.mjs
+++ b/website/scripts/check-playground.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { chromium } from 'playwright';
+import { checkPlaygroundGuide } from './check-playground-guide.mjs';
 import { checkPlaygroundMobile, checkPlaygroundMobileFiles } from './check-playground-mobile.mjs';
 import { checkPlaygroundProject } from './check-playground-project.mjs';
 import { checkPlaygroundTabs } from './check-playground-tabs.mjs';
@@ -81,6 +82,7 @@ try {
       await page.close();
     }
   }
+  await checkPlaygroundGuide(browser, origin);
   await checkPlaygroundTracing(browser, origin);
   await checkPlaygroundMobile(browser, origin);
   await checkPlaygroundMobileFiles(browser, origin);


### PR DESCRIPTION
The Drizzle playground opened with a dense checklist of numbered operation filenames before explaining the example. The guide now introduces how GraphQL selections become Drizzle queries in a short paragraph, then points readers to Queries and Console. Pagination, caption filtering, alias inspection, and viewer-context tips live beside the corresponding GraphQL operations.

Single-line guides remain paragraphs; authored multiline step instructions render as list items, and mobile step titles remain visible. AUTHORING describes contextual introductions and query-local guidance. No schema or runtime behavior changed, and all five commented operations have identical parsed GraphQL ASTs.

Validation: generated examples and 159 playground references pass; website TypeScript, scoped Biome, and diff checks pass. Browser checks at 1440, 390, and 320 pixels cover the concise paragraph, absence of filename checklists, viewport bounds, guide link and reset; mobile next/previous step navigation passes. Independent content and preservation review approved the final copy and independently verified operation AST parity.
