### PR TITLE
fix(docs): restore snippet parity and catalog formatting checks

### DIFF
--- a/website/components/plugins/PluginsPage.tsx
+++ b/website/components/plugins/PluginsPage.tsx
@@ -24,9 +24,9 @@ export function PluginsPage() {
           Plugins
         </h1>
         <p className="text-bm-ink-soft leading-[1.5] mt-5 text-[17px] max-w-[640px]">
-          {totalPlugins} plugins for your data layer, auth, tracing, and common schema
-          patterns. Each one adds methods and options to the builder, with the same type inference
-          as the core API.
+          {totalPlugins} plugins for your data layer, auth, tracing, and common schema patterns.
+          Each one adds methods and options to the builder, with the same type inference as the core
+          API.
         </p>
         <p className="text-bm-ink-soft leading-[1.5] mt-4 text-[17px] max-w-[640px]">
           See{' '}

--- a/website/playground-examples/inputs-oneof/schema.ts
+++ b/website/playground-examples/inputs-oneof/schema.ts
@@ -2,7 +2,6 @@ import SchemaBuilder from '@pothos/core';
 
 const builder = new SchemaBuilder({});
 
-// #region lookup-input
 export const GiraffeLookup = builder.inputType('GiraffeLookup', {
   isOneOf: true,
   fields: (t) => ({
@@ -10,11 +9,9 @@ export const GiraffeLookup = builder.inputType('GiraffeLookup', {
     name: t.string({ required: false }),
   }),
 });
-// #endregion lookup-input
 
 const giraffes = [{ id: '1', name: 'Gina' }];
 
-// #region lookup-query
 builder.queryType({
   fields: (t) => ({
     giraffeName: t.string({
@@ -31,6 +28,5 @@ builder.queryType({
     }),
   }),
 });
-// #endregion lookup-query
 
 export const schema = builder.toSchema();


### PR DESCRIPTION
Restore main's Node and Documentation playground CI after all build/runtime checks succeed.

The OneOf guide includes its complete schema, but the example retained unused region markers from an earlier excerpt layout. Full-file rendering preserved those comments while the exact source-parity checker strips them, failing both HTML and Markdown comparisons. Remove the four unused comments; preserve the strict parity assertions. Also apply Biome's required line wrapping to the plugin catalog introduction.

Validation: reproduced both failures, then passed full Biome (1,692 files), production website build, and the complete format checker: 577 snippets and 178 source includes across 80 pages in HTML, public/internal Markdown, full corpus, LLM index and sitemap, plus 66 README source excerpts. All 12 OneOf tests pass; focused browser verification passed both docs actions, desktop/mobile, editor types, valid alternatives and rejected inputs. The latest main CI had already passed all 116 build/test/type tasks and all runtime/browser/link checks before these two failures.
