### PR TITLE
fix(directives): address 3 findings from the plugin review

### DIFF
--- a/.changeset/directives-review-fixes.md
+++ b/.changeset/directives-review-fixes.md
@@ -3,5 +3,5 @@
 ---
 
 - Allow directives declared for multiple locations to be used in the ordered (array) directive format
-- Flatten repeated directive args when merging unordered directive extensions with ordered directive options
+- Expand repeated directive args (`{ tag: [argsA, argsB] }`) into one directive per args object when converting to the ordered format, both when merging `extensions.directives` with the `directives` option and when only one of them is provided. Previously the unmerged case produced a single directive whose args were the whole array, printing as `@tag(0: ..., 1: ...)`
 - Support directives whose name shadows an `Object.prototype` member (eg. `constructor`) in the unordered format

--- a/.changeset/directives-review-fixes.md
+++ b/.changeset/directives-review-fixes.md
@@ -1,0 +1,7 @@
+---
+"@pothos/plugin-directives": patch
+---
+
+- Allow directives declared for multiple locations to be used in the ordered (array) directive format
+- Flatten repeated directive args when merging unordered directive extensions with ordered directive options
+- Support directives whose name shadows an `Object.prototype` member (eg. `constructor`) in the unordered format

--- a/packages/plugin-directives/src/index.ts
+++ b/packages/plugin-directives/src/index.ts
@@ -20,8 +20,7 @@ function toDirectiveList(directives: DirectiveList | Record<string, object>): Di
     return directives;
   }
 
-  // Unordered (graphql-tools) directives use an array of arg objects for repeated directives,
-  // each of which becomes its own entry in the ordered list.
+  // An array of args in the unordered format is a repeated directive, one entry per args object.
   return Object.keys(directives).flatMap((name) => {
     const args = directives[name];
 

--- a/packages/plugin-directives/src/index.ts
+++ b/packages/plugin-directives/src/index.ts
@@ -20,7 +20,6 @@ function toDirectiveList(directives: DirectiveList | Record<string, object>): Di
     return directives;
   }
 
-  // An array of args in the unordered format is a repeated directive, one entry per args object.
   return Object.keys(directives).flatMap((name) => {
     const args = directives[name];
 
@@ -149,8 +148,6 @@ export class PothosDirectivesPlugin<Types extends SchemaTypes> extends BasePlugi
         return directives;
       }
 
-      // Directive names may collide with Object.prototype members (eg. `constructor`), so
-      // accumulate into a Map rather than reading back from a plain object.
       const byName = new Map<string, {}[]>();
 
       for (const directive of directives) {

--- a/packages/plugin-directives/src/index.ts
+++ b/packages/plugin-directives/src/index.ts
@@ -150,15 +150,21 @@ export class PothosDirectivesPlugin<Types extends SchemaTypes> extends BasePlugi
         return directives;
       }
 
-      return directives.reduce<Record<string, {}[]>>((obj, directive) => {
-        if (obj[directive.name]) {
-          obj[directive.name].push(directive.args ?? {});
-        } else {
-          obj[directive.name] = [directive.args ?? {}];
-        }
+      // Directive names may collide with Object.prototype members (eg. `constructor`), so
+      // accumulate into a Map rather than reading back from a plain object.
+      const byName = new Map<string, {}[]>();
 
-        return obj;
-      }, {});
+      for (const directive of directives) {
+        const args = byName.get(directive.name);
+
+        if (args) {
+          args.push(directive.args ?? {});
+        } else {
+          byName.set(directive.name, [directive.args ?? {}]);
+        }
+      }
+
+      return Object.fromEntries(byName);
     }
 
     if (Array.isArray(directives)) {

--- a/packages/plugin-directives/src/index.ts
+++ b/packages/plugin-directives/src/index.ts
@@ -15,6 +15,22 @@ export * from './types.js';
 
 const pluginName = 'directives';
 
+function toDirectiveList(directives: DirectiveList | Record<string, object>): DirectiveList {
+  if (Array.isArray(directives)) {
+    return directives;
+  }
+
+  // Unordered (graphql-tools) directives use an array of arg objects for repeated directives,
+  // each of which becomes its own entry in the ordered list.
+  return Object.keys(directives).flatMap((name) => {
+    const args = directives[name];
+
+    return Array.isArray(args)
+      ? (args as object[]).map((entry) => ({ name, args: entry }))
+      : [{ name, args }];
+  });
+}
+
 export default pluginName;
 export class PothosDirectivesPlugin<Types extends SchemaTypes> extends BasePlugin<Types> {
   override onOutputFieldConfig(fieldConfig: PothosOutputFieldConfig<Types>) {
@@ -125,14 +141,7 @@ export class PothosDirectivesPlugin<Types extends SchemaTypes> extends BasePlugi
       return left || right;
     }
 
-    return [
-      ...(Array.isArray(left)
-        ? left
-        : Object.keys(left).map((name) => ({ name, args: left[name] }))),
-      ...(Array.isArray(right)
-        ? right
-        : Object.keys(right).map((name) => ({ name, args: right[name] }))),
-    ];
+    return [...toDirectiveList(left), ...toDirectiveList(right)];
   }
 
   normalizeDirectives(directives: DirectiveList | Record<string, object>) {

--- a/packages/plugin-directives/src/index.ts
+++ b/packages/plugin-directives/src/index.ts
@@ -167,11 +167,7 @@ export class PothosDirectivesPlugin<Types extends SchemaTypes> extends BasePlugi
       return Object.fromEntries(byName);
     }
 
-    if (Array.isArray(directives)) {
-      return directives;
-    }
-
-    return Object.keys(directives).map((name) => ({ name, args: directives[name] }));
+    return toDirectiveList(directives);
   }
 }
 

--- a/packages/plugin-directives/src/types.ts
+++ b/packages/plugin-directives/src/types.ts
@@ -23,7 +23,7 @@ export type DirectivesFor<Types extends SchemaTypes, Location extends DirectiveL
 
 export type Directives<Types extends SchemaTypes, Location extends DirectiveLocation> =
   | {
-      [K in keyof Types['Directives']]: Types['Directives'][K]['locations'] extends Location
+      [K in keyof Types['Directives']]: Location extends Types['Directives'][K]['locations']
         ? {
             name: K;
             args: Types['Directives'][K]['args'];

--- a/packages/plugin-directives/tests/normalize.test.ts
+++ b/packages/plugin-directives/tests/normalize.test.ts
@@ -1,0 +1,32 @@
+import SchemaBuilder from '@pothos/core';
+import type { GraphQLObjectType } from 'graphql';
+import DirectivesPlugin from '../src';
+
+describe('unordered directives', () => {
+  it('merges repeated directives from extensions with directive options without nesting args', () => {
+    const builder = new SchemaBuilder<{
+      Directives: {
+        tag: { locations: 'FIELD_DEFINITION'; args: { value: string } };
+      };
+    }>({
+      plugins: [DirectivesPlugin],
+      directives: { useGraphQLToolsUnorderedDirectives: true },
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        hello: t.string({
+          extensions: { directives: { tag: [{ value: 'a' }, { value: 'b' }] } },
+          directives: [{ name: 'tag', args: { value: 'c' } }],
+          resolve: () => '',
+        }),
+      }),
+    });
+
+    const field = (builder.toSchema().getQueryType() as GraphQLObjectType).getFields().hello;
+
+    expect(field.extensions.directives).toEqual({
+      tag: [{ value: 'a' }, { value: 'b' }, { value: 'c' }],
+    });
+  });
+});

--- a/packages/plugin-directives/tests/normalize.test.ts
+++ b/packages/plugin-directives/tests/normalize.test.ts
@@ -1,6 +1,16 @@
 import SchemaBuilder from '@pothos/core';
-import type { GraphQLObjectType } from 'graphql';
+import { type GraphQLObjectType, print } from 'graphql';
 import DirectivesPlugin from '../src';
+
+function orderedBuilder() {
+  return new SchemaBuilder<{
+    Directives: {
+      tag: { locations: 'FIELD_DEFINITION'; args: { value: string } };
+    };
+  }>({
+    plugins: [DirectivesPlugin],
+  });
+}
 
 describe('unordered directives', () => {
   it('merges repeated directives from extensions with directive options without nesting args', () => {
@@ -50,5 +60,64 @@ describe('unordered directives', () => {
     const queryType = builder.toSchema().getQueryType() as GraphQLObjectType;
 
     expect(queryType.extensions.directives).toEqual({ constructor: [{}] });
+  });
+});
+
+describe('ordered directives', () => {
+  it('expands repeated args from extensions when there are no directive options to merge', () => {
+    const builder = orderedBuilder();
+
+    builder.queryType({
+      fields: (t) => ({
+        hello: t.string({
+          extensions: { directives: { tag: [{ value: 'a' }, { value: 'b' }] } },
+          resolve: () => '',
+        }),
+      }),
+    });
+
+    const field = (builder.toSchema().getQueryType() as GraphQLObjectType).getFields().hello;
+
+    expect(field.extensions.directives).toEqual([
+      { name: 'tag', args: { value: 'a' } },
+      { name: 'tag', args: { value: 'b' } },
+    ]);
+    expect(print(field.astNode!)).toBe('hello: String @tag(value: "a") @tag(value: "b")');
+  });
+
+  it('keeps the single-args record form unchanged', () => {
+    const builder = orderedBuilder();
+
+    builder.queryType({
+      fields: (t) => ({
+        hello: t.string({
+          extensions: { directives: { tag: { value: 'a' } } },
+          resolve: () => '',
+        }),
+      }),
+    });
+
+    const field = (builder.toSchema().getQueryType() as GraphQLObjectType).getFields().hello;
+
+    expect(field.extensions.directives).toEqual([{ name: 'tag', args: { value: 'a' } }]);
+    expect(print(field.astNode!)).toBe('hello: String @tag(value: "a")');
+  });
+
+  it('drops a directive with no repeated args', () => {
+    const builder = orderedBuilder();
+
+    builder.queryType({
+      fields: (t) => ({
+        hello: t.string({
+          extensions: { directives: { tag: [] } },
+          resolve: () => '',
+        }),
+      }),
+    });
+
+    const field = (builder.toSchema().getQueryType() as GraphQLObjectType).getFields().hello;
+
+    expect(field.extensions.directives).toEqual([]);
+    expect(print(field.astNode!)).toBe('hello: String');
   });
 });

--- a/packages/plugin-directives/tests/normalize.test.ts
+++ b/packages/plugin-directives/tests/normalize.test.ts
@@ -29,4 +29,26 @@ describe('unordered directives', () => {
       tag: [{ value: 'a' }, { value: 'b' }, { value: 'c' }],
     });
   });
+
+  it('supports directives named after Object.prototype members', () => {
+    const builder = new SchemaBuilder<{
+      Directives: {
+        constructor: { locations: 'OBJECT'; args: {} };
+      };
+    }>({
+      plugins: [DirectivesPlugin],
+      directives: { useGraphQLToolsUnorderedDirectives: true },
+    });
+
+    builder.queryType({
+      directives: [{ name: 'constructor', args: {} }],
+      fields: (t) => ({
+        ok: t.boolean({ resolve: () => true }),
+      }),
+    });
+
+    const queryType = builder.toSchema().getQueryType() as GraphQLObjectType;
+
+    expect(queryType.extensions.directives).toEqual({ constructor: [{}] });
+  });
 });

--- a/packages/plugin-directives/tests/types.test-d.ts
+++ b/packages/plugin-directives/tests/types.test-d.ts
@@ -1,0 +1,28 @@
+import SchemaBuilder from '@pothos/core';
+import type { GraphQLSchema } from 'graphql';
+import { expectTypeOf } from 'vitest';
+import DirectivesPlugin from '../src';
+
+describe('directive types', () => {
+  it('accepts directives with multiple locations in the ordered (array) format', () => {
+    const builder = new SchemaBuilder<{
+      Directives: {
+        multi: { locations: 'FIELD_DEFINITION' | 'OBJECT'; args: { name: string } };
+      };
+    }>({
+      plugins: [DirectivesPlugin],
+    });
+
+    builder.queryType({
+      directives: [{ name: 'multi', args: { name: 'root' } }],
+      fields: (t) => ({
+        hello: t.string({
+          directives: [{ name: 'multi', args: { name: 'field' } }],
+          resolve: () => '',
+        }),
+      }),
+    });
+
+    expectTypeOf(builder.toSchema()).toEqualTypeOf<GraphQLSchema>();
+  });
+});


### PR DESCRIPTION
Fixes the three P2 findings from the `@pothos/plugin-directives` whole-plugin review. Each finding has a regression test that was confirmed to fail for the stated reason before the fix.

### 1. Ordered format rejected multi-location directives (`src/types.ts`)

The array (ordered) directive type tested `Types['Directives'][K]['locations'] extends Location` — the reverse of the membership test the object format uses. A directive declared for `'OBJECT' | 'FIELD_DEFINITION'` therefore resolved to `never` in either ordered list, even though the equivalent object format worked.

**Fix:** test `Location extends Types['Directives'][K]['locations']`. This only widens what is accepted; single-location directives are unaffected.

**Verified:** new strict type fixture `tests/types.test-d.ts` (run by vitest's tsc typecheck) emitted exactly the two `TS2322 … not assignable to type 'never'` diagnostics before the change and passes after.

### 2. Repeated directive args collapsed into one malformed entry (`src/index.ts`)

Converting the unordered directive record (`{ tag: [argsA, argsB] }`) to the ordered list mapped each name to a single entry whose `args` was the whole array. That happened on **both** conversion paths:

- merging `extensions.directives` with the `directives` option produced `{ tag: [[a, b], c] }`;
- and — the ordinary single-source case — `mergeDirectives` short-circuits when only one of the two is supplied, so the record fell through to the ordered conversion in `normalizeDirectives` untouched and printed as `@tag(0: { value: "a" }, 1: { value: "b" })`. `0` and `1` are not valid GraphQL names and match no argument on the directive definition, and `src/mock-ast.ts` turns them straight into `ArgumentNode`s.

**Fix:** a `toDirectiveList` helper expands an array-valued record entry into one ordered entry per args object, and both `mergeDirectives` and `normalizeDirectives` use it. `{ tag: [a, b] }` now yields `@tag(value: "a") @tag(value: "b")` whether or not there is a `directives` option to merge, matching the expansion `mock-ast.ts` already does for the unordered format.

**Verified:** tests in `tests/normalize.test.ts` for the merged path (failed with the nested `[[a, b], c]` diff) and the unmerged path (failed with the single collapsed entry). Pinned alongside: the single-args record form `{ tag: { value: 'a' } }` is unchanged, and `{ tag: [] }` drops the directive.

### 3. A directive named `constructor` crashed unordered conversion (`src/index.ts`)

`normalizeDirectives` accumulated into a plain object and checked `obj[directive.name]` with no ownership test. For the valid GraphQL directive name `constructor` this read `Object.prototype.constructor`, so building threw `obj[directive.name].push is not a function`.

**Fix:** accumulate into a `Map` and convert with `Object.fromEntries`, preserving the existing plain-object output and insertion order.

**Verified:** new test in `tests/normalize.test.ts`; it reproduced the exact `TypeError` before the change.

### Results

- `pnpm --filter @pothos/plugin-directives run test` — 3 files, 12 tests passed (baseline 6), no type errors
- `pnpm --filter @pothos/plugin-directives run type` — clean
- `pnpm biome check packages/plugin-directives` — clean
- `pnpm --filter @pothos/plugin-federation run test` / `run type` — still green (only other package depending on this plugin)

Changeset added at `.changeset/directives-review-fixes.md` (patch).

The two external-tools integrations blocked by dual GraphQL module realms are a known environment limitation and were not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
