### PR TITLE
feat(website): show Drizzle query options in playground

### DIFF
--- a/website/lib/playground/__tests__/drizzle-capture.test.ts
+++ b/website/lib/playground/__tests__/drizzle-capture.test.ts
@@ -1,0 +1,109 @@
+import { defineRelations, eq, sql } from 'drizzle-orm';
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import { drizzle } from 'drizzle-orm/sqlite-proxy';
+import { beforeEach, expect, it, vi } from 'vitest';
+import { captureDrizzleQueries, snapshotQuery } from '../drizzle/capture';
+import { drizzleSqliteProxy } from '../drizzle/sqlite-proxy';
+import { getExtensionPanels, resetExtensionPanels } from '../extension-panels-slot';
+
+const users = sqliteTable('users', { id: integer().primaryKey(), name: text().notNull() });
+const relations = defineRelations({ users });
+beforeEach(resetExtensionPanels);
+
+it('captures relational options without changing SQL or returned rows', async () => {
+  const driver = vi.fn(async (..._args: unknown[]) => ({
+    rows: [[JSON.stringify({ id: 1, name: 'Maya' })]],
+  }));
+  const normal = drizzle(driver, { relations });
+  const inspected = drizzleSqliteProxy.drizzle(driver, { relations });
+  const options = { columns: { id: true, name: true }, where: { id: 1 }, limit: 2 } as const;
+  const expected = await normal.query.users.findMany(options);
+  const actual = await inspected.query.users.findMany(options);
+  expect(actual).toEqual(expected);
+  expect(actual).toEqual([{ id: 1, name: 'Maya' }]);
+  expect(driver.mock.calls[1]).toEqual(driver.mock.calls[0]);
+  const panel = getExtensionPanels()[0];
+  expect(panel.name).toBe('Queries');
+  expect(panel.tabs).toHaveLength(1);
+  expect(panel.tabs![0].name).toBe('1. db.query.users.findMany');
+  expect(JSON.parse(panel.tabs![0].content)).toEqual({
+    method: 'db.query.users.findMany',
+    arguments: [options],
+  });
+});
+
+it('snapshots arguments, preserves the query object, and starts fresh after reset', () => {
+  // biome-ignore lint/suspicious/noThenProperty: verify capture never consumes a lazy query
+  const result = { then: vi.fn() };
+  const table = {
+    findFirst: vi.fn(function (this: unknown, ..._args: unknown[]) {
+      expect(this).toBe(table);
+      return result;
+    }),
+  };
+  const db = captureDrizzleQueries({ query: { users: table } });
+  const options = { where: { id: 1 }, with: { posts: { limit: 2 } } };
+  expect(db.query.users.findFirst(options)).toBe(result);
+  options.where.id = 9;
+  const previous = getExtensionPanels()[0];
+  expect(JSON.parse(previous.tabs![0].content).arguments[0].where.id).toBe(1);
+  db.query.users.findFirst();
+  expect(previous.tabs).toHaveLength(2);
+  expect(result.then).not.toHaveBeenCalled();
+  resetExtensionPanels();
+  expect(getExtensionPanels()).toEqual([]);
+  db.query.users.findFirst({ where: { id: 3 } });
+  expect(getExtensionPanels()[0]).not.toBe(previous);
+  expect(getExtensionPanels()[0].tabs).toHaveLength(1);
+  expect(previous.tabs).toHaveLength(2);
+});
+
+it('records count arguments and preserves synchronous API failures', () => {
+  const db = drizzleSqliteProxy.drizzle(async () => ({ rows: [] }), { relations });
+  db.$count(users, eq(users.id, 1));
+  const entry = JSON.parse(getExtensionPanels()[0].tabs![0].content);
+  expect(entry.method).toBe('db.$count');
+  expect(entry.arguments[0]).toEqual({ $type: 'Table', name: 'users' });
+  expect(entry.arguments[1].$type).toBe('SQL');
+  const error = new Error('invalid query');
+  const broken = captureDrizzleQueries({
+    query: {
+      users: {
+        findMany: () => {
+          throw error;
+        },
+      },
+    },
+  });
+  expect(() => broken.query.users.findMany()).toThrow(error);
+  expect(getExtensionPanels()[0].tabs).toHaveLength(2);
+});
+
+it('labels callbacks, SQL, cycles and special values without evaluating callbacks or getters', () => {
+  const callback = vi.fn(() => {
+    throw new Error('must not run');
+  });
+  const getter = vi.fn(() => {
+    throw new Error('must not run');
+  });
+  const options: Record<string, unknown> = {
+    where: callback,
+    extras: { count: sql`length(${users.name})` },
+    date: new Date('2026-01-01T00:00:00.123Z'),
+    id: 9n,
+    missing: undefined,
+  };
+  Object.defineProperty(options, 'getter', { enumerable: true, get: getter });
+  options.self = options;
+  const snapshot = snapshotQuery(options) as Record<string, unknown>;
+  expect(snapshot.where).toMatchObject({ $type: 'Function' });
+  expect(snapshot.extras).toMatchObject({ count: { $type: 'SQL' } });
+  expect(snapshot.id).toEqual({ $type: 'bigint', value: '9' });
+  expect(snapshot.missing).toEqual({ $type: 'undefined' });
+  expect(snapshot.date).toEqual({ $type: 'Date', value: '2026-01-01T00:00:00.123Z' });
+  expect(snapshot.self).toEqual({ $type: 'Circular', path: '$' });
+  expect(snapshot.getter).toMatchObject({ $type: 'Accessor' });
+  expect(callback).not.toHaveBeenCalled();
+  expect(getter).not.toHaveBeenCalled();
+  expect(() => JSON.stringify(snapshot)).not.toThrow();
+});

--- a/website/lib/playground/drizzle/capture.ts
+++ b/website/lib/playground/drizzle/capture.ts
@@ -1,0 +1,161 @@
+import { Column, getTableName, SQL, Table } from 'drizzle-orm';
+import { getExtensionPanels, pushExtensionPanel } from '../extension-panels-slot';
+import type { ExtensionPanel, ExtensionSubPanel } from '../playground-panels';
+
+let current: (ExtensionPanel & { tabs: ExtensionSubPanel[] }) | undefined;
+
+/** Diagnostic snapshots, not executable JSON: callbacks are never called and getters never read. */
+export function snapshotQuery(value: unknown): unknown {
+  const ancestors = new Map<object, string>();
+  let remaining = 1000;
+
+  function visit(value: unknown, path: string, depth: number): unknown {
+    if (--remaining < 0 || depth > 12) {
+      return { $type: 'Truncated' };
+    }
+    if (value === undefined) {
+      return { $type: 'undefined' };
+    }
+    if (typeof value === 'bigint') {
+      return { $type: 'bigint', value: String(value) };
+    }
+    if (typeof value === 'function') {
+      return { $type: 'Function', source: Function.prototype.toString.call(value) };
+    }
+    if (typeof value === 'symbol') {
+      return { $type: 'Symbol', value: String(value) };
+    }
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+      return { $type: 'number', value: String(value) };
+    }
+    if (value === null || typeof value !== 'object') {
+      return value;
+    }
+    if (ancestors.has(value)) {
+      return { $type: 'Circular', path: ancestors.get(value) };
+    }
+    if (value instanceof Date) {
+      return {
+        $type: 'Date',
+        value: Number.isNaN(value.getTime()) ? 'Invalid Date' : value.toISOString(),
+      };
+    }
+    if (value instanceof Column) {
+      return {
+        $type: 'Column',
+        table: getTableName((value as Column & { table: Table }).table),
+        name: value.name,
+      };
+    }
+    if (value instanceof Table) {
+      return { $type: 'Table', name: getTableName(value) };
+    }
+
+    ancestors.set(value, path);
+    try {
+      if (Array.isArray(value)) {
+        const items: unknown[] = [];
+        for (let i = 0; i < value.length; i++) {
+          if (remaining <= 0) {
+            items.push({ $type: 'Truncated', omittedItems: value.length - i });
+            break;
+          }
+          const descriptor = Object.getOwnPropertyDescriptor(value, i);
+          items.push(
+            descriptor
+              ? 'value' in descriptor
+                ? visit(descriptor.value, `${path}[${i}]`, depth + 1)
+                : { $type: 'Accessor', note: 'Not evaluated' }
+              : { $type: 'Empty slot' },
+          );
+        }
+        return items;
+      }
+      if (value instanceof SQL) {
+        return { $type: 'SQL', chunks: visit(value.queryChunks, `${path}.chunks`, depth + 1) };
+      }
+      const properties: Record<string, unknown> = {};
+      for (const key of Reflect.ownKeys(value)) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, key)!;
+        if (!descriptor.enumerable) {
+          continue;
+        }
+        if (remaining <= 0) {
+          return { $type: 'Truncated object', properties, note: 'Remaining properties omitted' };
+        }
+        const name = typeof key === 'symbol' ? `[${String(key)}]` : key;
+        Object.defineProperty(properties, name, {
+          value:
+            'value' in descriptor
+              ? visit(descriptor.value, `${path}.${name}`, depth + 1)
+              : { $type: 'Accessor', note: 'Not evaluated' },
+          enumerable: true,
+        });
+      }
+      const prototype = Object.getPrototypeOf(value);
+      return prototype === Object.prototype || prototype === null
+        ? properties
+        : {
+            $type:
+              Object.getOwnPropertyDescriptor(prototype, 'constructor')?.value?.name ?? 'Object',
+            properties,
+          };
+    } finally {
+      ancestors.delete(value);
+    }
+  }
+
+  try {
+    return visit(value, '$', 0);
+  } catch {
+    // An unusual proxy/object must not stop the database call merely because inspection failed.
+    return { $type: 'Uninspectable', note: 'The argument could not be inspected safely' };
+  }
+}
+
+function capture(method: string, args: unknown[]) {
+  if (!current || !getExtensionPanels().includes(current)) {
+    current = { name: 'Queries', tabs: [] };
+    pushExtensionPanel(current);
+  }
+  current.tabs.push({
+    name: `${current.tabs.length + 1}. ${method}`,
+    language: 'json',
+    content: JSON.stringify({ method, arguments: snapshotQuery(args) }, null, 2),
+  });
+}
+
+/** Capture API invocations, including fallback loads, before Drizzle processes the options. */
+export function captureDrizzleQueries<T extends object>(db: T): T {
+  const proxies = new WeakMap<object, object>();
+  function wrap<T extends object>(target: T, kind: 'db' | 'query' | 'table', path: string): T {
+    if (proxies.has(target)) {
+      return proxies.get(target) as T;
+    }
+    const proxy = new Proxy(target, {
+      get(target, key, receiver) {
+        const value: unknown = Reflect.get(target, key, receiver);
+        if (kind === 'db' && key === 'query' && value && typeof value === 'object') {
+          return wrap(value, 'query', 'db.query');
+        }
+        if (kind === 'query' && typeof key === 'string' && value && typeof value === 'object') {
+          return wrap(value, 'table', `${path}.${key}`);
+        }
+        if (
+          typeof value === 'function' &&
+          ((kind === 'table' && (key === 'findFirst' || key === 'findMany')) ||
+            (kind === 'db' && key === '$count'))
+        ) {
+          return (...args: unknown[]) => {
+            capture(`${path}.${String(key)}`, args);
+            return Reflect.apply(value, target, args);
+          };
+        }
+        return value;
+      },
+    });
+    proxies.set(target, proxy);
+    return proxy;
+  }
+  return wrap(db, 'db', 'db');
+}

--- a/website/lib/playground/drizzle/sqlite-proxy.ts
+++ b/website/lib/playground/drizzle/sqlite-proxy.ts
@@ -1,0 +1,12 @@
+import * as sqliteProxy from 'drizzle-orm/sqlite-proxy';
+import { captureDrizzleQueries } from './capture';
+
+// Keep the upstream overloads and returned client types. Only the playground module registry
+// substitutes this factory; authored examples remain ordinary, copyable Drizzle code.
+const drizzle = new Proxy(sqliteProxy.drizzle, {
+  apply(target, receiver, args) {
+    return captureDrizzleQueries(Reflect.apply(target, receiver, args));
+  },
+});
+
+export const drizzleSqliteProxy = { ...sqliteProxy, drizzle };

--- a/website/lib/playground/plugins-bundle.ts
+++ b/website/lib/playground/plugins-bundle.ts
@@ -31,13 +31,13 @@ import * as WithInputModule from '@pothos/plugin-with-input';
 import * as ZodModule from '@pothos/plugin-zod';
 import * as DrizzleOrm from 'drizzle-orm';
 import * as DrizzleSqliteCore from 'drizzle-orm/sqlite-core';
-import * as DrizzleSqliteProxy from 'drizzle-orm/sqlite-proxy';
+import { drizzleSqliteProxy } from './drizzle/sqlite-proxy';
 
 export const pluginModules = {
   '@pothos/plugin-drizzle': DrizzleModule,
   'drizzle-orm': DrizzleOrm,
   'drizzle-orm/sqlite-core': DrizzleSqliteCore,
-  'drizzle-orm/sqlite-proxy': DrizzleSqliteProxy,
+  'drizzle-orm/sqlite-proxy': drizzleSqliteProxy,
   '@pothos/plugin-tracing': TracingModule,
   '@pothos/plugin-zod': ZodModule,
   '@pothos/plugin-simple-objects': SimpleObjectsModule,

--- a/website/playground-examples/plugin-drizzle/README.md
+++ b/website/playground-examples/plugin-drizzle/README.md
@@ -19,3 +19,10 @@ driver and their normal migration workflow instead of this playground bridge.
 
 The operation fixtures cover author lookups, aliased relation queries, viewer context, pagination,
 missing rows, related counts, node refetching, computed selections, conditional variants, and attachment edges with filtered cursor pagination.
+
+After running an operation, the **Queries** response tab shows each `db.query.<table>.findFirst`,
+`findMany`, and `db.$count` invocation with the arguments passed to Drizzle, including Pothos's
+nested selections and fallback loads. These are snapshots at API invocation, not a count of SQL
+executions. SQL remains in Console. Callbacks are shown as function source without being evaluated;
+SQL objects, columns, dates, and other non-JSON values use labeled diagnostic representations.
+Captures are replaced on each run and cleared when the example is reset.

--- a/website/playground-examples/plugin-drizzle/metadata.json
+++ b/website/playground-examples/plugin-drizzle/metadata.json
@@ -1,7 +1,7 @@
 {
   "id": "plugin-drizzle",
   "title": "A publishing API with Drizzle",
-  "description": "Continue 04-pagination with endCursor as Variables.after. In 10-attachments, set hasCaption to true or use endCursor as after. Compare 02-aliases SQL in Console. Change Context userId to 2 in 03-viewer or 09-variant. Reset restores the seed.",
+  "description": "Continue 04-pagination with endCursor as Variables.after. In 10-attachments, set hasCaption to true or use endCursor as after. Compare 02-aliases in Queries and its SQL in Console. Change Context userId to 2 in 03-viewer or 09-variant. Reset restores the seed.",
   "category": "plugins",
   "difficulty": "intermediate",
   "relatedDocs": ["/docs/plugins/drizzle"],

--- a/website/scripts/check-database-browser.mjs
+++ b/website/scripts/check-database-browser.mjs
@@ -46,6 +46,54 @@ const run = async () => {
   await output.filter({ hasText: /\S/ }).waitFor({ state: 'attached' });
   return JSON.parse(await output.textContent());
 };
+// Inspect the same Monaco content a reader sees, through the generic response tabs.
+const inspectQueries = async (surface = page) => {
+  await surface.getByRole('button', { name: 'Queries', exact: true }).click();
+  const tabs = surface.getByRole('tablist', { name: 'Queries sub-tabs' }).getByRole('tab');
+  const names = await tabs.allTextContents();
+  const entries = [];
+  for (const name of names) {
+    await tabs.filter({ hasText: name }).click();
+    const method = name.replace(/^\d+\. /, '');
+    await surface.waitForFunction(
+      (method) =>
+        window.monaco.editor.getEditors().some((editor) => {
+          if (
+            editor.getDomNode()?.offsetParent === null ||
+            !editor.getOption(window.monaco.editor.EditorOption.readOnly)
+          ) {
+            return false;
+          }
+          try {
+            return JSON.parse(editor.getValue()).method === method;
+          } catch {
+            return false;
+          }
+        }),
+      method,
+    );
+    entries.push(
+      await surface.evaluate((method) => {
+        for (const editor of window.monaco.editor.getEditors()) {
+          if (
+            editor.getDomNode()?.offsetParent === null ||
+            !editor.getOption(window.monaco.editor.EditorOption.readOnly)
+          ) {
+            continue;
+          }
+          try {
+            const value = JSON.parse(editor.getValue());
+            if (value.method === method) {
+              return value;
+            }
+          } catch {}
+        }
+      }, method),
+    );
+  }
+  await surface.getByRole('button', { name: 'Response', exact: true }).click();
+  return entries;
+};
 try {
   await page.goto(`${origin}/playground?example=plugin-drizzle`);
   await page.getByRole('button', { name: /schema synced/ }).waitFor();
@@ -95,10 +143,25 @@ try {
     results[`${query.title}.graphql`] = result;
     if (query.title === '01-author') {
       assert.equal(sql.length, 1, 'nested author and posts are loaded by one SQL query');
+      const entries = await inspectQueries();
+      assert.equal(entries.length, 1);
+      assert.equal(entries[0].method, 'db.query.users.findFirst');
+      assert.deepEqual(entries[0].arguments[0].where, { id: 1 });
+      assert.ok(entries[0].arguments[0].with.posts, 'show the nested relation options');
     }
     if (query.title === '02-aliases') {
       assert.equal(sql.length, 2, 'incompatible aliases require a fallback query');
       assert.deepEqual(result.data.author.newest, [...result.data.author.oldest].reverse());
+      const entries = await inspectQueries();
+      assert.deepEqual(
+        entries.map((entry) => entry.method),
+        ['db.query.users.findFirst', 'db.query.users.findMany'],
+      );
+      assert.equal(
+        entries[1].arguments[0].where.RAW.$type,
+        'Function',
+        'fallback callback is represented without evaluating it',
+      );
     }
     console.log('PASS', query.title);
   }
@@ -189,6 +252,17 @@ try {
   assert.deepEqual((await run()).data, { posts: { totalCount: 3 } });
   assert.equal(sql.length, 1, 'root count-only selection skips the row query');
   assert.match(sql[0], /count\(/i);
+  const countEntries = await inspectQueries();
+  assert.equal(countEntries.length, 1, 'capture is replaced on every run');
+  assert.equal(countEntries[0].method, 'db.$count');
+  assert.equal(countEntries[0].arguments[1].$type, 'SQL');
+  await pane('Query', '{ __typename }');
+  await run();
+  assert.equal(
+    await page.getByRole('button', { name: 'Queries', exact: true }).count(),
+    0,
+    'no stale Queries tab for a run without database calls',
+  );
 
   await operation('10-attachments');
   const attachments =
@@ -288,6 +362,11 @@ try {
   await page.waitForTimeout(1000);
   await page.getByRole('button', { name: /schema synced/ }).waitFor();
   assert.equal((await run()).data.author.fullName, 'Maya Chen');
+  assert.equal(
+    (await inspectQueries()).length,
+    1,
+    'reset does not retain captures from an old database',
+  );
   console.log(
     'PASS cursor continuation, backward/empty pages, count-only SQL, viewer isolation, seed edit and reset',
   );
@@ -397,6 +476,16 @@ try {
         }
         if (check === 'aliases') {
           assert.deepEqual(result.data.author.newest, [...result.data.author.oldest].reverse());
+          const entries = await inspectQueries(runtime);
+          assert.deepEqual(
+            entries.map((entry) => entry.method),
+            ['db.query.users.findFirst', 'db.query.users.findMany'],
+          );
+          assert.equal(
+            entries[1].arguments[0].where.RAW.$type,
+            'Function',
+            'fallback callback is represented without evaluating it',
+          );
         }
         if (check === 'viewer') {
           assert.equal(result.data.me.__typename, 'EditorViewer');
@@ -451,6 +540,10 @@ try {
     .first()
     .filter({ hasText: 'Maya Chen' })
     .waitFor({ state: 'attached' });
+  const mobileRuntime = page.frames().find((candidate) => candidate.url().includes('/playground?'));
+  assert.equal((await inspectQueries(mobileRuntime)).length, 1);
+  await mobile.getByRole('button', { name: 'Queries', exact: true }).click();
+  await mobile.getByRole('tablist', { name: 'Queries sub-tabs' }).scrollIntoViewIfNeeded();
   await page.screenshot({ path: '/tmp/pothos-drizzle-mobile.png' });
   console.log('PASS mobile docs action, query and result');
 } finally {


### PR DESCRIPTION
Drizzle examples currently expose SQL only through Console. Add a **Queries** response tab showing the actual arguments passed to `db.query.<table>.findFirst`, `findMany`, and `db.$count`, including Pothos selections and fallback loads.

The playground wraps the existing SQLite proxy factory and reuses the generic extension panels. It snapshots arguments before Drizzle processes them, preserving the original arguments, receiver, lazy result, SQL, and rows. Functions, SQL objects, columns, dates, bigint, cycles, accessors, and truncated values are labeled diagnostic representations; capture does not invoke callbacks or consume queries. Each run gets fresh captures, and runs without database calls have no stale tab. Authored database code stays unchanged and copyable.

Validation:
- 70 website unit tests pass, including four query-capture tests using real Drizzle query construction and comparing SQL/results.
- Website TypeScript and all 103 playground source files in 75 isolated programs pass; generated example bundles and playground references pass.
- Browser: all ten Drizzle operations, author/alias query options, count-only SQL objects, per-run clearing, no-query clearing, cursor traversal, viewer isolation, seed edit/share/reset pass. Desktop and 390px mobile Queries rendering checked; mobile docs launch/run passes.
- Full existing database browser script passes, including every rendered Drizzle docs action and the mobile Queries tab (the initial dev-server sweep timed out on iframe loading; the final warmed-cache run completed successfully).
- Independent correctness/preservation review found no blocker. No existing guide instructions removed; the alias instruction additionally points to Queries.

Scope: captures relational API calls and `$count`, not transaction clients or the SQL query-builder chain. API invocation snapshots do not imply SQL execution. SQL remains in Console.

The description wording overlaps #1742 only on the alias instruction: preserve that PR's newline formatting and use “Compare 02-aliases in Queries and its SQL in Console.”
