### PR TITLE
fix(complexity): address 4 findings from the plugin review

### DIFF
--- a/.changeset/complexity-review-fixes.md
+++ b/.changeset/complexity-review-fixes.md
@@ -2,7 +2,7 @@
 "@pothos/plugin-complexity": patch
 ---
 
-Resolve operation root types by role so schemas with renamed roots work
-Treat a maximum of `0` as a real limit instead of as "no limit"
-Honor the schema-level `complexity.disabled` option passed to `toSchema`
-Reset validation rule state per operation so operations are measured independently
+- Resolve operation root types by role so schemas with renamed roots work
+- Treat a maximum of `0` as a real limit instead of as "no limit"
+- Honor the schema-level `complexity.disabled` option passed to `toSchema`
+- Reset validation rule state per operation so operations are measured independently. For a document with multiple operations, `createComplexityRule`'s `onResult` callback is now called once per operation with that operation's own cost, rather than with a running total across the document.

--- a/.changeset/complexity-review-fixes.md
+++ b/.changeset/complexity-review-fixes.md
@@ -1,0 +1,8 @@
+---
+"@pothos/plugin-complexity": patch
+---
+
+Resolve operation root types by role so schemas with renamed roots work
+Treat a maximum of `0` as a real limit instead of as "no limit"
+Honor the schema-level `complexity.disabled` option passed to `toSchema`
+Reset validation rule state per operation so operations are measured independently

--- a/packages/plugin-complexity/src/calculate-complexity.ts
+++ b/packages/plugin-complexity/src/calculate-complexity.ts
@@ -93,14 +93,10 @@ function complexityFromField(
 }
 
 export function calculateComplexity(ctx: object, info: GraphQLResolveInfo) {
-  const operationName = `${info.operation.operation
-    .slice(0, 1)
-    .toUpperCase()}${info.operation.operation.slice(1)}`;
-
-  const operationType = info.schema.getType(operationName);
+  const operationType = info.schema.getRootType(info.operation.operation);
 
   if (!operationType || !isOutputType(operationType)) {
-    throw new PothosValidationError(`Unsupported operation ${operationName}`);
+    throw new PothosValidationError(`Unsupported operation ${info.operation.operation}`);
   }
 
   return complexityFromSelectionSet(ctx, info, info.operation.selectionSet, operationType);

--- a/packages/plugin-complexity/src/index.ts
+++ b/packages/plugin-complexity/src/index.ts
@@ -146,7 +146,11 @@ export class PothosComplexityPlugin<Types extends SchemaTypes> extends BasePlugi
       max = max(ctx);
     }
 
-    if (max?.complexity || max?.depth || max?.breadth) {
+    if (
+      typeof max?.complexity === 'number' ||
+      typeof max?.depth === 'number' ||
+      typeof max?.breadth === 'number'
+    ) {
       return max;
     }
 

--- a/packages/plugin-complexity/src/index.ts
+++ b/packages/plugin-complexity/src/index.ts
@@ -84,7 +84,7 @@ export class PothosComplexityPlugin<Types extends SchemaTypes> extends BasePlugi
     resolver: GraphQLFieldResolver<unknown, Types['Context'], object>,
     fieldConfig: PothosOutputFieldConfig<Types>,
   ): GraphQLFieldResolver<unknown, Types['Context'], object> {
-    if (this.builder.options.complexity?.disabled) {
+    if (this.options.complexity?.disabled ?? this.builder.options.complexity?.disabled) {
       return resolver;
     }
 

--- a/packages/plugin-complexity/src/util.ts
+++ b/packages/plugin-complexity/src/util.ts
@@ -39,9 +39,7 @@ export function complexityFromQuery(
     {},
   );
 
-  const rootType = options.schema.getType(
-    operation.operation.slice(0, 1).toUpperCase() + operation.operation.slice(1),
-  );
+  const rootType = options.schema.getRootType(operation.operation);
 
   if (!rootType) {
     throw new PothosValidationError(`No root type found for operation ${operation.operation}`);

--- a/packages/plugin-complexity/src/validator.ts
+++ b/packages/plugin-complexity/src/validator.ts
@@ -45,8 +45,6 @@ export function createComplexityRule({
     return {
       OperationDefinition: {
         enter: (node) => {
-          // Each operation in a document is executed on its own, so limits apply per operation
-          // rather than to the document as a whole.
           state = {
             complexity: 0,
             depth: 0,

--- a/packages/plugin-complexity/src/validator.ts
+++ b/packages/plugin-complexity/src/validator.ts
@@ -27,7 +27,7 @@ export function createComplexityRule({
   ) => void;
 }) {
   const complexityValidationRule: ValidationRule = (validationContext) => {
-    const state = {
+    let state = {
       complexity: 0,
       depth: 0,
       breadth: 0,
@@ -45,6 +45,14 @@ export function createComplexityRule({
     return {
       OperationDefinition: {
         enter: (node) => {
+          // Each operation in a document is executed on its own, so limits apply per operation
+          // rather than to the document as a whole.
+          state = {
+            complexity: 0,
+            depth: 0,
+            breadth: 0,
+          };
+
           const type = schema.getRootType(node.operation);
 
           if (!type) {

--- a/packages/plugin-complexity/tests/review-fixes.test.ts
+++ b/packages/plugin-complexity/tests/review-fixes.test.ts
@@ -56,7 +56,9 @@ describe('zero limits', () => {
     });
 
     expect(result.errors).toHaveLength(1);
-    expect(result.errors?.[0].message).toBe('Query exceeds maximum complexity (complexity: 1, max: 0)');
+    expect(result.errors?.[0].message).toBe(
+      'Query exceeds maximum complexity (complexity: 1, max: 0)',
+    );
   });
 });
 

--- a/packages/plugin-complexity/tests/review-fixes.test.ts
+++ b/packages/plugin-complexity/tests/review-fixes.test.ts
@@ -1,0 +1,126 @@
+import SchemaBuilder from '@pothos/core';
+import { execute, parse, validate } from 'graphql';
+import ComplexityPlugin, { complexityFromQuery, createComplexityRule } from '../src';
+
+describe('renamed operation roots', () => {
+  it('checks complexity against the schema root type when the query root is renamed', async () => {
+    const builder = new SchemaBuilder({
+      plugins: [ComplexityPlugin],
+      complexity: { limit: { complexity: 10 } },
+    });
+
+    builder.queryType({
+      name: 'Root',
+      fields: (t) => ({ hello: t.string({ resolve: () => 'hello' }) }),
+    });
+
+    const result = await execute({
+      schema: builder.toSchema(),
+      document: parse('{ hello }'),
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ hello: 'hello' });
+  });
+
+  it('resolves the root type by operation for complexityFromQuery', () => {
+    const builder = new SchemaBuilder({ plugins: [ComplexityPlugin] });
+
+    builder.queryType({
+      name: 'Root',
+      fields: (t) => ({ hello: t.string({ resolve: () => 'hello' }) }),
+    });
+
+    expect(complexityFromQuery('{ hello }', { schema: builder.toSchema() })).toEqual({
+      complexity: 1,
+      depth: 1,
+      breadth: 1,
+    });
+  });
+});
+
+describe('zero limits', () => {
+  it('enforces a complexity limit of 0', async () => {
+    const builder = new SchemaBuilder({
+      plugins: [ComplexityPlugin],
+      complexity: { limit: { complexity: 0 } },
+    });
+
+    builder.queryType({ fields: (t) => ({ hello: t.string({ resolve: () => 'hello' }) }) });
+
+    const result = await execute({
+      schema: builder.toSchema(),
+      document: parse('{ hello }'),
+      contextValue: {},
+    });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors?.[0].message).toBe('Query exceeds maximum complexity (complexity: 1, max: 0)');
+  });
+});
+
+describe('schema level options', () => {
+  it('honors `disabled` passed to toSchema', async () => {
+    const builder = new SchemaBuilder({
+      plugins: [ComplexityPlugin],
+      complexity: { limit: { complexity: 1 } },
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        hello: t.string({ resolve: () => 'hello' }),
+        other: t.string({ resolve: () => 'other' }),
+      }),
+    });
+
+    const result = await execute({
+      schema: builder.toSchema({ complexity: { disabled: true } }),
+      document: parse('{ hello other }'),
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ hello: 'hello', other: 'other' });
+  });
+});
+
+describe('validation rule', () => {
+  it('measures each operation independently', () => {
+    const builder = new SchemaBuilder({ plugins: [ComplexityPlugin] });
+
+    builder.queryType({ fields: (t) => ({ hello: t.string({ resolve: () => 'hello' }) }) });
+
+    const schema = builder.toSchema();
+
+    const errors = validate(schema, parse('query A { hello } query B { hello }'), [
+      createComplexityRule({ context: {}, variableValues: {}, maxComplexity: 1 }),
+    ]);
+
+    expect(errors).toEqual([]);
+  });
+
+  it('reports per-operation results to onResult', () => {
+    const builder = new SchemaBuilder({ plugins: [ComplexityPlugin] });
+
+    builder.queryType({ fields: (t) => ({ hello: t.string({ resolve: () => 'hello' }) }) });
+
+    const schema = builder.toSchema();
+    const results: { complexity: number; depth: number; breadth: number }[] = [];
+
+    validate(schema, parse('query A { hello } query B { hello }'), [
+      createComplexityRule({
+        context: {},
+        variableValues: {},
+        onResult: (result) => {
+          results.push({ ...result });
+        },
+      }),
+    ]);
+
+    expect(results).toEqual([
+      { complexity: 1, depth: 1, breadth: 1 },
+      { complexity: 1, depth: 1, breadth: 1 },
+    ]);
+  });
+});


### PR DESCRIPTION
Fixes the four P2 findings from the whole-plugin review of `@pothos/plugin-complexity`. Each finding gets its own commit, and each was reproduced by a failing test before the fix was written. New tests live in `packages/plugin-complexity/tests/review-fixes.test.ts`.

## 1. Renamed operation roots rejected

`calculateComplexity` (`src/calculate-complexity.ts`) and `complexityFromQuery` (`src/util.ts`) derived the root type by capitalizing the operation kind — `query` → `Query` — and looking that name up in the schema. A schema whose query root is named anything else (`builder.queryType({ name: 'Root' })`) failed at runtime with `Unsupported operation Query`, and the standalone calculator threw `No root type found for operation query`.

**Fix:** use `GraphQLSchema#getRootType(operation)`, which resolves the root by its operation *role*. This is already what `src/validator.ts` does, so the three entry points are now consistent.

**Verified:** two tests — one executing a query against a schema with a renamed query root, one calling `complexityFromQuery` against the same schema. Both failed with the errors above before the fix.

## 2. Zero budgets disabled

`getMax` gated on truthiness (`max?.complexity || max?.depth || max?.breadth`), so `limit: { complexity: 0 }` was indistinguishable from no limit configured and allowed unlimited work — the strictest possible budget silently became the most permissive.

**Fix:** check for the presence of a number instead, matching how `checkComplexity` already reads each individual maximum.

**Verified:** a test asserting that a `complexity: 0` limit rejects a cost-1 query with `Query exceeds maximum complexity (complexity: 1, max: 0)`. Before the fix the query executed with no errors at all.

## 3. Schema-level `disabled` ignored

`wrapResolve` read `this.builder.options.complexity?.disabled` only. `ComplexityPluginOptions.disabled` is part of the public `BuildSchemaOptions` type, and every other complexity option (`defaultComplexity`, `defaultListMultiplier`, `complexityError`, `fieldComplexity`, `limit`) already falls back from schema options to builder options — so `toSchema({ complexity: { disabled: true } })` was accepted by the types and then had no effect.

**Fix:** `this.options.complexity?.disabled ?? this.builder.options.complexity?.disabled`, matching the surrounding fallback pattern.

**Verified:** a test that builds a schema with a `complexity: 1` builder limit and calls `toSchema({ complexity: { disabled: true } })`, then runs a cost-2 query. Before the fix the query was rejected.

## 4. Validation rule accumulated unrelated operations

In `createComplexityRule`, the `state` accumulator was created once per *document* rather than per operation, outside the `OperationDefinition` visitor. Cost therefore carried across operations in a multi-operation document: two individually valid cost-1 operations failed a `maxComplexity: 1` rule on the second, reported as `Query complexity of 2 exceeds max complexity of 1`. Only one operation of a document is ever executed, so this over-counted by design.

**Fix:** reset `state` on entering each `OperationDefinition`. As a consequence `onResult` now fires once per operation with that operation's own figures, rather than with a running total.

**Verified:** two tests — one asserting `validate()` returns no errors for `query A { hello } query B { hello }` under `maxComplexity: 1`, one asserting `onResult` receives `{ complexity: 1, ... }` twice rather than `1` then `2`.

## Verification

All run from a clean build of the monorepo:

- `pnpm --filter @pothos/plugin-complexity run test` — 23 passed (2 files), no type errors. 17 of those are the pre-existing tests, unchanged and still passing; the 6 new ones each failed for the stated reason before their fix.
- `pnpm --filter @pothos/plugin-complexity run type` — clean.
- `pnpm biome check packages/plugin-complexity` — clean.
- `pnpm --filter @pothos/plugin-relay --filter @pothos/plugin-prisma run test` — the two other packages that depend on this plugin: 23 and 253 tests passing respectively, no type errors.

No public types changed and no serialization format changed. The one behavior change beyond the bug fixes themselves is the `onResult` callback now reporting per-operation rather than cumulative figures, which is inherent to fixing finding 4. A changeset is included at `.changeset/complexity-review-fixes.md` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB