### PR TITLE
fix(mocks): address 2 findings from the plugin review

### DIFF
--- a/.changeset/mocks-review-fixes.md
+++ b/.changeset/mocks-review-fixes.md
@@ -3,4 +3,6 @@
 ---
 
 - Apply mocks defined for a concrete object type to fields inherited from an interface
-- Only use mocks for fields that are explicitly configured, instead of inherited object properties
+- Ignore built-in prototype members (`toString`, `constructor`, ...) when looking up mocks, so
+  fields that are not explicitly mocked keep their original resolvers. Mocks provided through a
+  Proxy or a user defined prototype continue to work

--- a/.changeset/mocks-review-fixes.md
+++ b/.changeset/mocks-review-fixes.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-mocks": patch
+---
+
+Apply mocks defined for a concrete object type to fields inherited from an interface

--- a/.changeset/mocks-review-fixes.md
+++ b/.changeset/mocks-review-fixes.md
@@ -2,4 +2,5 @@
 "@pothos/plugin-mocks": patch
 ---
 
-Apply mocks defined for a concrete object type to fields inherited from an interface
+- Apply mocks defined for a concrete object type to fields inherited from an interface
+- Only use mocks for fields that are explicitly configured, instead of inherited object properties

--- a/packages/plugin-mocks/src/index.ts
+++ b/packages/plugin-mocks/src/index.ts
@@ -9,27 +9,22 @@ import type { ResolverMap } from './types.js';
 
 const pluginName = 'mocks';
 
-// Values inherited from these prototypes are never mocks, they are built-in members that happen to
-// share a name with a type or field (`toString`, `constructor`, `call`, ...).
+// Members of these prototypes are never mocks, they are built-ins that happen to share a name with
+// a type or field (`toString`, `constructor`, `call`, ...).
 const builtInPrototypes: object[] = [Object.prototype, Function.prototype];
 
-function isBuiltInMember(map: object, key: string) {
-  for (
-    let proto: object | null = Object.getPrototypeOf(map) as object | null;
-    proto !== null;
-    proto = Object.getPrototypeOf(proto) as object | null
-  ) {
-    if (Object.hasOwn(proto, key)) {
-      return builtInPrototypes.includes(proto);
-    }
-  }
-
-  return false;
+// Checks whether the value a mock map returned for a key *is* the built-in inherited for that name,
+// rather than whether some prototype happens to define the name. A Proxy or a prototype that
+// supplies its own `toString` mock returns a different value than `Object.prototype.toString`.
+function isBuiltInValue(map: object, key: string, value: unknown) {
+  return builtInPrototypes.some(
+    (proto) => Object.hasOwn(proto, key) && Reflect.get(proto, key, map) === value,
+  );
 }
 
-// Looks a key up in a user provided mock map. Values the map provides itself are used as is, even
-// when they come from a prototype or a Proxy, but built-in members are ignored so that types and
-// fields the user never mocked keep their original resolvers.
+// Looks a key up in a user provided mock map. Values the map provides are used as is, even when
+// they come from a prototype, a class or a Proxy, but inherited built-ins are ignored so that types
+// and fields the user never mocked keep their original resolvers.
 function lookupMock<T>(map: Record<string, T> | undefined, key: string): T | undefined {
   if (map === undefined) {
     return undefined;
@@ -41,7 +36,7 @@ function lookupMock<T>(map: Record<string, T> | undefined, key: string): T | und
     return value;
   }
 
-  return isBuiltInMember(map, key) ? undefined : value;
+  return isBuiltInValue(map, key, value) ? undefined : value;
 }
 
 export default pluginName;

--- a/packages/plugin-mocks/src/index.ts
+++ b/packages/plugin-mocks/src/index.ts
@@ -23,6 +23,19 @@ export class PothosMocksPlugin<Types extends SchemaTypes> extends BasePlugin<Typ
 
     const resolveMock = this.resolveMock(fieldConfig.parentType, fieldConfig.name, mocks);
 
+    // Fields defined on an interface are shared by every type that implements it, so mocks for the
+    // concrete object type can only be resolved when the field is executed.
+    if (fieldConfig.graphqlKind === 'Interface') {
+      return (parent, args, context, info) => {
+        const mock =
+          info.parentType.name === fieldConfig.parentType
+            ? resolveMock
+            : (this.resolveMock(info.parentType.name, fieldConfig.name, mocks) ?? resolveMock);
+
+        return (mock ?? resolver)(parent, args, context, info);
+      };
+    }
+
     return resolveMock ?? resolver;
   }
 

--- a/packages/plugin-mocks/src/index.ts
+++ b/packages/plugin-mocks/src/index.ts
@@ -9,6 +9,10 @@ import type { ResolverMap } from './types.js';
 
 const pluginName = 'mocks';
 
+function getOwn<T>(map: Record<string, T> | undefined, key: string): T | undefined {
+  return map !== undefined && Object.hasOwn(map, key) ? map[key] : undefined;
+}
+
 export default pluginName;
 export class PothosMocksPlugin<Types extends SchemaTypes> extends BasePlugin<Types> {
   override wrapResolve(
@@ -55,7 +59,7 @@ export class PothosMocksPlugin<Types extends SchemaTypes> extends BasePlugin<Typ
   }
 
   resolveMock(typename: string, fieldName: string, mocks: ResolverMap<Types>) {
-    const fieldMock = mocks[typename]?.[fieldName] || null;
+    const fieldMock = getOwn(getOwn(mocks, typename), fieldName) || null;
 
     if (!fieldMock) {
       return null;
@@ -69,7 +73,7 @@ export class PothosMocksPlugin<Types extends SchemaTypes> extends BasePlugin<Typ
   }
 
   subscribeMock(typename: string, fieldName: string, mocks: ResolverMap<Types>) {
-    const fieldMock = mocks[typename]?.[fieldName] || null;
+    const fieldMock = getOwn(getOwn(mocks, typename), fieldName) || null;
 
     if (!fieldMock) {
       return null;

--- a/packages/plugin-mocks/src/index.ts
+++ b/packages/plugin-mocks/src/index.ts
@@ -9,13 +9,9 @@ import type { ResolverMap } from './types.js';
 
 const pluginName = 'mocks';
 
-// Members of these prototypes are never mocks, they are built-ins that happen to share a name with
-// a type or field (`toString`, `constructor`, `call`, ...).
 const builtInPrototypes: object[] = [Object.prototype, Function.prototype];
 
-// Finds the object in the prototype chain of `map` that defines `key`, without reading the property
-// itself: `Function.prototype.caller` and `Function.prototype.arguments` are accessors that throw on
-// any access.
+// Descriptors, not property reads: `Function.prototype.caller` and `arguments` throw when read.
 function findDeclaringPrototype(map: object, key: string) {
   for (
     let proto: object | null = Object.getPrototypeOf(map) as object | null;
@@ -32,11 +28,6 @@ function findDeclaringPrototype(map: object, key: string) {
   return null;
 }
 
-// Checks whether the value a mock map returned for a key *is* an inherited built-in, rather than
-// whether some prototype happens to define the name: a Proxy or a prototype that supplies its own
-// `toString` mock returns a different value than `Object.prototype.toString`. Only a data property
-// can be compared to the value that was read: comparing an accessor would mean invoking it, which
-// throws for `caller` and `arguments`, so values declared by a built-in accessor are kept.
 function isBuiltInValue(map: object, key: string, value: unknown) {
   const declaration = findDeclaringPrototype(map, key);
 
@@ -48,9 +39,6 @@ function isBuiltInValue(map: object, key: string, value: unknown) {
   );
 }
 
-// Looks a key up in a user provided mock map. Values the map provides are used as is, even when
-// they come from a prototype, a class or a Proxy, but inherited built-ins are ignored so that types
-// and fields the user never mocked keep their original resolvers.
 function lookupMock<T>(map: Record<string, T> | undefined, key: string): T | undefined {
   if (map === undefined) {
     return undefined;
@@ -79,9 +67,6 @@ export class PothosMocksPlugin<Types extends SchemaTypes> extends BasePlugin<Typ
 
     const resolveMock = this.resolveMock(fieldConfig.parentType, fieldConfig.name, mocks);
 
-    // Fields defined on an interface are shared by every type that implements it, and graphql-js
-    // always executes them against the concrete type, so mocks for the object type can only be
-    // resolved when the field is executed. The lookup is cached per concrete type.
     if (fieldConfig.graphqlKind === 'Interface') {
       const resolversByType = new Map<
         string,

--- a/packages/plugin-mocks/src/index.ts
+++ b/packages/plugin-mocks/src/index.ts
@@ -9,8 +9,39 @@ import type { ResolverMap } from './types.js';
 
 const pluginName = 'mocks';
 
-function getOwn<T>(map: Record<string, T> | undefined, key: string): T | undefined {
-  return map !== undefined && Object.hasOwn(map, key) ? map[key] : undefined;
+// Values inherited from these prototypes are never mocks, they are built-in members that happen to
+// share a name with a type or field (`toString`, `constructor`, `call`, ...).
+const builtInPrototypes: object[] = [Object.prototype, Function.prototype];
+
+function isBuiltInMember(map: object, key: string) {
+  for (
+    let proto: object | null = Object.getPrototypeOf(map) as object | null;
+    proto !== null;
+    proto = Object.getPrototypeOf(proto) as object | null
+  ) {
+    if (Object.hasOwn(proto, key)) {
+      return builtInPrototypes.includes(proto);
+    }
+  }
+
+  return false;
+}
+
+// Looks a key up in a user provided mock map. Values the map provides itself are used as is, even
+// when they come from a prototype or a Proxy, but built-in members are ignored so that types and
+// fields the user never mocked keep their original resolvers.
+function lookupMock<T>(map: Record<string, T> | undefined, key: string): T | undefined {
+  if (map === undefined) {
+    return undefined;
+  }
+
+  const value = map[key];
+
+  if (value === undefined || Object.hasOwn(map, key)) {
+    return value;
+  }
+
+  return isBuiltInMember(map, key) ? undefined : value;
 }
 
 export default pluginName;
@@ -59,7 +90,7 @@ export class PothosMocksPlugin<Types extends SchemaTypes> extends BasePlugin<Typ
   }
 
   resolveMock(typename: string, fieldName: string, mocks: ResolverMap<Types>) {
-    const fieldMock = getOwn(getOwn(mocks, typename), fieldName) || null;
+    const fieldMock = lookupMock(lookupMock(mocks, typename), fieldName) || null;
 
     if (!fieldMock) {
       return null;
@@ -73,7 +104,7 @@ export class PothosMocksPlugin<Types extends SchemaTypes> extends BasePlugin<Typ
   }
 
   subscribeMock(typename: string, fieldName: string, mocks: ResolverMap<Types>) {
-    const fieldMock = getOwn(getOwn(mocks, typename), fieldName) || null;
+    const fieldMock = lookupMock(lookupMock(mocks, typename), fieldName) || null;
 
     if (!fieldMock) {
       return null;

--- a/packages/plugin-mocks/src/index.ts
+++ b/packages/plugin-mocks/src/index.ts
@@ -58,16 +58,32 @@ export class PothosMocksPlugin<Types extends SchemaTypes> extends BasePlugin<Typ
 
     const resolveMock = this.resolveMock(fieldConfig.parentType, fieldConfig.name, mocks);
 
-    // Fields defined on an interface are shared by every type that implements it, so mocks for the
-    // concrete object type can only be resolved when the field is executed.
+    // Fields defined on an interface are shared by every type that implements it, and graphql-js
+    // always executes them against the concrete type, so mocks for the object type can only be
+    // resolved when the field is executed. The lookup is cached per concrete type.
     if (fieldConfig.graphqlKind === 'Interface') {
-      return (parent, args, context, info) => {
-        const mock =
-          info.parentType.name === fieldConfig.parentType
-            ? resolveMock
-            : (this.resolveMock(info.parentType.name, fieldConfig.name, mocks) ?? resolveMock);
+      const resolversByType = new Map<
+        string,
+        GraphQLFieldResolver<unknown, Types['Context'], object>
+      >();
 
-        return (mock ?? resolver)(parent, args, context, info);
+      return (parent, args, context, info) => {
+        let mocked = resolversByType.get(info.parentType.name);
+
+        if (mocked === undefined) {
+          mocked =
+            (this.resolveMock(
+              info.parentType.name,
+              fieldConfig.name,
+              mocks,
+            ) as GraphQLFieldResolver<unknown, Types['Context'], object> | null) ??
+            resolveMock ??
+            resolver;
+
+          resolversByType.set(info.parentType.name, mocked);
+        }
+
+        return mocked(parent, args, context, info);
       };
     }
 

--- a/packages/plugin-mocks/src/index.ts
+++ b/packages/plugin-mocks/src/index.ts
@@ -13,12 +13,38 @@ const pluginName = 'mocks';
 // a type or field (`toString`, `constructor`, `call`, ...).
 const builtInPrototypes: object[] = [Object.prototype, Function.prototype];
 
-// Checks whether the value a mock map returned for a key *is* the built-in inherited for that name,
-// rather than whether some prototype happens to define the name. A Proxy or a prototype that
-// supplies its own `toString` mock returns a different value than `Object.prototype.toString`.
+// Finds the object in the prototype chain of `map` that defines `key`, without reading the property
+// itself: `Function.prototype.caller` and `Function.prototype.arguments` are accessors that throw on
+// any access.
+function findDeclaringPrototype(map: object, key: string) {
+  for (
+    let proto: object | null = Object.getPrototypeOf(map) as object | null;
+    proto !== null;
+    proto = Object.getPrototypeOf(proto) as object | null
+  ) {
+    const descriptor = Object.getOwnPropertyDescriptor(proto, key);
+
+    if (descriptor) {
+      return { proto, descriptor };
+    }
+  }
+
+  return null;
+}
+
+// Checks whether the value a mock map returned for a key *is* an inherited built-in, rather than
+// whether some prototype happens to define the name: a Proxy or a prototype that supplies its own
+// `toString` mock returns a different value than `Object.prototype.toString`. Only a data property
+// can be compared to the value that was read: comparing an accessor would mean invoking it, which
+// throws for `caller` and `arguments`, so values declared by a built-in accessor are kept.
 function isBuiltInValue(map: object, key: string, value: unknown) {
-  return builtInPrototypes.some(
-    (proto) => Object.hasOwn(proto, key) && Reflect.get(proto, key, map) === value,
+  const declaration = findDeclaringPrototype(map, key);
+
+  return (
+    declaration !== null &&
+    builtInPrototypes.includes(declaration.proto) &&
+    'value' in declaration.descriptor &&
+    declaration.descriptor.value === value
   );
 }
 

--- a/packages/plugin-mocks/tests/mocks.test.ts
+++ b/packages/plugin-mocks/tests/mocks.test.ts
@@ -314,6 +314,96 @@ describe('mock maps that are not plain objects', () => {
 
     expect(result).toEqual({ data: { obj: { call: 'mocked' } } });
   });
+
+  it('uses mocks supplied for names guarded by Function.prototype', async () => {
+    const collidingBuilder = new SchemaBuilder<{ Context: {} }>({ plugins: [Mocks] });
+
+    collidingBuilder.queryType({
+      fields: (t) => ({
+        caller: t.string({ resolve: () => 'original' }),
+        arguments: t.string({ resolve: () => 'original' }),
+      }),
+    });
+
+    const fieldMocks = Object.create({
+      caller: () => 'mocked',
+      arguments: () => 'mocked',
+    }) as {};
+
+    const schema = collidingBuilder.toSchema({
+      mocks: { Query: fieldMocks } as unknown as MockMap,
+    });
+
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          caller
+          arguments
+        }
+      `,
+      contextValue: {},
+    });
+
+    expect(result).toEqual({ data: { caller: 'mocked', arguments: 'mocked' } });
+  });
+
+  it('uses mocks a Proxy supplies for names guarded by Function.prototype', async () => {
+    const collidingBuilder = new SchemaBuilder<{ Context: {} }>({ plugins: [Mocks] });
+
+    collidingBuilder.queryType({
+      fields: (t) => ({
+        caller: t.string({ resolve: () => 'original' }),
+      }),
+    });
+
+    const typeMocks = new Proxy(
+      {},
+      {
+        get: (_target, key) => (key === 'Query' ? { caller: () => 'mocked' } : undefined),
+      },
+    );
+
+    const schema = collidingBuilder.toSchema({ mocks: typeMocks as unknown as MockMap });
+
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          caller
+        }
+      `,
+      contextValue: {},
+    });
+
+    expect(result).toEqual({ data: { caller: 'mocked' } });
+  });
+
+  it('does not mock unlisted fields named after restricted function members', async () => {
+    const collidingBuilder = new SchemaBuilder<{ Context: {} }>({ plugins: [Mocks] });
+
+    collidingBuilder.queryType({
+      fields: (t) => ({
+        caller: t.string({ resolve: () => 'original' }),
+        arguments: t.string({ resolve: () => 'original' }),
+      }),
+    });
+
+    const schema = collidingBuilder.toSchema({ mocks: { Query: {} } as unknown as MockMap });
+
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          caller
+          arguments
+        }
+      `,
+      contextValue: {},
+    });
+
+    expect(result).toEqual({ data: { caller: 'original', arguments: 'original' } });
+  });
 });
 
 describe('interface field mock lookups', () => {

--- a/packages/plugin-mocks/tests/mocks.test.ts
+++ b/packages/plugin-mocks/tests/mocks.test.ts
@@ -187,3 +187,58 @@ describe('mock resolution', () => {
     expect(first.value).toEqual({ data: { toString: 'original' } });
   });
 });
+
+describe('mock maps that are not plain objects', () => {
+  const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [Mocks] });
+
+  builder.queryType({
+    fields: (t) => ({
+      hello: t.string({ resolve: () => 'original' }),
+    }),
+  });
+
+  type MockMap = NonNullable<NonNullable<Parameters<typeof builder.toSchema>[0]>['mocks']>;
+
+  function queryHello(mocks: MockMap) {
+    return execute({
+      schema: builder.toSchema({ mocks }),
+      document: gql`
+        query {
+          hello
+        }
+      `,
+      contextValue: {},
+    });
+  }
+
+  it('uses mocks served by a Proxy', async () => {
+    const mocks = new Proxy(
+      {},
+      {
+        get: (_target, key) => (key === 'Query' ? { hello: () => 'mocked' } : undefined),
+      },
+    ) as MockMap;
+
+    expect(await queryHello(mocks)).toEqual({ data: { hello: 'mocked' } });
+  });
+
+  it('uses mocks inherited from a user provided prototype', async () => {
+    const mocks = Object.create({
+      Query: { hello: () => 'mocked' },
+    }) as MockMap;
+
+    expect(await queryHello(mocks)).toEqual({ data: { hello: 'mocked' } });
+  });
+
+  it('uses mocks defined as methods on a class', async () => {
+    class QueryMocks {
+      hello() {
+        return 'mocked';
+      }
+    }
+
+    const mocks = { Query: new QueryMocks() } as unknown as MockMap;
+
+    expect(await queryHello(mocks)).toEqual({ data: { hello: 'mocked' } });
+  });
+});

--- a/packages/plugin-mocks/tests/mocks.test.ts
+++ b/packages/plugin-mocks/tests/mocks.test.ts
@@ -451,7 +451,6 @@ describe('interface field mock lookups', () => {
       });
 
       expect(result.errors).toBeUndefined();
-      // 2 interface fields x 5 items: one lookup per (field, concrete type), not one per resolution
       expect(resolveMock).toHaveBeenCalledTimes(2);
     } finally {
       resolveMock.mockRestore();

--- a/packages/plugin-mocks/tests/mocks.test.ts
+++ b/packages/plugin-mocks/tests/mocks.test.ts
@@ -1,7 +1,8 @@
 import SchemaBuilder from '@pothos/core';
 import { execute, subscribe } from 'graphql';
 import { gql } from 'graphql-tag';
-import Mocks from '../src';
+import { vi } from 'vitest';
+import Mocks, { PothosMocksPlugin } from '../src';
 
 describe('mock resolution', () => {
   it('applies object mocks to fields inherited from an interface', async () => {
@@ -240,5 +241,58 @@ describe('mock maps that are not plain objects', () => {
     const mocks = { Query: new QueryMocks() } as unknown as MockMap;
 
     expect(await queryHello(mocks)).toEqual({ data: { hello: 'mocked' } });
+  });
+});
+
+describe('interface field mock lookups', () => {
+  it('resolves the mock once per concrete type instead of once per field resolution', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [Mocks] });
+
+    const Named = builder.interfaceRef<{ a: string; b: string }>('Named').implement({
+      resolveType: () => 'Obj',
+      fields: (t) => ({
+        a: t.exposeString('a'),
+        b: t.exposeString('b'),
+      }),
+    });
+
+    const Obj = builder.objectRef<{ a: string; b: string }>('Obj').implement({
+      interfaces: [Named],
+      fields: () => ({}),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        objs: t.field({
+          type: [Obj],
+          resolve: () => Array.from({ length: 5 }, () => ({ a: 'a', b: 'b' })),
+        }),
+      }),
+    });
+
+    const schema = builder.toSchema({ mocks: { Query: {} } });
+
+    const resolveMock = vi.spyOn(PothosMocksPlugin.prototype, 'resolveMock');
+
+    try {
+      const result = await execute({
+        schema,
+        document: gql`
+          query {
+            objs {
+              a
+              b
+            }
+          }
+        `,
+        contextValue: {},
+      });
+
+      expect(result.errors).toBeUndefined();
+      // 2 interface fields x 5 items: one lookup per (field, concrete type), not one per resolution
+      expect(resolveMock).toHaveBeenCalledTimes(2);
+    } finally {
+      resolveMock.mockRestore();
+    }
   });
 });

--- a/packages/plugin-mocks/tests/mocks.test.ts
+++ b/packages/plugin-mocks/tests/mocks.test.ts
@@ -1,5 +1,5 @@
 import SchemaBuilder from '@pothos/core';
-import { execute } from 'graphql';
+import { execute, subscribe } from 'graphql';
 import { gql } from 'graphql-tag';
 import Mocks from '../src';
 
@@ -90,5 +90,100 @@ describe('mock resolution', () => {
     });
 
     expect(result).toEqual({ data: { obj: { hello: 'mocked' } } });
+  });
+
+  it('does not mock unlisted fields that share a name with Object.prototype members', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [Mocks] });
+
+    builder.queryType({
+      fields: (t) => ({
+        toString: t.string({ resolve: () => 'original' }),
+        constructor: t.string({ resolve: () => 'original' }),
+      }),
+    });
+
+    const schema = builder.toSchema({ mocks: { Query: {} } });
+
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          toString
+          constructor
+        }
+      `,
+      contextValue: {},
+    });
+
+    expect(result).toEqual({ data: { toString: 'original', constructor: 'original' } });
+  });
+
+  it('does not mock fields on types that share a name with Object.prototype members', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [Mocks] });
+
+    const Constructor = builder.objectRef<{}>('constructor').implement({
+      fields: (t) => ({
+        call: t.string({ resolve: () => 'original' }),
+      }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        obj: t.field({ type: Constructor, resolve: () => ({}) }),
+      }),
+    });
+
+    const schema = builder.toSchema({ mocks: {} });
+
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          obj {
+            call
+          }
+        }
+      `,
+      contextValue: {},
+    });
+
+    expect(result).toEqual({ data: { obj: { call: 'original' } } });
+  });
+
+  it('does not use prototype members as subscribe mocks', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [Mocks] });
+
+    builder.queryType({
+      fields: (t) => ({
+        hello: t.string({ resolve: () => 'original' }),
+      }),
+    });
+
+    builder.subscriptionType({
+      fields: (t) => ({
+        toString: t.string({
+          subscribe: async function* subscribeField() {
+            yield await Promise.resolve('original');
+          },
+          resolve: (value) => value as string,
+        }),
+      }),
+    });
+
+    const schema = builder.toSchema({ mocks: { Subscription: {} } });
+
+    const iterator = (await subscribe({
+      schema,
+      document: gql`
+        subscription {
+          toString
+        }
+      `,
+      contextValue: {},
+    })) as AsyncGenerator<unknown>;
+
+    const first = await iterator.next();
+
+    expect(first.value).toEqual({ data: { toString: 'original' } });
   });
 });

--- a/packages/plugin-mocks/tests/mocks.test.ts
+++ b/packages/plugin-mocks/tests/mocks.test.ts
@@ -242,6 +242,78 @@ describe('mock maps that are not plain objects', () => {
 
     expect(await queryHello(mocks)).toEqual({ data: { hello: 'mocked' } });
   });
+
+  it('uses mocks a Proxy supplies for a built-in member name', async () => {
+    const collidingBuilder = new SchemaBuilder<{ Context: {} }>({ plugins: [Mocks] });
+
+    collidingBuilder.queryType({
+      fields: (t) => ({
+        toString: t.string({ resolve: () => 'original' }),
+      }),
+    });
+
+    const fieldMocks = new Proxy(
+      {},
+      {
+        get: () => () => 'mocked',
+      },
+    );
+
+    const schema = collidingBuilder.toSchema({
+      mocks: { Query: fieldMocks } as unknown as MockMap,
+    });
+
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          toString
+        }
+      `,
+      contextValue: {},
+    });
+
+    expect(result).toEqual({ data: { toString: 'mocked' } });
+  });
+
+  it('uses mocks a Proxy supplies for a type named like a built-in member', async () => {
+    const collidingBuilder = new SchemaBuilder<{ Context: {} }>({ plugins: [Mocks] });
+
+    const Constructor = collidingBuilder.objectRef<{}>('constructor').implement({
+      fields: (t) => ({
+        call: t.string({ resolve: () => 'original' }),
+      }),
+    });
+
+    collidingBuilder.queryType({
+      fields: (t) => ({
+        obj: t.field({ type: Constructor, resolve: () => ({}) }),
+      }),
+    });
+
+    const typeMocks = new Proxy(
+      {},
+      {
+        get: (_target, key) => (key === 'constructor' ? { call: () => 'mocked' } : undefined),
+      },
+    );
+
+    const schema = collidingBuilder.toSchema({ mocks: typeMocks as unknown as MockMap });
+
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          obj {
+            call
+          }
+        }
+      `,
+      contextValue: {},
+    });
+
+    expect(result).toEqual({ data: { obj: { call: 'mocked' } } });
+  });
 });
 
 describe('interface field mock lookups', () => {

--- a/packages/plugin-mocks/tests/mocks.test.ts
+++ b/packages/plugin-mocks/tests/mocks.test.ts
@@ -1,0 +1,94 @@
+import SchemaBuilder from '@pothos/core';
+import { execute } from 'graphql';
+import { gql } from 'graphql-tag';
+import Mocks from '../src';
+
+describe('mock resolution', () => {
+  it('applies object mocks to fields inherited from an interface', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [Mocks] });
+
+    const Node = builder.interfaceRef<{}>('Node').implement({
+      resolveType: () => 'Obj',
+      fields: (t) => ({
+        hello: t.string({ resolve: () => 'original' }),
+      }),
+    });
+
+    const Obj = builder.objectRef<{}>('Obj').implement({
+      interfaces: [Node],
+      fields: () => ({}),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        obj: t.field({ type: Obj, resolve: () => ({}) }),
+      }),
+    });
+
+    const schema = builder.toSchema({
+      mocks: {
+        Obj: {
+          hello: () => 'mocked',
+        },
+      },
+    });
+
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          obj {
+            hello
+          }
+        }
+      `,
+      contextValue: {},
+    });
+
+    expect(result).toEqual({ data: { obj: { hello: 'mocked' } } });
+  });
+
+  it('still applies interface mocks to inherited fields', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [Mocks] });
+
+    const Node = builder.interfaceRef<{}>('Node').implement({
+      resolveType: () => 'Obj',
+      fields: (t) => ({
+        hello: t.string({ resolve: () => 'original' }),
+      }),
+    });
+
+    const Obj = builder.objectRef<{}>('Obj').implement({
+      interfaces: [Node],
+      fields: () => ({}),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        obj: t.field({ type: Obj, resolve: () => ({}) }),
+      }),
+    });
+
+    const schema = builder.toSchema({
+      mocks: {
+        Node: {
+          hello: () => 'mocked',
+        },
+      },
+    });
+
+    const result = await execute({
+      schema,
+      document: gql`
+        query {
+          obj {
+            hello
+          }
+        }
+      `,
+      contextValue: {},
+    });
+
+    expect(result).toEqual({ data: { obj: { hello: 'mocked' } } });
+  });
+});


### PR DESCRIPTION
Fixes the two P2 findings from the whole-plugin review of `@pothos/plugin-mocks`, plus the follow-ups from review rounds on this PR. Each change has a regression test that was confirmed failing before it.

## 1. Concrete mock overrides ignored on interface-inherited fields

**Problem** — mocks were looked up by `fieldConfig.parentType`, which for a field inherited from an interface is the *interface* name. A documented `mocks.Obj.hello` override for the implementing object type was never applied and the original resolver ran.

**Fix** — interface field configs are shared by every implementing type, and graphql-js always executes them against the resolved concrete type, so the mock can only be chosen at execution time. Interface fields are wrapped and the mock is looked up with `info.parentType.name`, falling back to the interface mock. The resolver chosen for each concrete type is cached for the lifetime of the schema, so the lookup happens once per (field, concrete type) rather than once per field resolution. Non-interface fields keep the existing static lookup and are not wrapped at all.

**Verified by** `applies object mocks to fields inherited from an interface` (fails on `main`: returns `original`), `still applies interface mocks to inherited fields` (guards the fallback), and `resolves the mock once per concrete type instead of once per field resolution`, which counts `resolveMock` calls during `{ objs { a b } }` over a 5-element list: 10 without the cache, 2 with it (one per interface field).

## 2. Unlisted prototype-named fields unexpectedly mocked

**Problem** — the lookups `mocks[typename]?.[fieldName]` read inherited `Object.prototype` members. With `mocks: { Query: {} }`, a valid unmocked `Query.toString` field executed `Object.prototype.toString` and returned `[object Undefined]`; `Query.constructor` returned `null` with a coercion error. The same lookup was used for subscription mocks.

**Fix** — own properties of a mock map are always used. For an inherited value, the prototype that declares the name is found with `Object.getOwnPropertyDescriptor` (never by reading the property), and the value is ignored only when that prototype is `Object.prototype`/`Function.prototype` **and** declares the name as a data property whose value is identical to what was read. So everything a map itself supplies is used as a mock — own properties, a user-defined prototype, class methods, or a `Proxy` `get` trap, including a trap that deliberately supplies a mock named `toString` — while an unmocked field named after a built-in keeps its resolver. Descriptors rather than reads matter because `Function.prototype.caller` and `.arguments` are accessors that throw on any access, and `caller`/`arguments` are valid GraphQL field names. Applies to the resolve and subscribe paths alike.

Three earlier revisions of this rule were rejected in review: an own-property check silently disabled Proxy and prototype-based mock maps; a prototype-chain walk asking *who owns the key* still discarded Proxy-supplied mocks for colliding names; and a `Reflect.get` value comparison threw a `TypeError` during schema construction for mocks named `caller`/`arguments`.

**Verified by** these cases, each of which fails against at least one earlier revision:

| mock map | name | expected |
|---|---|---|
| plain object, field unlisted | `toString`, `constructor` | original resolver |
| plain object, field unlisted (subscription) | `toString` | original subscribe |
| plain object, type named `constructor` | field `call` | original resolver |
| plain object, fields unlisted | `caller`, `arguments` | original resolver, no throw |
| `Proxy` `get` trap | `Query.hello` | mocked |
| `Object.create({ Query: … })` | `Query.hello` | mocked |
| class instance, method on prototype | `Query.hello` | mocked |
| `Proxy` supplying a colliding name | `Query.toString`, type `constructor` | mocked |
| prototype / `Proxy` supplying a guarded name | `caller`, `arguments` | mocked, no throw |

## Notes for review

- `Object.hasOwn` is the first use of that built-in in `packages/*/src`. `.swcrc` targets `es2019` and no package declares `engines.node`, so the published output now requires Node >= 16.9 (CI tests 22 and 24). If a lower floor matters, `Object.prototype.hasOwnProperty.call` with a `biome-ignore` comment is a drop-in replacement.
- Unchanged, pre-existing gap: only the concrete type and the interface that *declares* the field are consulted. With `Obj implements Middle implements Base` and `hello` declared on `Base`, `mocks: { Middle: { hello } }` is not applied — same on `main`. Left alone as out of scope.

## Verification

```
pnpm --filter @pothos/plugin-mocks run test   # 2 files, 15 tests passed (1 pre-existing + 14 new), no type errors
pnpm --filter @pothos/plugin-mocks run type   # clean
pnpm biome check packages/plugin-mocks        # clean
```

No public types changed; changeset added as a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
