### PR TITLE
fix(sub-graph): address 2 findings from the plugin review

### DIFF
--- a/.changeset/sub-graph-review-fixes.md
+++ b/.changeset/sub-graph-review-fixes.md
@@ -1,0 +1,6 @@
+---
+"@pothos/plugin-sub-graph": patch
+---
+
+Remap custom directive argument types to the rebuilt sub-graph types instead of reusing the originals
+Preserve the schema description when creating a sub-graph

--- a/.changeset/sub-graph-review-fixes.md
+++ b/.changeset/sub-graph-review-fixes.md
@@ -2,5 +2,5 @@
 "@pothos/plugin-sub-graph": patch
 ---
 
-Remap custom directive argument types to the rebuilt sub-graph types instead of reusing the originals
+Remap custom directive argument types to the rebuilt sub-graph types instead of reusing the originals, and throw when a directive argument references a type that is not part of the sub-graph rather than publishing the excluded type
 Preserve the schema description when creating a sub-graph

--- a/packages/plugin-sub-graph/src/index.ts
+++ b/packages/plugin-sub-graph/src/index.ts
@@ -94,6 +94,7 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
     }
 
     return new GraphQLSchema({
+      description: config.description,
       directives: config.directives.map((directive) =>
         PothosSubGraphPlugin.mapDirective(directive, newTypes, subGraphs),
       ),

--- a/packages/plugin-sub-graph/src/index.ts
+++ b/packages/plugin-sub-graph/src/index.ts
@@ -116,10 +116,6 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
     });
   }
 
-  // Directive arguments reference the types of the original schema, and need to be re-pointed at
-  // the types rebuilt for the sub-graph, otherwise the schema ends up with 2 types of the same name.
-  // Arguments that reference a type which is not part of the sub-graph throw, rather than keeping
-  // the original type, which would publish an excluded type through the directive.
   static mapDirective(
     directive: GraphQLDirective,
     newTypes: Map<string, GraphQLNamedType>,

--- a/packages/plugin-sub-graph/src/index.ts
+++ b/packages/plugin-sub-graph/src/index.ts
@@ -117,7 +117,9 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
   }
 
   // Directive arguments reference the types of the original schema, and need to be re-pointed at
-  // the types rebuilt for the sub-graph, otherwise the schema ends up with 2 types of the same name
+  // the types rebuilt for the sub-graph, otherwise the schema ends up with 2 types of the same name.
+  // Arguments that reference a type which is not part of the sub-graph throw, rather than keeping
+  // the original type, which would publish an excluded type through the directive.
   static mapDirective(
     directive: GraphQLDirective,
     newTypes: Map<string, GraphQLNamedType>,
@@ -129,23 +131,18 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
 
     for (const [argName, argConfig] of Object.entries(directiveConfig.args ?? {})) {
       const namedType = getNamedType(argConfig.type);
-      const newType = newTypes.get(namedType.name);
+      const type = replaceType(
+        argConfig.type,
+        newTypes,
+        `${argName} argument of @${directive.name}`,
+        subGraphs,
+      );
 
-      if (!newType || newType === namedType) {
-        newArguments[argName] = argConfig;
-        continue;
+      if (newTypes.get(namedType.name) !== namedType) {
+        replacedType = true;
       }
 
-      replacedType = true;
-      newArguments[argName] = {
-        ...argConfig,
-        type: replaceType(
-          argConfig.type,
-          newTypes,
-          `${argName} argument of @${directive.name}`,
-          subGraphs,
-        ),
-      };
+      newArguments[argName] = { ...argConfig, type };
     }
 
     if (!replacedType) {

--- a/packages/plugin-sub-graph/src/index.ts
+++ b/packages/plugin-sub-graph/src/index.ts
@@ -8,6 +8,7 @@ import SchemaBuilder, {
   type SchemaTypes,
 } from '@pothos/core';
 import {
+  GraphQLDirective,
   GraphQLEnumType,
   type GraphQLFieldConfigArgumentMap,
   type GraphQLFieldConfigMap,
@@ -93,7 +94,9 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
     }
 
     return new GraphQLSchema({
-      directives: config.directives,
+      directives: config.directives.map((directive) =>
+        PothosSubGraphPlugin.mapDirective(directive, newTypes, subGraphs),
+      ),
       extensions: config.extensions,
       extensionASTNodes: config.extensionASTNodes,
       assumeValid: false,
@@ -109,6 +112,48 @@ export class PothosSubGraphPlugin<Types extends SchemaTypes> extends BasePlugin<
           ((isObjectType(type) || isInterfaceType(type)) &&
             hasReturnedInterface(type as GraphQLInterfaceType | GraphQLObjectType)),
       ),
+    });
+  }
+
+  // Directive arguments reference the types of the original schema, and need to be re-pointed at
+  // the types rebuilt for the sub-graph, otherwise the schema ends up with 2 types of the same name
+  static mapDirective(
+    directive: GraphQLDirective,
+    newTypes: Map<string, GraphQLNamedType>,
+    subGraphs: string[],
+  ) {
+    const directiveConfig = directive.toConfig();
+    const newArguments: GraphQLFieldConfigArgumentMap = {};
+    let replacedType = false;
+
+    for (const [argName, argConfig] of Object.entries(directiveConfig.args ?? {})) {
+      const namedType = getNamedType(argConfig.type);
+      const newType = newTypes.get(namedType.name);
+
+      if (!newType || newType === namedType) {
+        newArguments[argName] = argConfig;
+        continue;
+      }
+
+      replacedType = true;
+      newArguments[argName] = {
+        ...argConfig,
+        type: replaceType(
+          argConfig.type,
+          newTypes,
+          `${argName} argument of @${directive.name}`,
+          subGraphs,
+        ),
+      };
+    }
+
+    if (!replacedType) {
+      return directive;
+    }
+
+    return new GraphQLDirective({
+      ...directiveConfig,
+      args: newArguments,
     });
   }
 

--- a/packages/plugin-sub-graph/tests/create-sub-graph.test.ts
+++ b/packages/plugin-sub-graph/tests/create-sub-graph.test.ts
@@ -56,4 +56,22 @@ describe('createSubGraph', () => {
 
     expect(directiveArgType).toBe(subGraph.getType('Filter'));
   });
+
+  it('preserves the schema description', () => {
+    const builder = createBuilder();
+
+    builder.queryType({
+      fields: (t) => ({ hello: t.string({ resolve: () => 'hello' }) }),
+    });
+
+    const fullSchema = builder.toSchema();
+    const describedSchema = new GraphQLSchema({
+      ...fullSchema.toConfig(),
+      description: 'Public API',
+    });
+
+    const subGraph = PothosSubGraphPlugin.createSubGraph(describedSchema, 'Public', builder);
+
+    expect(subGraph.description).toBe('Public API');
+  });
 });

--- a/packages/plugin-sub-graph/tests/create-sub-graph.test.ts
+++ b/packages/plugin-sub-graph/tests/create-sub-graph.test.ts
@@ -55,6 +55,77 @@ describe('createSubGraph', () => {
       ?.args.find((arg) => arg.name === 'input')?.type;
 
     expect(directiveArgType).toBe(subGraph.getType('Filter'));
+    // directives that need no remapping are passed through untouched
+    expect(subGraph.getDirective('skip')).toBe(schemaWithDirective.getDirective('skip'));
+  });
+
+  it('throws when a directive argument type is excluded from the sub-graph', () => {
+    const builder = createBuilder();
+    const Filter = builder.inputType('Filter', {
+      fields: (t) => ({ term: t.string() }),
+    });
+    builder.inputType('Secret', {
+      subGraphs: ['Private'],
+      fields: (t) => ({ key: t.string() }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        hello: t.string({
+          args: { filter: t.arg({ type: Filter }) },
+          resolve: () => 'hello',
+        }),
+      }),
+    });
+
+    const fullSchema = builder.toSchema();
+    const directive = new GraphQLDirective({
+      name: 'mixed',
+      locations: [DirectiveLocation.FIELD_DEFINITION],
+      args: {
+        input: { type: fullSchema.getType('Filter') as GraphQLInputObjectType },
+        secret: { type: fullSchema.getType('Secret') as GraphQLInputObjectType },
+      },
+    });
+    const schemaWithDirective = new GraphQLSchema({
+      ...fullSchema.toConfig(),
+      directives: [...fullSchema.getDirectives(), directive],
+    });
+
+    expect(() =>
+      PothosSubGraphPlugin.createSubGraph(schemaWithDirective, 'Public', builder),
+    ).toThrow(
+      'Secret (referenced by secret argument of @mixed) does not exist in subGraph (Public)',
+    );
+  });
+
+  it('throws when every argument of a directive is excluded from the sub-graph', () => {
+    const builder = createBuilder();
+    builder.inputType('Secret', {
+      subGraphs: ['Private'],
+      fields: (t) => ({ key: t.string() }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({ hello: t.string({ resolve: () => 'hello' }) }),
+    });
+
+    const fullSchema = builder.toSchema();
+    const directive = new GraphQLDirective({
+      name: 'secretOnly',
+      locations: [DirectiveLocation.FIELD_DEFINITION],
+      args: { secret: { type: fullSchema.getType('Secret') as GraphQLInputObjectType } },
+    });
+    const schemaWithDirective = new GraphQLSchema({
+      ...fullSchema.toConfig(),
+      directives: [...fullSchema.getDirectives(), directive],
+    });
+
+    expect(() =>
+      PothosSubGraphPlugin.createSubGraph(schemaWithDirective, 'Public', builder),
+    ).toThrow(
+      'Secret (referenced by secret argument of @secretOnly) does not exist in subGraph (Public)',
+    );
   });
 
   it('preserves the schema description', () => {

--- a/packages/plugin-sub-graph/tests/create-sub-graph.test.ts
+++ b/packages/plugin-sub-graph/tests/create-sub-graph.test.ts
@@ -55,7 +55,6 @@ describe('createSubGraph', () => {
       ?.args.find((arg) => arg.name === 'input')?.type;
 
     expect(directiveArgType).toBe(subGraph.getType('Filter'));
-    // directives that need no remapping are passed through untouched
     expect(subGraph.getDirective('skip')).toBe(schemaWithDirective.getDirective('skip'));
   });
 

--- a/packages/plugin-sub-graph/tests/create-sub-graph.test.ts
+++ b/packages/plugin-sub-graph/tests/create-sub-graph.test.ts
@@ -1,0 +1,59 @@
+import SchemaBuilder from '@pothos/core';
+import {
+  DirectiveLocation,
+  GraphQLDirective,
+  type GraphQLInputObjectType,
+  GraphQLSchema,
+} from 'graphql';
+import SubGraphPlugin, { PothosSubGraphPlugin } from '../src';
+
+interface Types {
+  SubGraphs: 'Private' | 'Public';
+}
+
+function createBuilder() {
+  return new SchemaBuilder<Types>({
+    plugins: [SubGraphPlugin],
+    subGraphs: {
+      defaultForTypes: ['Public'],
+      fieldsInheritFromTypes: true,
+    },
+  });
+}
+
+describe('createSubGraph', () => {
+  it('remaps custom directive argument types to the rebuilt types', () => {
+    const builder = createBuilder();
+    const Filter = builder.inputType('Filter', {
+      fields: (t) => ({ term: t.string() }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        hello: t.string({
+          args: { filter: t.arg({ type: Filter }) },
+          resolve: () => 'hello',
+        }),
+      }),
+    });
+
+    const fullSchema = builder.toSchema();
+    const directive = new GraphQLDirective({
+      name: 'filter',
+      locations: [DirectiveLocation.FIELD_DEFINITION],
+      args: { input: { type: fullSchema.getType('Filter') as GraphQLInputObjectType } },
+    });
+    const schemaWithDirective = new GraphQLSchema({
+      ...fullSchema.toConfig(),
+      directives: [...fullSchema.getDirectives(), directive],
+    });
+
+    const subGraph = PothosSubGraphPlugin.createSubGraph(schemaWithDirective, 'Public', builder);
+
+    const directiveArgType = subGraph
+      .getDirective('filter')
+      ?.args.find((arg) => arg.name === 'input')?.type;
+
+    expect(directiveArgType).toBe(subGraph.getType('Filter'));
+  });
+});


### PR DESCRIPTION
Addresses the two confirmed findings from the `@pothos/plugin-sub-graph` whole-plugin review.

### 1. (P2) Custom directive input types retained stale identities

`createSubGraph` copied the source schema's `directives` array unchanged while rebuilding every input/output type for the sub-graph. A custom directive argument and a retained field argument that referenced the same input type therefore pointed at two *different* objects both named `Filter`, and `new GraphQLSchema(...)` threw `Schema must contain uniquely named types but contains multiple types named "Filter"`.

**Fix:** `PothosSubGraphPlugin.mapDirective` runs every directive argument through the existing `replaceType` helper, so arguments are re-pointed at the types rebuilt for the sub-graph. A directive whose argument types were not rebuilt (built-in scalars, and scalars/enums that are reused by identity) is returned unchanged, preserving directive identity where nothing needs remapping.

**When an argument's type is not in the sub-graph, this now throws** rather than keeping the original type. That matters: keeping it silently published a type the user had explicitly excluded. With `Filter` in `Public` and `Secret` restricted to `Private`, and a directive `@mixed(input: Filter, secret: Secret)`:

| | `main` | first version of this PR | now |
|---|---|---|---|
| `@mixed(input: Filter, secret: Secret)` | throws `multiple types named "Filter"` | **builds; `printSchema` contains `input Secret`** | throws `Secret (referenced by secret argument of @mixed) does not exist in subGraph (Public)` |
| `@secretOnly(secret: Secret)` (all args excluded) | **builds; `printSchema` contains `input Secret`** | **builds; leaks `Secret`** | throws `Secret (referenced by secret argument of @secretOnly) does not exist in subGraph (Public)` |

The all-excluded leak pre-exists on `main`; the mixed case is where remapping one argument removed the incidental duplicate-name error that used to surface the problem. For a plugin whose job is excluding types from a published schema, an error naming the directive, the argument and the excluded type is the right outcome in both — and it matches what `replaceType` already does for field and argument types elsewhere in the plugin. Both cases are pinned by tests.

### 2. (P3) Schema description was lost

`createSubGraph` reconstructed the `GraphQLSchema` without copying `config.description`, so a schema-level description was dropped from the sub-graph. **Fix:** `description: config.description` is now carried over alongside `extensions`/`directives`.

Scope note: this is only reachable through the public `PothosSubGraphPlugin.createSubGraph` static, which accepts any `GraphQLSchema` — **not** through `builder.toSchema`. Core's `BuildSchemaOptions` (`packages/core/src/types/global/schema-types.ts:33-38`) has only `directives`, `extensions`, `sortSchema` and `astNode`, and `builder.ts:723-731` never passes a description, so `builder.toSchema({ description })` does not type-check and yields `undefined` with or without a `subGraph`. The test therefore exercises `createSubGraph` directly. Giving `toSchema` a `description` option would be a separate core change.

### Follow-up, not fixed here

`astNode` *is* settable via `BuildSchemaOptions.astNode` and is still dropped by `createSubGraph` — the reachable analogue of the unreachable field fixed above. Pre-existing on `main`; left for a separate change.

### Verification

Tests in `packages/plugin-sub-graph/tests/create-sub-graph.test.ts`, each confirmed failing before its fix and passing after:

```
pnpm --filter @pothos/plugin-sub-graph run test   # 9 passed (5 existing + 4 new), no type errors
pnpm --filter @pothos/plugin-sub-graph run type   # clean
pnpm biome check packages/plugin-sub-graph        # clean
```

Existing snapshots are unchanged. Out of scope and intentionally untouched: the documented required-input and excluded-union dependency errors; no federation composition run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
