### PR TITLE
fix(smart-subscriptions): address 2 findings from the plugin review

### DIFF
--- a/.changeset/smart-subscriptions-review-fixes.md
+++ b/.changeset/smart-subscriptions-review-fixes.md
@@ -1,0 +1,7 @@
+---
+"@pothos/plugin-smart-subscriptions": patch
+---
+
+Fix refetching objects in lists resolved to non-array iterables (eg. a Set), which previously threw instead of updating
+
+Attempt every unsubscribe when a subscription is cleaned up, instead of stopping at the first rejection and leaking the remaining subscriptions

--- a/.changeset/smart-subscriptions-review-fixes.md
+++ b/.changeset/smart-subscriptions-review-fixes.md
@@ -2,6 +2,6 @@
 "@pothos/plugin-smart-subscriptions": patch
 ---
 
-Fix refetching objects in lists resolved to non-array iterables (eg. a Set), which previously threw instead of updating
+Fix refetching objects in lists resolved to non-array iterables (eg. a Set or a generator), which previously threw instead of updating
 
 Attempt every unsubscribe when a subscription is cleaned up, instead of stopping at the first rejection and leaking the remaining subscriptions

--- a/packages/plugin-smart-subscriptions/src/cache-node.ts
+++ b/packages/plugin-smart-subscriptions/src/cache-node.ts
@@ -64,17 +64,42 @@ export default class CacheNode<Types extends SchemaTypes> {
 
   replaceValue(value: unknown, key: number | string) {
     if (typeof key === 'number') {
-      if (!Array.isArray(this.value)) {
-        throw new PothosValidationError('Expected value of CacheNode for list path to be an array');
-      }
+      const list = this.valueAsList();
 
       this.cache.invalidPaths.push(`${this.path}.${key}`);
-      this.value[key] = value;
+      list[key] = value;
     } else {
       this.cache.invalidPaths.push(`${this.path}.`);
       this.value = value;
     }
 
     this.typeManagers.delete(key);
+  }
+
+  /**
+   * Lists may be resolved to any iterable, but replacing an entry requires indexed access, so
+   * non-array iterables are materialized into an array the first time an entry is replaced.
+   */
+  private valueAsList(): unknown[] {
+    if (Array.isArray(this.value)) {
+      return this.value as unknown[];
+    }
+
+    if (
+      typeof this.value === 'object' &&
+      this.value !== null &&
+      Symbol.iterator in this.value &&
+      typeof (this.value as Iterable<unknown>)[Symbol.iterator] === 'function'
+    ) {
+      const list = [...(this.value as Iterable<unknown>)];
+
+      this.value = list;
+
+      return list;
+    }
+
+    throw new PothosValidationError(
+      'Expected value of CacheNode for list path to be an array or iterable',
+    );
   }
 }

--- a/packages/plugin-smart-subscriptions/src/cache-node.ts
+++ b/packages/plugin-smart-subscriptions/src/cache-node.ts
@@ -77,8 +77,9 @@ export default class CacheNode<Types extends SchemaTypes> {
   }
 
   /**
-   * Lists may be resolved to any iterable, but replacing an entry requires indexed access, so
-   * non-array iterables are materialized into an array the first time an entry is replaced.
+   * List values are normally materialized into an array before they are cached, but a node may be
+   * created with any iterable, so fall back to materializing it here. This only recovers every
+   * entry for iterables that can be iterated more than once.
    */
   private valueAsList(): unknown[] {
     if (Array.isArray(this.value)) {

--- a/packages/plugin-smart-subscriptions/src/cache-node.ts
+++ b/packages/plugin-smart-subscriptions/src/cache-node.ts
@@ -76,11 +76,7 @@ export default class CacheNode<Types extends SchemaTypes> {
     this.typeManagers.delete(key);
   }
 
-  /**
-   * List values are normally materialized into an array before they are cached, but a node may be
-   * created with any iterable, so fall back to materializing it here. This only recovers every
-   * entry for iterables that can be iterated more than once.
-   */
+  // Only recovers every entry for iterables that can be iterated more than once.
   private valueAsList(): unknown[] {
     if (Array.isArray(this.value)) {
       return this.value as unknown[];

--- a/packages/plugin-smart-subscriptions/src/cache.ts
+++ b/packages/plugin-smart-subscriptions/src/cache.ts
@@ -8,12 +8,6 @@ import {
 import CacheNode from './cache-node.js';
 import type SubscriptionManager from './manager/index.js';
 
-/**
- * Lists may be resolved to any synchronous iterable, but refetching an entry requires indexed
- * access, and single-use iterables (like generators) are exhausted by the first execution.
- * Materializing the iterable before it is cached and executed keeps every entry available for
- * later refetches. Arrays, async iterables and non-list values are left untouched.
- */
 function normalizeListValue(type: GraphQLOutputType, value: unknown) {
   if (!isListType(getNullableType(type)) || Array.isArray(value)) {
     return value;

--- a/packages/plugin-smart-subscriptions/src/cache.ts
+++ b/packages/plugin-smart-subscriptions/src/cache.ts
@@ -1,7 +1,34 @@
 import type { BuildCache, Path, SchemaTypes } from '@pothos/core';
-import type { GraphQLResolveInfo } from 'graphql';
+import {
+  type GraphQLOutputType,
+  type GraphQLResolveInfo,
+  getNullableType,
+  isListType,
+} from 'graphql';
 import CacheNode from './cache-node.js';
 import type SubscriptionManager from './manager/index.js';
+
+/**
+ * Lists may be resolved to any synchronous iterable, but refetching an entry requires indexed
+ * access, and single-use iterables (like generators) are exhausted by the first execution.
+ * Materializing the iterable before it is cached and executed keeps every entry available for
+ * later refetches. Arrays, async iterables and non-list values are left untouched.
+ */
+function normalizeListValue(type: GraphQLOutputType, value: unknown) {
+  if (!isListType(getNullableType(type)) || Array.isArray(value)) {
+    return value;
+  }
+
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Iterable<unknown>)[Symbol.iterator] === 'function'
+  ) {
+    return [...(value as Iterable<unknown>)];
+  }
+
+  return value;
+}
 
 export default class SubscriptionCache<Types extends SchemaTypes> {
   manager: SubscriptionManager;
@@ -93,7 +120,7 @@ export default class SubscriptionCache<Types extends SchemaTypes> {
     const node = new CacheNode(
       this,
       path,
-      value,
+      normalizeListValue(info.returnType, value),
       canRefetch || !parent
         ? () => {
             this.invalidPaths.push(path);

--- a/packages/plugin-smart-subscriptions/src/manager/index.ts
+++ b/packages/plugin-smart-subscriptions/src/manager/index.ts
@@ -202,8 +202,24 @@ export default class SubscriptionManager implements AsyncIterator<object> {
       this.resolveNext(true);
     }
 
+    // The manager is already marked as stopped and its registrations are cleared, so a failed
+    // cleanup can never be retried. Attempt every unsubscribe before surfacing any errors.
+    const errors: unknown[] = [];
+
     for (const name of names) {
-      await this.unsubscribeFromName(name);
+      try {
+        await this.unsubscribeFromName(name);
+      } catch (error: unknown) {
+        errors.push(error);
+      }
+    }
+
+    if (errors.length === 1) {
+      throw errors[0];
+    }
+
+    if (errors.length > 1) {
+      throw new AggregateError(errors, 'Failed to unsubscribe from some subscriptions');
     }
   }
 

--- a/packages/plugin-smart-subscriptions/src/manager/index.ts
+++ b/packages/plugin-smart-subscriptions/src/manager/index.ts
@@ -202,8 +202,8 @@ export default class SubscriptionManager implements AsyncIterator<object> {
       this.resolveNext(true);
     }
 
-    // The manager is already marked as stopped and its registrations are cleared, so a failed
-    // cleanup can never be retried. Attempt every unsubscribe before surfacing any errors.
+    // The manager is already stopped and its registrations cleared, so a failed cleanup can never
+    // be retried.
     const errors: unknown[] = [];
 
     for (const name of names) {

--- a/packages/plugin-smart-subscriptions/src/resolve-with-cache.ts
+++ b/packages/plugin-smart-subscriptions/src/resolve-with-cache.ts
@@ -38,11 +38,13 @@ export default function resolveWithCache<Types extends SchemaTypes>(
 
     const sub = subscribe?.(cacheNode.managerForField(), parent, args, context, info);
 
+    // The cache node may have normalized the resolved value (see normalizeListValue), and execution
+    // needs to use the same value that will be refetched into later.
     if (isThenable(sub)) {
-      return sub.then(() => result);
+      return sub.then(() => cacheNode.value);
     }
 
-    return result;
+    return cacheNode.value;
   }
 
   return isThenable(resultOrPromise)

--- a/packages/plugin-smart-subscriptions/src/resolve-with-cache.ts
+++ b/packages/plugin-smart-subscriptions/src/resolve-with-cache.ts
@@ -38,8 +38,8 @@ export default function resolveWithCache<Types extends SchemaTypes>(
 
     const sub = subscribe?.(cacheNode.managerForField(), parent, args, context, info);
 
-    // The cache node may have normalized the resolved value (see normalizeListValue), and execution
-    // needs to use the same value that will be refetched into later.
+    // `cacheNode.value`, not `result`: the node may have normalized the value, and execution has to
+    // use the same one that refetches are written into.
     if (isThenable(sub)) {
       return sub.then(() => cacheNode.value);
     }

--- a/packages/plugin-smart-subscriptions/tests/iterable-list.test.ts
+++ b/packages/plugin-smart-subscriptions/tests/iterable-list.test.ts
@@ -1,0 +1,74 @@
+import SchemaBuilder from '@pothos/core';
+import { type ExecutionResult, parse, subscribe } from 'graphql';
+import SmartSubscriptionsPlugin from '../src';
+
+describe('lists returned as non-array iterables', () => {
+  it('refetches an object in a list resolved to a Set', async () => {
+    let emit: ((err: unknown, value: unknown) => void) | undefined;
+
+    const builder = new SchemaBuilder<{
+      Context: {};
+      SmartSubscriptions: string;
+    }>({
+      plugins: [SmartSubscriptionsPlugin],
+      smartSubscriptions: {
+        debounceDelay: null,
+        subscribe: (_name, _context, cb) => {
+          emit = cb;
+        },
+        unsubscribe: () => {},
+      },
+    });
+
+    const Item = builder.objectRef<{ value: number }>('Item').implement({
+      subscribe: (subscriptions) => {
+        subscriptions.register('change', { refetch: () => ({ value: 2 }) });
+      },
+      fields: (t) => ({
+        value: t.exposeInt('value'),
+      }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        items: t.field({
+          type: [Item],
+          smartSubscription: true,
+          resolve: () => new Set([{ value: 1 }]),
+        }),
+      }),
+    });
+
+    builder.subscriptionType({});
+
+    const result = await subscribe({
+      schema: builder.toSchema(),
+      document: parse(`
+        subscription {
+          items {
+            value
+          }
+        }
+      `),
+      contextValue: {},
+    });
+
+    if (!(Symbol.asyncIterator in result)) {
+      throw new Error(JSON.stringify(result));
+    }
+
+    const iterator = (result as AsyncIterableIterator<ExecutionResult>)[Symbol.asyncIterator]();
+
+    try {
+      expect((await iterator.next()).value).toEqual({ data: { items: [{ value: 1 }] } });
+
+      const next = iterator.next();
+
+      emit!(null, {});
+
+      expect((await next).value).toEqual({ data: { items: [{ value: 2 }] } });
+    } finally {
+      await iterator.return?.();
+    }
+  });
+});

--- a/packages/plugin-smart-subscriptions/tests/iterable-list.test.ts
+++ b/packages/plugin-smart-subscriptions/tests/iterable-list.test.ts
@@ -1,72 +1,127 @@
 import SchemaBuilder from '@pothos/core';
-import { type ExecutionResult, parse, subscribe } from 'graphql';
+import { type ExecutionResult, type GraphQLSchema, parse, subscribe } from 'graphql';
 import SmartSubscriptionsPlugin from '../src';
+
+interface Item {
+  value: number;
+}
+
+function createSchema(
+  resolveItems: () => Iterable<Item>,
+  refetchItem: (item: Item) => Item | null,
+) {
+  let emit: ((err: unknown, value: unknown) => void) | undefined;
+
+  const builder = new SchemaBuilder<{
+    Context: {};
+    SmartSubscriptions: string;
+  }>({
+    plugins: [SmartSubscriptionsPlugin],
+    smartSubscriptions: {
+      debounceDelay: null,
+      subscribe: (_name, _context, cb) => {
+        emit = cb;
+      },
+      unsubscribe: () => {},
+    },
+  });
+
+  const ItemRef = builder.objectRef<Item>('Item').implement({
+    subscribe: (subscriptions, item) => {
+      const refetched = refetchItem(item);
+
+      if (refetched) {
+        subscriptions.register('change', { refetch: () => refetched });
+      }
+    },
+    fields: (t) => ({
+      value: t.exposeInt('value'),
+    }),
+  });
+
+  builder.queryType({
+    fields: (t) => ({
+      items: t.field({
+        type: [ItemRef],
+        smartSubscription: true,
+        resolve: () => resolveItems(),
+      }),
+    }),
+  });
+
+  builder.subscriptionType({});
+
+  return {
+    schema: builder.toSchema(),
+    emit: (value: unknown) => emit!(null, value),
+  };
+}
+
+async function subscribeToItems(schema: GraphQLSchema) {
+  const result = await subscribe({
+    schema,
+    document: parse(`
+      subscription {
+        items {
+          value
+        }
+      }
+    `),
+    contextValue: {},
+  });
+
+  if (!(Symbol.asyncIterator in result)) {
+    throw new Error(JSON.stringify(result));
+  }
+
+  return (result as AsyncIterableIterator<ExecutionResult>)[Symbol.asyncIterator]();
+}
 
 describe('lists returned as non-array iterables', () => {
   it('refetches an object in a list resolved to a Set', async () => {
-    let emit: ((err: unknown, value: unknown) => void) | undefined;
+    const { schema, emit } = createSchema(
+      () => new Set([{ value: 1 }]),
+      () => ({ value: 2 }),
+    );
 
-    const builder = new SchemaBuilder<{
-      Context: {};
-      SmartSubscriptions: string;
-    }>({
-      plugins: [SmartSubscriptionsPlugin],
-      smartSubscriptions: {
-        debounceDelay: null,
-        subscribe: (_name, _context, cb) => {
-          emit = cb;
-        },
-        unsubscribe: () => {},
-      },
-    });
-
-    const Item = builder.objectRef<{ value: number }>('Item').implement({
-      subscribe: (subscriptions) => {
-        subscriptions.register('change', { refetch: () => ({ value: 2 }) });
-      },
-      fields: (t) => ({
-        value: t.exposeInt('value'),
-      }),
-    });
-
-    builder.queryType({
-      fields: (t) => ({
-        items: t.field({
-          type: [Item],
-          smartSubscription: true,
-          resolve: () => new Set([{ value: 1 }]),
-        }),
-      }),
-    });
-
-    builder.subscriptionType({});
-
-    const result = await subscribe({
-      schema: builder.toSchema(),
-      document: parse(`
-        subscription {
-          items {
-            value
-          }
-        }
-      `),
-      contextValue: {},
-    });
-
-    if (!(Symbol.asyncIterator in result)) {
-      throw new Error(JSON.stringify(result));
-    }
-
-    const iterator = (result as AsyncIterableIterator<ExecutionResult>)[Symbol.asyncIterator]();
+    const iterator = await subscribeToItems(schema);
 
     try {
       expect((await iterator.next()).value).toEqual({ data: { items: [{ value: 1 }] } });
 
       const next = iterator.next();
 
-      emit!(null, {});
+      emit({});
 
       expect((await next).value).toEqual({ data: { items: [{ value: 2 }] } });
+    } finally {
+      await iterator.return?.();
+    }
+  });
+
+  it('keeps every entry of a single-use iterable when one is refetched', async () => {
+    const { schema, emit } = createSchema(
+      function* items() {
+        yield { value: 1 };
+        yield { value: 2 };
+      },
+      (item) => (item.value === 1 ? { value: 10 } : null),
+    );
+
+    const iterator = await subscribeToItems(schema);
+
+    try {
+      expect((await iterator.next()).value).toEqual({
+        data: { items: [{ value: 1 }, { value: 2 }] },
+      });
+
+      const next = iterator.next();
+
+      emit({});
+
+      expect((await next).value).toEqual({
+        data: { items: [{ value: 10 }, { value: 2 }] },
+      });
     } finally {
       await iterator.return?.();
     }

--- a/packages/plugin-smart-subscriptions/tests/manager-cleanup.test.ts
+++ b/packages/plugin-smart-subscriptions/tests/manager-cleanup.test.ts
@@ -1,0 +1,52 @@
+import { SubscriptionManager } from '../src';
+
+describe('SubscriptionManager cleanup', () => {
+  it('unsubscribes from every name when one unsubscribe rejects', async () => {
+    const cleaned: string[] = [];
+
+    const manager = new SubscriptionManager({
+      value: {},
+      subscribe: () => {},
+      unsubscribe: (name) => {
+        cleaned.push(name);
+
+        return name === 'first' ? Promise.reject(new Error('cleanup failed')) : Promise.resolve();
+      },
+    });
+
+    manager.register({ name: 'first' });
+    manager.register({ name: 'second' });
+
+    await expect(manager.return()).rejects.toThrow('cleanup failed');
+    expect(cleaned).toEqual(['first', 'second']);
+  });
+
+  it('surfaces every error when multiple unsubscribes reject', async () => {
+    const cleaned: string[] = [];
+
+    const manager = new SubscriptionManager({
+      value: {},
+      subscribe: () => {},
+      unsubscribe: (name) => {
+        cleaned.push(name);
+
+        return Promise.reject(new Error(`${name} failed`));
+      },
+    });
+
+    manager.register({ name: 'first' });
+    manager.register({ name: 'second' });
+
+    const error = await manager.return().then(
+      () => null,
+      (err: unknown) => err as AggregateError,
+    );
+
+    expect(cleaned).toEqual(['first', 'second']);
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error!.errors as Error[]).map((err) => err.message)).toEqual([
+      'first failed',
+      'second failed',
+    ]);
+  });
+});


### PR DESCRIPTION
Addresses the 2 confirmed P2 findings from the whole-plugin review of `@pothos/plugin-smart-subscriptions`, plus a follow-up fix for a regression an independent review found in the first commit. Each commit carries a regression test that was confirmed failing before the fix.

## 1. Refetching an object inside a non-array iterable list crashed

**Problem** — `CacheNode.replaceValue` (`src/cache-node.ts`) assumed a cached list value was always an `Array`. A resolver returning a supported iterable such as a `Set` is accepted by both the Pothos types and GraphQL execution, and the first subscription payload is correct, but an object-level event that refetches one of the entries threw `PothosValidationError: Expected value of CacheNode for list path to be an array` through the event source instead of pushing an update.

**Fix** — a synchronous iterable resolved for a list field is materialized into an array when the cache node first records it (`normalizeListValue` in `src/cache.ts`), and execution uses the value the cache holds, so later refetches can replace an entry by index. Arrays keep their identity; async iterables, non-list values and `null` are untouched; non-iterable values still throw the validation error.

**Follow-up (third commit)** — the first version of this fix materialized *lazily*, at the moment an entry was replaced. That is correct for a re-iterable value like a `Set`, but a generator has already been consumed by GraphQL execution by then: the spread produced an empty array and replacing an entry silently dropped the untouched siblings. A two-item generator with only its first entry refetched returned just that entry after the update. Normalizing at record time — before execution consumes the iterable — fixes that, and is what the code now does.

**Verified by** `packages/plugin-smart-subscriptions/tests/iterable-list.test.ts`, two public GraphQL subscription cases:
- a field resolving `new Set([{ value: 1 }])` whose object type registers a `refetch` — before the fix it failed with the validation error at `src/cache-node.ts:68`; now the second payload is `{ items: [{ value: 2 }] }`.
- a field resolving a two-item generator where only the first entry registers a `refetch` — before the follow-up it returned `{ items: [{ value: 10 }] }`, dropping the untouched second entry; now it returns `{ items: [{ value: 10 }, { value: 2 }] }`.

## 2. One cleanup rejection leaked the remaining registrations

**Problem** — `SubscriptionManager.stop` (`src/manager/index.ts`) marks itself stopped and clears its registration sets before awaiting each unsubscribe sequentially. A single rejection aborted the loop, so the remaining topics were never unsubscribed — and no retry was possible, since `stopped` was already `true` and the names had been dropped. Those event-source listeners leaked for the rest of the process.

**Fix** — every unsubscribe is attempted; failures are collected and surfaced afterwards. A single failure is rethrown as-is (unchanged behaviour for callers); multiple failures are rethrown as an `AggregateError`.

**Verified by** `packages/plugin-smart-subscriptions/tests/manager-cleanup.test.ts`: registering `first`/`second` with a rejecting `unsubscribe('first')` previously recorded cleanup of `['first']` only; it now records `['first', 'second']` and still rejects with the original error. A second case covers both unsubscribes rejecting.

## Verification

```
pnpm --filter @pothos/plugin-smart-subscriptions run test   # 3 files, 7 tests passed (3 pre-existing + 4 new), no type errors
pnpm --filter @pothos/plugin-smart-subscriptions run type   # clean
pnpm biome check packages/plugin-smart-subscriptions        # clean
```

Out of scope and deliberately untouched: the fixed-window numeric debounce delay and the fresh-context-per-subscription requirement, both of which are documented behaviour rather than defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
