### PR TITLE
fix(federation): replace custom query roots by operation role

### DIFF
--- a/.changeset/federation-review-fix.md
+++ b/.changeset/federation-review-fix.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-federation": patch
+---
+
+Fix duplicate type error in toSubGraphSchema when using a custom query root name

--- a/packages/plugin-federation/src/schema-builder.ts
+++ b/packages/plugin-federation/src/schema-builder.ts
@@ -163,7 +163,10 @@ schemaBuilderProto.toSubGraphSchema = function toSubGraphSchema(
     extensions: schema.extensions,
     directives: schema.getDirectives(),
     extensionASTNodes: schema.extensionASTNodes,
-    types: [...Object.values(types).filter((type) => type.name !== 'Query'), newQuery],
+    types: [
+      ...Object.values(types).filter((type) => type !== queryType && type.name !== newQuery.name),
+      newQuery,
+    ],
   });
 
   const sorted = lexicographicSortSchema(subGraphSchema);

--- a/packages/plugin-federation/tests/custom-query-root.test.ts
+++ b/packages/plugin-federation/tests/custom-query-root.test.ts
@@ -1,0 +1,76 @@
+import { printSubgraphSchema } from '@apollo/subgraph';
+import SchemaBuilder from '@pothos/core';
+import DirectivesPlugin from '@pothos/plugin-directives';
+import FederationPlugin from '../src';
+
+function createBuilder() {
+  return new SchemaBuilder({
+    plugins: [DirectivesPlugin, FederationPlugin],
+    directives: {
+      useGraphQLToolsUnorderedDirectives: true,
+    },
+  });
+}
+
+describe('federation', () => {
+  describe('custom query root name', () => {
+    it('replaces the custom root instead of duplicating it', () => {
+      const builder = createBuilder();
+
+      const UserRef = builder.objectRef<{ id: string }>('User');
+
+      UserRef.implement({
+        fields: (t) => ({
+          id: t.exposeString('id'),
+        }),
+      });
+
+      builder.asEntity(UserRef, {
+        key: builder.selection<{ id: string }>('id'),
+        resolveReference: (user) => user,
+      });
+
+      builder.queryType({
+        name: 'Root',
+        fields: (t) => ({
+          user: t.field({
+            type: UserRef,
+            resolve: () => ({ id: '1' }),
+          }),
+        }),
+      });
+
+      const schema = builder.toSubGraphSchema({});
+      const queryType = schema.getQueryType()!;
+
+      expect(queryType.name).toBe('Root');
+      // The rebuilt root must be the only type registered under its name.
+      expect(schema.getType('Root')).toBe(queryType);
+      // Federation fields are only added to the rebuilt root.
+      expect(Object.keys(queryType.getFields())).toEqual(
+        expect.arrayContaining(['_entities', '_service', 'user']),
+      );
+
+      expect(printSubgraphSchema(schema)).toContain('type Root');
+    });
+
+    it('still replaces a conventional Query root', () => {
+      const builder = createBuilder();
+
+      builder.queryType({
+        fields: (t) => ({
+          hello: t.string({ resolve: () => 'world' }),
+        }),
+      });
+
+      const schema = builder.toSubGraphSchema({});
+      const queryType = schema.getQueryType()!;
+
+      expect(queryType.name).toBe('Query');
+      expect(schema.getType('Query')).toBe(queryType);
+      expect(Object.keys(queryType.getFields())).toEqual(
+        expect.arrayContaining(['_service', 'hello']),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Finding

`toSubGraphSchema` rebuilds the query root type so it can add the federation `_entities` and `_service` fields, then constructs a new `GraphQLSchema` whose type list is "every existing type except the old root, plus the rebuilt root". That exclusion was written against the literal name `Query`:

```ts
types: [...Object.values(types).filter((type) => type.name !== 'Query'), newQuery],
```

The rebuilt root, however, takes its name from the *actual* root (`queryType?.name ?? 'Query'`). So for a schema declaring a custom query root — `builder.queryType({ name: 'Root', ... })` — the original `Root` survives the filter and is handed to `GraphQLSchema` alongside the rebuilt `Root`. Schema construction throws:

```
Schema must contain uniquely named types but contains multiple types named "Root".
```

Conventional `Query` roots were unaffected, which is why this went unnoticed.

## Fix

Filter the original root by *identity* (its role as the operation root) rather than by hard-coded name, and additionally drop anything colliding with the rebuilt root's name:

```ts
types: [
  ...Object.values(types).filter((type) => type !== queryType && type.name !== newQuery.name),
  newQuery,
],
```

One-line behavioural change, no public type or API change. For a schema with a conventional `Query` root this is exactly equivalent to the previous code.

## Verification

Added `packages/plugin-federation/tests/custom-query-root.test.ts` with two cases that exercise the `toSubGraphSchema` path directly:

- **custom root** — a `Root` query type plus an entity; asserts the rebuilt root is the only type registered under that name and carries `_entities`/`_service`. Confirmed failing before the fix with the exact error above (`new GraphQLSchema … src/schema-builder.ts:159`), passing after.
- **conventional `Query` control** — passes both before and after, guarding against regression in the common case.

Results on this branch:

- `pnpm --filter @pothos/plugin-federation run test` — **4 files, 11 tests, all passing**, no type errors. No pre-existing failures were observed.
- `pnpm --filter @pothos/plugin-federation run type` — clean.
- `pnpm biome check packages/plugin-federation` — clean, 31 files, no fixes applied.

## On the module-realm limitation

The review that produced this finding noted that the full Apollo server suite could resolve a second copy of `graphql` through nested dependencies and fail graphql's cross-realm instance check, so the regression test was written to avoid depending on that setup. Reporting honestly: in this worktree that failure did **not** reproduce — `packages/plugin-federation/vitest.config.js` already pins every importer to a single resolved `graphql` entry and inlines the graphql-touching deps, and `tests/index.test.ts` (the Apollo `startStandaloneServer` / gateway suite) ran and passed along with everything else. So no suite was skipped here. The new test is nonetheless deliberately independent of the Apollo server harness: it needs only `@apollo/subgraph`'s `printSubgraphSchema` and the schema builder, so it stays meaningful in environments where the server suite cannot start.

Not attempted, and out of scope for this fix: a full federation deployment or composition matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
