### PR TITLE
fix(tracing): address 2 findings from the plugin review

### DIFF
--- a/.changeset/tracing-review-fixes.md
+++ b/.changeset/tracing-review-fixes.md
@@ -3,4 +3,4 @@
 ---
 
 Preserve an explicit `tracing: null` field option instead of falling back to the builder default
-Use a Map for the span cache so a field aliased `constructor` no longer produces a fabricated parent span
+Use a Map for the span cache so a field aliased `constructor` no longer produces a fabricated parent span. The cache lives on the context under the cross-realm registry key `Symbol.for('Pothos.tracing.spanCache')`, so its value changes shape from a plain object to a `Map`. This only matters if two different versions of `@pothos/plugin-tracing` share one context in the same process, which the `peerDependency` on every `tracing-*` package normally prevents; if you have a duplicated install, upgrade all copies together.

--- a/.changeset/tracing-review-fixes.md
+++ b/.changeset/tracing-review-fixes.md
@@ -1,0 +1,6 @@
+---
+"@pothos/plugin-tracing": patch
+---
+
+Preserve an explicit `tracing: null` field option instead of falling back to the builder default
+Use a Map for the span cache so a field aliased `constructor` no longer produces a fabricated parent span

--- a/packages/plugin-tracing/src/index.ts
+++ b/packages/plugin-tracing/src/index.ts
@@ -24,13 +24,17 @@ export class PothosTracingPlugin<Types extends SchemaTypes> extends BasePlugin<T
     }
 
     const { wrap, default: defaultConfig } = this.builder.options.tracing;
+    const fieldTracing = fieldConfig.pothosOptions.tracing;
+    // Only an unset (undefined) field option falls back to the default, so an explicit `null`
+    // disables tracing the same way a callback returning `null` does
     const tracingValue =
-      fieldConfig.pothosOptions.tracing ??
-      (typeof defaultConfig === 'function'
-        ? (defaultConfig as (config: PothosOutputFieldConfig<Types>) => Types['Tracing'])(
-            fieldConfig,
-          )
-        : defaultConfig);
+      fieldTracing !== undefined
+        ? fieldTracing
+        : typeof defaultConfig === 'function'
+          ? (defaultConfig as (config: PothosOutputFieldConfig<Types>) => Types['Tracing'])(
+              fieldConfig,
+            )
+          : defaultConfig;
 
     return wrapResolver(fieldConfig, tracingValue, wrap, resolver);
   }

--- a/packages/plugin-tracing/src/index.ts
+++ b/packages/plugin-tracing/src/index.ts
@@ -25,8 +25,6 @@ export class PothosTracingPlugin<Types extends SchemaTypes> extends BasePlugin<T
 
     const { wrap, default: defaultConfig } = this.builder.options.tracing;
     const fieldTracing = fieldConfig.pothosOptions.tracing;
-    // Only an unset (undefined) field option falls back to the default, so an explicit `null`
-    // disables tracing the same way a callback returning `null` does
     const tracingValue =
       fieldTracing !== undefined
         ? fieldTracing

--- a/packages/plugin-tracing/src/util.ts
+++ b/packages/plugin-tracing/src/util.ts
@@ -42,7 +42,9 @@ export function resolveFieldType<Types extends SchemaTypes>(
 const spanCacheSymbol = Symbol.for('Pothos.tracing.spanCache');
 
 interface InternalContext<T> {
-  [spanCacheSymbol]?: Record<string, T>;
+  // A Map rather than an object so that field paths that collide with `Object.prototype`
+  // members (eg. a field aliased `constructor`) can't resolve to an inherited property
+  [spanCacheSymbol]?: Map<string, T>;
 }
 
 export function pathToString(info: GraphQLResolveInfo) {
@@ -80,8 +82,10 @@ export function getParentSpan<T>(context: InternalContext<T>, info: GraphQLResol
   }
 
   for (const path of paths) {
-    if (spanCache[path]) {
-      return spanCache[path];
+    const span = spanCache.get(path);
+
+    if (span) {
+      return span;
     }
   }
 
@@ -98,10 +102,10 @@ export function createSpanWithParent<T>(
   const span = createSpan(stringPath, parentSpan);
 
   if (!(context as InternalContext<T>)[spanCacheSymbol]) {
-    (context as InternalContext<T>)[spanCacheSymbol] = {};
+    (context as InternalContext<T>)[spanCacheSymbol] = new Map();
   }
 
-  (context as InternalContext<T>)[spanCacheSymbol]![stringPath] = span;
+  (context as InternalContext<T>)[spanCacheSymbol]!.set(stringPath, span);
 
   return span;
 }

--- a/packages/plugin-tracing/src/util.ts
+++ b/packages/plugin-tracing/src/util.ts
@@ -42,8 +42,7 @@ export function resolveFieldType<Types extends SchemaTypes>(
 const spanCacheSymbol = Symbol.for('Pothos.tracing.spanCache');
 
 interface InternalContext<T> {
-  // A Map rather than an object so that field paths that collide with `Object.prototype`
-  // members (eg. a field aliased `constructor`) can't resolve to an inherited property
+  // A Map, not an object: field paths like `constructor` collide with `Object.prototype` members.
   [spanCacheSymbol]?: Map<string, T>;
 }
 

--- a/packages/plugin-tracing/tests/span-cache.test.ts
+++ b/packages/plugin-tracing/tests/span-cache.test.ts
@@ -1,0 +1,88 @@
+import SchemaBuilder from '@pothos/core';
+import { graphql } from 'graphql';
+import TracingPlugin, { createSpanWithParent } from '../src';
+
+describe('span cache', () => {
+  it('does not inherit a parent span from an untraced field with an Object.prototype alias', async () => {
+    const parents: unknown[] = [];
+
+    const builder = new SchemaBuilder({
+      plugins: [TracingPlugin],
+      tracing: {
+        default: true,
+        wrap: (resolver) => (source, args, ctx, info) => {
+          createSpanWithParent(ctx as object, info, (_path, parent) => {
+            parents.push(parent);
+
+            return { span: true };
+          });
+
+          return resolver(source, args, ctx, info);
+        },
+      },
+    });
+
+    const Obj = builder.objectRef<{}>('Obj').implement({
+      fields: (t) => ({
+        value: t.string({ resolve: () => 'ok' }),
+      }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        seed: t.string({ resolve: () => 'seed' }),
+        obj: t.field({ type: Obj, tracing: false, resolve: () => ({}) }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ seed constructor: obj { value } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(parents).toEqual([null, null]);
+  });
+
+  it('still inherits the span of a traced ancestor', async () => {
+    const parents: unknown[] = [];
+
+    const builder = new SchemaBuilder({
+      plugins: [TracingPlugin],
+      tracing: {
+        default: true,
+        wrap: (resolver) => (source, args, ctx, info) => {
+          createSpanWithParent(ctx as object, info, (path, parent) => {
+            parents.push(parent);
+
+            return { path };
+          });
+
+          return resolver(source, args, ctx, info);
+        },
+      },
+    });
+
+    const Obj = builder.objectRef<{}>('Obj').implement({
+      fields: (t) => ({
+        value: t.string({ resolve: () => 'ok' }),
+      }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        obj: t.field({ type: Obj, resolve: () => ({}) }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ constructor: obj { value } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(parents).toEqual([null, { path: 'constructor' }]);
+  });
+});

--- a/packages/plugin-tracing/tests/tracing-option.test.ts
+++ b/packages/plugin-tracing/tests/tracing-option.test.ts
@@ -1,0 +1,60 @@
+import SchemaBuilder from '@pothos/core';
+import { graphql } from 'graphql';
+import TracingPlugin from '../src';
+
+function createBuilder(traced: string[]) {
+  return new SchemaBuilder<{ Tracing: boolean | null }>({
+    plugins: [TracingPlugin],
+    tracing: {
+      default: true,
+      wrap: (resolve, _options, config) => {
+        traced.push(config.name);
+
+        return resolve;
+      },
+    },
+  });
+}
+
+describe('field tracing option', () => {
+  it('static null disables tracing just like a callback returning null', async () => {
+    const traced: string[] = [];
+    const builder = createBuilder(traced);
+
+    builder.queryType({
+      fields: (t) => ({
+        static: t.string({ tracing: null, resolve: () => '' }),
+        dynamic: t.string({ tracing: () => null, resolve: () => '' }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ static dynamic }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(traced).toEqual([]);
+  });
+
+  it('uses the default when a field does not set tracing', async () => {
+    const traced: string[] = [];
+    const builder = createBuilder(traced);
+
+    builder.queryType({
+      fields: (t) => ({
+        inherited: t.string({ resolve: () => '' }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ inherited }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(traced).toEqual(['inherited']);
+  });
+});


### PR DESCRIPTION
Two P2 findings from the `@pothos/plugin-tracing` whole-plugin review, each with a regression test written first and confirmed failing before the fix.

### 1. Explicit static `null` fell back to the enabled default

`src/index.ts` merged the field `tracing` option with the builder default using nullish coalescing, so with a custom `Tracing` type of `boolean | null` a static `tracing: null` was traced anyway, while a callback returning `null` correctly disabled tracing.

**Fix:** only an unset (`undefined`) field option falls back to the default; an explicit `null` is passed through and disables tracing as before.

**Verified:** `tests/tracing-option.test.ts` — a static `tracing: null` field and a `tracing: () => null` field are both left unwrapped (failed with `[ 'static' ]` before the fix), plus a companion case asserting a field with no `tracing` option still picks up the default.

### 2. An untraced valid alias produced a fabricated parent span

`src/util.ts` stored the per-request span cache in a plain object keyed by field path, so an untraced field aliased with an `Object.prototype` member name (eg. `constructor`) resolved to the inherited property, and the `Object` constructor was handed to a traced child as its parent span even though no ancestor span existed.

**Fix:** the span cache is a `Map`. Lookup keeps the previous truthiness semantics, so a falsy span still falls through to the next ancestor path.

**Verified:** `tests/span-cache.test.ts` — a query selecting `constructor: obj { value }` through an untraced `obj` field records parents `[null, null]` (observed `[null, Object]` before the fix), plus a companion case asserting a genuinely traced ancestor aliased `constructor` is still inherited as the parent.

The cache lives on the context under `Symbol.for('Pothos.tracing.spanCache')`, a cross-realm registry key, so this changes the shape of a value two copies of the package would share. It is read nowhere else in the repo, and the `peerDependency` on `@pothos/plugin-tracing` in every `tracing-*` package means one copy is the norm — the changeset notes it for anyone with a duplicated install.

### Checks

- `pnpm --filter @pothos/plugin-tracing run test` — 3 files, 5 tests passing, no type errors
- `pnpm --filter @pothos/plugin-tracing run type` — clean
- `pnpm biome check packages/plugin-tracing` — clean
- `pnpm build` first, then `pnpm --filter "@pothos/tracing-*" run test` — newrelic, opentelemetry, sentry and xray all passing. The build step is load-bearing: those packages resolve `@pothos/plugin-tracing` to its built `esm`/`lib` output, so without rebuilding first that command exercises the old object cache rather than the change.

Changeset added at `.changeset/tracing-review-fixes.md` (patch).

Out of scope and deliberately untouched: the documented fresh-context and custom-root predicate requirements, and any external tracing SDK matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
