### PR TITLE
fix(relay): address 5 review findings and a sibling nullability bug

### DIFF
--- a/.changeset/relay-review-fixes.md
+++ b/.changeset/relay-review-fixes.md
@@ -1,0 +1,8 @@
+---
+"@pothos/plugin-relay": patch
+---
+
+- Cap backward (`last`) page size against `maxSize` before deriving the start offset, so trimming keeps the last requested items
+- Clamp offset windows when a stale `after` cursor points past `totalCount`, instead of producing a negative limit and `hasNextPage: true`
+- Group node ids in a `Map` so node types named `constructor`, `toString`, etc. no longer throw when loaded
+- Infer node types from readonly arrays returned by `resolveCursorConnection` resolvers instead of `never`

--- a/.changeset/relay-review-fixes.md
+++ b/.changeset/relay-review-fixes.md
@@ -7,3 +7,4 @@
 - Group node ids in a `Map` so node types named `constructor`, `toString`, etc. no longer throw when loaded
 - Infer node types from readonly arrays returned by `resolveCursorConnection` resolvers instead of `never`
 - Type the result of `resolveCursorConnection` as nullable when its resolver can return `null`, instead of a non-null connection that threw on unguarded `.edges`
+- Type the result of `resolveOffsetConnection` as nullable when its resolver can return `null` — the existing derivation was silently collapsed by `Merge`

--- a/.changeset/relay-review-fixes.md
+++ b/.changeset/relay-review-fixes.md
@@ -3,8 +3,7 @@
 ---
 
 - Cap backward (`last`) page size against `maxSize` before deriving the start offset, so trimming keeps the last requested items
-- Clamp offset windows when a stale `after` cursor points past `totalCount`, instead of producing a negative limit and `hasNextPage: true`
+- Clamp offset windows to the size of the collection when a cursor points past the end of it: a stale `after` cursor no longer produces a negative limit and `hasNextPage: true`, and a stale `before` cursor now pages off the real end instead of returning an empty page
 - Group node ids in a `Map` so node types named `constructor`, `toString`, etc. no longer throw when loaded
 - Infer node types from readonly arrays returned by `resolveCursorConnection` resolvers instead of `never`
-- Type the result of `resolveCursorConnection` as nullable when its resolver can return `null`, instead of a non-null connection that threw on unguarded `.edges`
-- Type the result of `resolveOffsetConnection` as nullable when its resolver can return `null` — the existing derivation was silently collapsed by `Merge`
+- Type the results of `resolveCursorConnection` and `resolveOffsetConnection` as nullable when their resolvers can return `null`, instead of non-null connections that threw on unguarded `.edges`. Resolvers typed `any` are unaffected

--- a/.changeset/relay-review-fixes.md
+++ b/.changeset/relay-review-fixes.md
@@ -6,3 +6,4 @@
 - Clamp offset windows when a stale `after` cursor points past `totalCount`, instead of producing a negative limit and `hasNextPage: true`
 - Group node ids in a `Map` so node types named `constructor`, `toString`, etc. no longer throw when loaded
 - Infer node types from readonly arrays returned by `resolveCursorConnection` resolvers instead of `never`
+- Type the result of `resolveCursorConnection` as nullable when its resolver can return `null`, instead of a non-null connection that threw on unguarded `.edges`

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -36,23 +36,10 @@ interface ResolveArrayConnectionOptions {
   maxSize?: number;
 }
 
-/** `true` only for `any`, which otherwise matches both branches of a conditional type. */
 type IsAny<T> = 0 extends 1 & T ? true : false;
 
-/**
- * `null` when the resolver can return `null` (directly or from its promise), `never` otherwise.
- *
- * This is unioned in at the outermost level rather than passed to `ArrayConnectionShape`'s
- * `Nullable` parameter, because intersecting a possibly-null union with an object type drops the
- * null member. `resolveOffsetConnection` used to declare this derivation inline and it never
- * reached callers, because `& { totalCount: C }` was applied on top of it. `Merge` is not the
- * culprit and does preserve null; the hazard is the intersection, so keep this out of one.
- *
- * `any` is excluded deliberately. It satisfies both branches of every conditional below, and
- * `Promise<null> extends Promise<any>` is true, so an `any`-typed resolver would be reported as
- * nullable even though such code never sees a null and compiled before nullability was derived
- * at all.
- */
+// Unioned into the return types rather than passed as `ArrayConnectionShape`'s `Nullable`:
+// intersecting a possibly-null union with an object type drops the null member.
 type ConnectionNullability<U> =
   IsAny<U> extends true
     ? never
@@ -88,11 +75,6 @@ export function offsetForArgs(options: ResolveOffsetConnectionOptions) {
     options.totalCount != null ? Math.max(options.totalCount, 0) : Number.POSITIVE_INFINITY;
 
   let startOffset = after ? afterOffset + 1 : 0;
-  // A cursor that was valid before the collection shrank can now point past the end of it, in
-  // either direction. Clamping to the known size keeps the window inside the collection: a stale
-  // `before` cursor still pages off the real end, and a stale `after` cursor yields an empty
-  // window rather than a negative one. `beforeOffset` is already `Infinity` when `before` is
-  // absent, so the same expression covers both.
   let endOffset = Math.max(Math.min(beforeOffset, endOfCollection), startOffset);
 
   if (first != null) {
@@ -104,8 +86,6 @@ export function offsetForArgs(options: ResolveOffsetConnectionOptions) {
         'Argument "last" can only be used in combination with "before" or "first"',
       );
     }
-    // Cap the backward page size before deriving the start offset so that trimming for
-    // `maxSize` keeps the last requested items rather than sliding the window backwards.
     startOffset = Math.max(startOffset, endOffset - Math.min(last, maxSize));
   }
 

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -204,16 +204,28 @@ export function resolveArrayConnection<T>(
 
 export { parseCursorConnectionArgs } from '@pothos/core';
 
-type NodeType<T> = T extends readonly (infer N)[] | Promise<readonly (infer N)[] | null> | null
+type NodeType<T> = T extends readonly (infer N)[] | Promise<readonly (infer N)[] | null>
   ? N
   : never;
+
+/**
+ * `null` when the resolver can return `null` (directly or from its promise), `never` otherwise.
+ *
+ * This is kept outside of `Merge`, which collapses `null` out of a union because `null & {}` is
+ * `never`.
+ */
+type ConnectionNullability<U> =
+  U extends NonNullable<U> ? (Promise<null> extends U ? null : never) : null;
 
 export async function resolveCursorConnection<
   U extends Promise<readonly unknown[] | null> | readonly unknown[] | null,
 >(
   options: ResolveCursorConnectionOptions<NodeType<U>>,
   resolve: (params: ResolveCursorConnectionArgs) => U,
-): Promise<Merge<ArrayConnectionShape<SchemaTypes, NodeType<U>, false, false, false>>> {
+): Promise<
+  | Merge<ArrayConnectionShape<SchemaTypes, NodeType<U>, false, false, false>>
+  | ConnectionNullability<U>
+> {
   const { before, after, limit, inverted, expectedSize, hasPreviousPage, hasNextPage } =
     parseCursorConnectionArgs(options);
 

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -36,6 +36,16 @@ interface ResolveArrayConnectionOptions {
   maxSize?: number;
 }
 
+/**
+ * `null` when the resolver can return `null` (directly or from its promise), `never` otherwise.
+ *
+ * This has to be unioned in outside of `Merge`. `Merge` is a homomorphic mapped type intersected
+ * with `{}`, so it distributes over unions and collapses the nullable member away: `null & {}` is
+ * `never`.
+ */
+type ConnectionNullability<U> =
+  U extends NonNullable<U> ? (Promise<null> extends U ? null : never) : null;
+
 const OFFSET_CURSOR_PREFIX = 'OffsetConnection:';
 const DEFAULT_MAX_SIZE = 100;
 const DEFAULT_SIZE = 20;
@@ -105,15 +115,16 @@ export async function resolveOffsetConnection<
     limit: number;
   }) => U & (MaybePromise<readonly T[] | null> | null),
 ): Promise<
-  Merge<
-    ArrayConnectionShape<
-      SchemaTypes,
-      NonNullable<T>,
-      U extends NonNullable<U> ? (Promise<null> extends U ? true : false) : true,
-      T extends NonNullable<T> ? false : { list: false; items: true },
-      false
-    > & { totalCount: C }
-  >
+  | Merge<
+      ArrayConnectionShape<
+        SchemaTypes,
+        NonNullable<T>,
+        false,
+        T extends NonNullable<T> ? false : { list: false; items: true },
+        false
+      > & { totalCount: C }
+    >
+  | ConnectionNullability<U>
 > {
   const { limit, offset, expectedSize, hasPreviousPage, hasNextPage } = offsetForArgs(options);
 
@@ -207,15 +218,6 @@ export { parseCursorConnectionArgs } from '@pothos/core';
 type NodeType<T> = T extends readonly (infer N)[] | Promise<readonly (infer N)[] | null>
   ? N
   : never;
-
-/**
- * `null` when the resolver can return `null` (directly or from its promise), `never` otherwise.
- *
- * This is kept outside of `Merge`, which collapses `null` out of a union because `null & {}` is
- * `never`.
- */
-type ConnectionNullability<U> =
-  U extends NonNullable<U> ? (Promise<null> extends U ? null : never) : null;
 
 export async function resolveCursorConnection<
   U extends Promise<readonly unknown[] | null> | readonly unknown[] | null,

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -42,9 +42,11 @@ type IsAny<T> = 0 extends 1 & T ? true : false;
 /**
  * `null` when the resolver can return `null` (directly or from its promise), `never` otherwise.
  *
- * This has to be unioned in outside of `Merge`. `Merge` is a homomorphic mapped type intersected
- * with `{}`, so it distributes over unions and collapses the nullable member away: `null & {}` is
- * `never`.
+ * This is unioned in at the outermost level rather than passed to `ArrayConnectionShape`'s
+ * `Nullable` parameter, because intersecting a possibly-null union with an object type drops the
+ * null member. `resolveOffsetConnection` used to declare this derivation inline and it never
+ * reached callers, because `& { totalCount: C }` was applied on top of it. `Merge` is not the
+ * culprit and does preserve null; the hazard is the intersection, so keep this out of one.
  *
  * `any` is excluded deliberately. It satisfies both branches of every conditional below, and
  * `Promise<null> extends Promise<any>` is true, so an `any`-typed resolver would be reported as

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -60,7 +60,9 @@ export function offsetForArgs(options: ResolveOffsetConnectionOptions) {
   let endOffset = before
     ? Math.max(beforeOffset, startOffset)
     : options.totalCount != null
-      ? Math.max(options.totalCount, 0)
+      ? // A previously valid cursor can point past the end of a collection that has since
+        // shrunk. Clamping to `startOffset` keeps that window empty rather than negative.
+        Math.max(options.totalCount, startOffset)
       : Number.POSITIVE_INFINITY;
 
   if (first != null) {

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -204,7 +204,9 @@ export function resolveArrayConnection<T>(
 
 export { parseCursorConnectionArgs } from '@pothos/core';
 
-type NodeType<T> = T extends (infer N)[] | Promise<(infer N)[] | null> | null ? N : never;
+type NodeType<T> = T extends readonly (infer N)[] | Promise<readonly (infer N)[] | null> | null
+  ? N
+  : never;
 
 export async function resolveCursorConnection<
   U extends Promise<readonly unknown[] | null> | readonly unknown[] | null,

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -36,15 +36,31 @@ interface ResolveArrayConnectionOptions {
   maxSize?: number;
 }
 
+/** `true` only for `any`, which otherwise matches both branches of a conditional type. */
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
 /**
  * `null` when the resolver can return `null` (directly or from its promise), `never` otherwise.
  *
  * This has to be unioned in outside of `Merge`. `Merge` is a homomorphic mapped type intersected
  * with `{}`, so it distributes over unions and collapses the nullable member away: `null & {}` is
  * `never`.
+ *
+ * `any` is excluded deliberately. It satisfies both branches of every conditional below, and
+ * `Promise<null> extends Promise<any>` is true, so an `any`-typed resolver would be reported as
+ * nullable even though such code never sees a null and compiled before nullability was derived
+ * at all.
  */
 type ConnectionNullability<U> =
-  U extends NonNullable<U> ? (Promise<null> extends U ? null : never) : null;
+  IsAny<U> extends true
+    ? never
+    : IsAny<Awaited<U>> extends true
+      ? never
+      : U extends NonNullable<U>
+        ? Promise<null> extends U
+          ? null
+          : never
+        : null;
 
 const OFFSET_CURSOR_PREFIX = 'OffsetConnection:';
 const DEFAULT_MAX_SIZE = 100;

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -66,14 +66,16 @@ export function offsetForArgs(options: ResolveOffsetConnectionOptions) {
     throw new PothosValidationError('Argument "last" must be a non-negative integer');
   }
 
+  const endOfCollection =
+    options.totalCount != null ? Math.max(options.totalCount, 0) : Number.POSITIVE_INFINITY;
+
   let startOffset = after ? afterOffset + 1 : 0;
-  let endOffset = before
-    ? Math.max(beforeOffset, startOffset)
-    : options.totalCount != null
-      ? // A previously valid cursor can point past the end of a collection that has since
-        // shrunk. Clamping to `startOffset` keeps that window empty rather than negative.
-        Math.max(options.totalCount, startOffset)
-      : Number.POSITIVE_INFINITY;
+  // A cursor that was valid before the collection shrank can now point past the end of it, in
+  // either direction. Clamping to the known size keeps the window inside the collection: a stale
+  // `before` cursor still pages off the real end, and a stale `after` cursor yields an empty
+  // window rather than a negative one. `beforeOffset` is already `Infinity` when `before` is
+  // absent, so the same expression covers both.
+  let endOffset = Math.max(Math.min(beforeOffset, endOfCollection), startOffset);
 
   if (first != null) {
     endOffset = Math.min(endOffset, startOffset + first);

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -38,8 +38,8 @@ interface ResolveArrayConnectionOptions {
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
 
-// Unioned into the return types rather than passed as `ArrayConnectionShape`'s `Nullable`:
-// intersecting a possibly-null union with an object type drops the null member.
+// Unioned in, not passed as `ArrayConnectionShape`'s `Nullable`: intersecting a nullable union
+// with an object type drops the `null` member.
 type ConnectionNullability<U> =
   IsAny<U> extends true
     ? never

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -72,7 +72,9 @@ export function offsetForArgs(options: ResolveOffsetConnectionOptions) {
         'Argument "last" can only be used in combination with "before" or "first"',
       );
     }
-    startOffset = Math.max(startOffset, endOffset - last);
+    // Cap the backward page size before deriving the start offset so that trimming for
+    // `maxSize` keeps the last requested items rather than sliding the window backwards.
+    startOffset = Math.max(startOffset, endOffset - Math.min(last, maxSize));
   }
 
   const size = first == null && last == null ? defaultSize : endOffset - startOffset;

--- a/packages/plugin-relay/src/utils/connections.ts
+++ b/packages/plugin-relay/src/utils/connections.ts
@@ -38,8 +38,6 @@ interface ResolveArrayConnectionOptions {
 
 type IsAny<T> = 0 extends 1 & T ? true : false;
 
-// Unioned in, not passed as `ArrayConnectionShape`'s `Nullable`: intersecting a nullable union
-// with an object type drops the `null` member.
 type ConnectionNullability<U> =
   IsAny<U> extends true
     ? never

--- a/packages/plugin-relay/src/utils/resolve-nodes.ts
+++ b/packages/plugin-relay/src/utils/resolve-nodes.ts
@@ -19,7 +19,9 @@ export async function resolveNodes<Types extends SchemaTypes>(
   globalIDs: ({ id: unknown; typename: string } | null | undefined)[],
 ): Promise<MaybePromise<unknown>[]> {
   const requestCache = getRequestCache(context);
-  const idsByType: Record<string, Set<unknown>> = {};
+  // Keyed by typename, so this must not inherit keys like `constructor` or `toString`,
+  // which are valid GraphQL type names.
+  const idsByType = new Map<string, Set<unknown>>();
   const results: Record<string, MaybePromise<unknown>> = {};
 
   for (const globalID of globalIDs) {
@@ -35,13 +37,19 @@ export async function resolveNodes<Types extends SchemaTypes>(
       continue;
     }
 
-    idsByType[typename] = idsByType[typename] ?? new Set();
-    idsByType[typename].add(id);
+    let idsForType = idsByType.get(typename);
+
+    if (!idsForType) {
+      idsForType = new Set();
+      idsByType.set(typename, idsForType);
+    }
+
+    idsForType.add(id);
   }
 
   await Promise.all(
-    Object.keys(idsByType).map(async (typename) => {
-      const ids = [...idsByType[typename]];
+    [...idsByType].map(async ([typename, idsForType]) => {
+      const ids = [...idsForType];
 
       const config = builder.configStore.getTypeConfig(typename, 'Object');
       const options = config.pothosOptions as NodeObjectOptions<Types, ObjectParam<Types>, []>;

--- a/packages/plugin-relay/src/utils/resolve-nodes.ts
+++ b/packages/plugin-relay/src/utils/resolve-nodes.ts
@@ -19,8 +19,7 @@ export async function resolveNodes<Types extends SchemaTypes>(
   globalIDs: ({ id: unknown; typename: string } | null | undefined)[],
 ): Promise<MaybePromise<unknown>[]> {
   const requestCache = getRequestCache(context);
-  // Keyed by typename, so this must not inherit keys like `constructor` or `toString`,
-  // which are valid GraphQL type names.
+  // A `Map`, not an object: `constructor` and `toString` are valid GraphQL type names.
   const idsByType = new Map<string, Set<unknown>>();
   const results: Record<string, MaybePromise<unknown>> = {};
 

--- a/packages/plugin-relay/src/utils/resolve-nodes.ts
+++ b/packages/plugin-relay/src/utils/resolve-nodes.ts
@@ -19,7 +19,6 @@ export async function resolveNodes<Types extends SchemaTypes>(
   globalIDs: ({ id: unknown; typename: string } | null | undefined)[],
 ): Promise<MaybePromise<unknown>[]> {
   const requestCache = getRequestCache(context);
-  // A `Map`, not an object: `constructor` and `toString` are valid GraphQL type names.
   const idsByType = new Map<string, Set<unknown>>();
   const results: Record<string, MaybePromise<unknown>> = {};
 

--- a/packages/plugin-relay/tests/connections.test-d.ts
+++ b/packages/plugin-relay/tests/connections.test-d.ts
@@ -91,3 +91,33 @@ it('preserves nullable items from the cursor resolver result', async () => {
   expectTypeOf(result).not.toBeNullable();
   expectTypeOf(result.edges[0]?.node).toEqualTypeOf<{ id: string } | null>();
 });
+
+// An `any` resolver never returns null as far as the type system is concerned, and it compiled
+// before nullability was derived at all. Deriving it must not make these stop compiling.
+it('leaves an `any` resolver result non-nullable', async () => {
+  // biome-ignore lint/suspicious/noExplicitAny: the point of the fixture
+  const anyRows: () => any = () => [{ id: '1' }];
+
+  const offset = await resolveOffsetConnection({ args: { first: 1 } }, anyRows);
+  const cursor = await resolveCursorConnection(
+    { args: { first: 1 }, toCursor: () => 'x' },
+    anyRows,
+  );
+
+  expectTypeOf(offset).not.toBeNullable();
+  expectTypeOf(cursor).not.toBeNullable();
+});
+
+it('leaves a `Promise<any>` resolver result non-nullable', async () => {
+  // biome-ignore lint/suspicious/noExplicitAny: the point of the fixture
+  const anyRows: () => Promise<any> = async () => [{ id: '1' }];
+
+  const offset = await resolveOffsetConnection({ args: { first: 1 } }, anyRows);
+  const cursor = await resolveCursorConnection(
+    { args: { first: 1 }, toCursor: () => 'x' },
+    anyRows,
+  );
+
+  expectTypeOf(offset).not.toBeNullable();
+  expectTypeOf(cursor).not.toBeNullable();
+});

--- a/packages/plugin-relay/tests/connections.test-d.ts
+++ b/packages/plugin-relay/tests/connections.test-d.ts
@@ -1,5 +1,44 @@
 import { expectTypeOf, it } from 'vitest';
-import { resolveCursorConnection } from '../src';
+import { resolveCursorConnection, resolveOffsetConnection } from '../src';
+
+it('types an offset resolver that cannot return null as a non-null connection', async () => {
+  const result = await resolveOffsetConnection({ args: { first: 1 } }, () => [{ id: '1' }]);
+
+  expectTypeOf(result).not.toBeNullable();
+  expectTypeOf(result.edges[0]?.node).toEqualTypeOf<{ id: string }>();
+});
+
+it('types an offset resolver that can return null as a nullable connection', async () => {
+  const result = await resolveOffsetConnection(
+    { args: { first: 1 } },
+    (): { id: string }[] | null => null,
+  );
+
+  expectTypeOf(result).toBeNullable();
+
+  // @ts-expect-error `result` may be null at runtime, so it has to be guarded first.
+  const unguarded: unknown = result.edges;
+
+  expectTypeOf(unguarded).toBeUnknown();
+
+  if (result) {
+    expectTypeOf(result.edges[0]?.node).toEqualTypeOf<{ id: string }>();
+  }
+});
+
+it('types an async offset resolver that can return null as a nullable connection', async () => {
+  const result = await resolveOffsetConnection(
+    { args: { first: 1 } },
+    async (): Promise<{ id: string }[] | null> => null,
+  );
+
+  expectTypeOf(result).toBeNullable();
+
+  // @ts-expect-error `result` may be null at runtime, so it has to be guarded first.
+  const unguarded: unknown = result.edges;
+
+  expectTypeOf(unguarded).toBeUnknown();
+});
 
 it('types a cursor resolver that cannot return null as a non-null connection', async () => {
   const result = await resolveCursorConnection(

--- a/packages/plugin-relay/tests/connections.test-d.ts
+++ b/packages/plugin-relay/tests/connections.test-d.ts
@@ -92,8 +92,6 @@ it('preserves nullable items from the cursor resolver result', async () => {
   expectTypeOf(result.edges[0]?.node).toEqualTypeOf<{ id: string } | null>();
 });
 
-// An `any` resolver never returns null as far as the type system is concerned, and it compiled
-// before nullability was derived at all. Deriving it must not make these stop compiling.
 it('leaves an `any` resolver result non-nullable', async () => {
   // biome-ignore lint/suspicious/noExplicitAny: the point of the fixture
   const anyRows: () => any = () => [{ id: '1' }];

--- a/packages/plugin-relay/tests/connections.test-d.ts
+++ b/packages/plugin-relay/tests/connections.test-d.ts
@@ -1,0 +1,54 @@
+import { expectTypeOf, it } from 'vitest';
+import { resolveCursorConnection } from '../src';
+
+it('types a cursor resolver that cannot return null as a non-null connection', async () => {
+  const result = await resolveCursorConnection(
+    { args: { first: 1 }, toCursor: (row) => row.id },
+    () => [{ id: '1' }],
+  );
+
+  expectTypeOf(result).not.toBeNullable();
+  expectTypeOf(result.edges[0]?.node).toEqualTypeOf<{ id: string }>();
+});
+
+it('types a cursor resolver that can return null as a nullable connection', async () => {
+  const result = await resolveCursorConnection(
+    { args: { first: 1 }, toCursor: (row) => row.id },
+    (): { id: string }[] | null => null,
+  );
+
+  expectTypeOf(result).toBeNullable();
+
+  // @ts-expect-error `result` may be null at runtime, so it has to be guarded first.
+  const unguarded: unknown = result.edges;
+
+  expectTypeOf(unguarded).toBeUnknown();
+
+  if (result) {
+    expectTypeOf(result.edges[0]?.node).toEqualTypeOf<{ id: string }>();
+  }
+});
+
+it('types an async cursor resolver that can return null as a nullable connection', async () => {
+  const result = await resolveCursorConnection(
+    { args: { first: 1 }, toCursor: (row) => row.id },
+    async (): Promise<{ id: string }[] | null> => null,
+  );
+
+  expectTypeOf(result).toBeNullable();
+
+  // @ts-expect-error `result` may be null at runtime, so it has to be guarded first.
+  const unguarded: unknown = result.edges;
+
+  expectTypeOf(unguarded).toBeUnknown();
+});
+
+it('preserves nullable items from the cursor resolver result', async () => {
+  const result = await resolveCursorConnection(
+    { args: { first: 1 }, toCursor: (row) => String(row?.id) },
+    () => [{ id: '1' }, null] as ({ id: string } | null)[],
+  );
+
+  expectTypeOf(result).not.toBeNullable();
+  expectTypeOf(result.edges[0]?.node).toEqualTypeOf<{ id: string } | null>();
+});

--- a/packages/plugin-relay/tests/connections.test.ts
+++ b/packages/plugin-relay/tests/connections.test.ts
@@ -1,9 +1,36 @@
-import { resolveArrayConnection } from '../src';
+import { offsetToCursor, resolveArrayConnection, resolveOffsetConnection } from '../src';
 
 describe('resolveArrayConnection', () => {
   it('caps backward pages from the end of the requested window', () => {
     const result = resolveArrayConnection({ args: { last: 3 }, maxSize: 2 }, [0, 1, 2, 3, 4]);
 
     expect(result.edges.map((edge) => edge?.node)).toEqual([3, 4]);
+  });
+
+  it('returns an empty page when a stale after cursor is past the end of the array', () => {
+    // Offset 4 was a valid cursor before the collection shrank to two rows.
+    const result = resolveArrayConnection({ args: { after: offsetToCursor(4), first: 2 } }, [0, 1]);
+
+    expect(result.edges).toEqual([]);
+    expect(result.pageInfo.hasNextPage).toBe(false);
+  });
+});
+
+describe('resolveOffsetConnection', () => {
+  it('never requests a negative limit when a stale after cursor is past totalCount', async () => {
+    let requested: { offset: number; limit: number } | undefined;
+
+    const result = await resolveOffsetConnection(
+      { args: { after: offsetToCursor(4), first: 2 }, totalCount: 2 },
+      (params) => {
+        requested = params;
+
+        return [];
+      },
+    );
+
+    expect(requested?.limit).toBeGreaterThanOrEqual(0);
+    expect(result.edges).toEqual([]);
+    expect(result.pageInfo.hasNextPage).toBe(false);
   });
 });

--- a/packages/plugin-relay/tests/connections.test.ts
+++ b/packages/plugin-relay/tests/connections.test.ts
@@ -51,4 +51,15 @@ describe('resolveCursorConnection', () => {
 
     expect(result.edges.map((edge) => edge?.node.id)).toEqual(['1']);
   });
+
+  it('returns null when the resolver returns null', async () => {
+    const result = await resolveCursorConnection(
+      { args: { first: 1 }, toCursor: (row) => row.id },
+      (): { id: string }[] | null => null,
+    );
+
+    expect(result).toBeNull();
+    // Reading `edges` without guarding throws, so the return type has to stay nullable.
+    expect(() => result!.edges).toThrow(TypeError);
+  });
 });

--- a/packages/plugin-relay/tests/connections.test.ts
+++ b/packages/plugin-relay/tests/connections.test.ts
@@ -1,4 +1,9 @@
-import { offsetToCursor, resolveArrayConnection, resolveOffsetConnection } from '../src';
+import {
+  offsetToCursor,
+  resolveArrayConnection,
+  resolveCursorConnection,
+  resolveOffsetConnection,
+} from '../src';
 
 describe('resolveArrayConnection', () => {
   it('caps backward pages from the end of the requested window', () => {
@@ -32,5 +37,18 @@ describe('resolveOffsetConnection', () => {
     expect(requested?.limit).toBeGreaterThanOrEqual(0);
     expect(result.edges).toEqual([]);
     expect(result.pageInfo.hasNextPage).toBe(false);
+  });
+});
+
+describe('resolveCursorConnection', () => {
+  it('infers the node type from a readonly array of rows', async () => {
+    const rows: readonly { id: string }[] = [{ id: '1' }, { id: '2' }];
+
+    const result = await resolveCursorConnection(
+      { args: { first: 1 }, toCursor: (row) => row.id },
+      () => rows,
+    );
+
+    expect(result.edges.map((edge) => edge?.node.id)).toEqual(['1']);
   });
 });

--- a/packages/plugin-relay/tests/connections.test.ts
+++ b/packages/plugin-relay/tests/connections.test.ts
@@ -38,6 +38,17 @@ describe('resolveOffsetConnection', () => {
     expect(result.edges).toEqual([]);
     expect(result.pageInfo.hasNextPage).toBe(false);
   });
+
+  it('returns null when the resolver returns null', async () => {
+    const result = await resolveOffsetConnection(
+      { args: { first: 1 } },
+      (): { id: string }[] | null => null,
+    );
+
+    expect(result).toBeNull();
+    // Reading `edges` without guarding throws, so the return type has to stay nullable.
+    expect(() => result!.edges).toThrow(TypeError);
+  });
 });
 
 describe('resolveCursorConnection', () => {

--- a/packages/plugin-relay/tests/connections.test.ts
+++ b/packages/plugin-relay/tests/connections.test.ts
@@ -13,7 +13,6 @@ describe('resolveArrayConnection', () => {
   });
 
   it('returns an empty page when a stale after cursor is past the end of the array', () => {
-    // Offset 4 was a valid cursor before the collection shrank to two rows.
     const result = resolveArrayConnection({ args: { after: offsetToCursor(4), first: 2 } }, [0, 1]);
 
     expect(result.edges).toEqual([]);
@@ -21,8 +20,6 @@ describe('resolveArrayConnection', () => {
   });
 
   it('returns the rows that exist when a stale before cursor is past the end of the array', () => {
-    // The mirror of the stale `after` case: offset 6 was a valid cursor before the collection
-    // shrank to four rows, so the backward page has to come off the real end of the array.
     const result = resolveArrayConnection(
       { args: { before: offsetToCursor(6), last: 4 }, maxSize: 2 },
       [0, 1, 2, 3],
@@ -86,7 +83,6 @@ describe('resolveOffsetConnection', () => {
     );
 
     expect(result).toBeNull();
-    // Reading `edges` without guarding throws, so the return type has to stay nullable.
     expect(() => result!.edges).toThrow(TypeError);
   });
 });
@@ -110,7 +106,6 @@ describe('resolveCursorConnection', () => {
     );
 
     expect(result).toBeNull();
-    // Reading `edges` without guarding throws, so the return type has to stay nullable.
     expect(() => result!.edges).toThrow(TypeError);
   });
 });

--- a/packages/plugin-relay/tests/connections.test.ts
+++ b/packages/plugin-relay/tests/connections.test.ts
@@ -1,0 +1,9 @@
+import { resolveArrayConnection } from '../src';
+
+describe('resolveArrayConnection', () => {
+  it('caps backward pages from the end of the requested window', () => {
+    const result = resolveArrayConnection({ args: { last: 3 }, maxSize: 2 }, [0, 1, 2, 3, 4]);
+
+    expect(result.edges.map((edge) => edge?.node)).toEqual([3, 4]);
+  });
+});

--- a/packages/plugin-relay/tests/connections.test.ts
+++ b/packages/plugin-relay/tests/connections.test.ts
@@ -19,9 +19,49 @@ describe('resolveArrayConnection', () => {
     expect(result.edges).toEqual([]);
     expect(result.pageInfo.hasNextPage).toBe(false);
   });
+
+  it('returns the rows that exist when a stale before cursor is past the end of the array', () => {
+    // The mirror of the stale `after` case: offset 6 was a valid cursor before the collection
+    // shrank to four rows, so the backward page has to come off the real end of the array.
+    const result = resolveArrayConnection(
+      { args: { before: offsetToCursor(6), last: 4 }, maxSize: 2 },
+      [0, 1, 2, 3],
+    );
+
+    expect(result.edges.map((edge) => edge?.node)).toEqual([2, 3]);
+  });
+
+  it('caps a backward page against the array when a stale before cursor is past the end', () => {
+    const result = resolveArrayConnection(
+      { args: { before: offsetToCursor(3), last: 2 }, maxSize: 1 },
+      [0, 1],
+    );
+
+    expect(result.edges.map((edge) => edge?.node)).toEqual([1]);
+  });
+
+  it('still honours a before cursor that is inside the array', () => {
+    const result = resolveArrayConnection(
+      { args: { before: offsetToCursor(3), last: 2 } },
+      [0, 1, 2, 3, 4],
+    );
+
+    expect(result.edges.map((edge) => edge?.node)).toEqual([1, 2]);
+  });
 });
 
 describe('resolveOffsetConnection', () => {
+  it('returns the rows that exist when a stale before cursor is past totalCount', async () => {
+    const rows = [0, 1, 2, 3];
+
+    const result = await resolveOffsetConnection(
+      { args: { before: offsetToCursor(6), last: 4 }, maxSize: 2, totalCount: rows.length },
+      ({ offset, limit }) => rows.slice(offset, offset + limit),
+    );
+
+    expect(result.edges.map((edge) => edge?.node)).toEqual([2, 3]);
+  });
+
   it('never requests a negative limit when a stale after cursor is past totalCount', async () => {
     let requested: { offset: number; limit: number } | undefined;
 

--- a/packages/plugin-relay/tests/resolve-nodes.test.ts
+++ b/packages/plugin-relay/tests/resolve-nodes.test.ts
@@ -1,0 +1,33 @@
+import SchemaBuilder from '@pothos/core';
+import { graphql } from 'graphql';
+import RelayPlugin, { encodeGlobalID } from '../src';
+
+describe('resolveNodes', () => {
+  it.each([
+    'constructor',
+    'toString',
+    'hasOwnProperty',
+  ])('loads nodes for a type named %s', async (typename) => {
+    const builder = new SchemaBuilder<{}>({ plugins: [RelayPlugin] });
+
+    const ref = builder.objectRef<{ id: string }>(typename);
+
+    builder.node(ref, {
+      id: { resolve: (value) => value.id },
+      loadOne: (id) => ({ id: String(id) }),
+      fields: () => ({}),
+    });
+
+    builder.queryType({});
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: 'query($id: ID!) { node(id: $id) { id } }',
+      variableValues: { id: encodeGlobalID(typename, '1') },
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ node: { id: encodeGlobalID(typename, '1') } });
+  });
+});


### PR DESCRIPTION
Addresses 5 of the 6 findings from the `@pothos/plugin-relay` review, plus one sibling bug found while fixing them. Each fix has a test that was confirmed failing for the stated reason before the fix landed; one commit per finding.

### 1. Backward page capping moved the wrong boundary (P2)

`offsetForArgs` derived `startOffset` from the **uncapped** `last` argument and only then truncated `endOffset` to satisfy `maxSize`, which slid the window backwards instead of trimming it.

`resolveArrayConnection({ args: { last: 3 }, maxSize: 2 }, [0, 1, 2, 3, 4])` returned `[2, 3]` instead of the last two items `[3, 4]`.

**Fix** (`src/utils/connections.ts`): clamp `last` to `maxSize` *before* deriving the start offset.

**Verified**: `tests/connections.test.ts` — "caps backward pages from the end of the requested window". Failed with `expected [ 2, 3 ] to deeply equal [ 3, 4 ]` before the fix.

### 2. A stale offset cursor yielded negative limits (P2)

`offsetForArgs` allowed `totalCount` to fall below the offset derived from an `after` cursor — e.g. a cursor that was valid before rows were deleted. The window went negative, so `resolveOffsetConnection` passed `limit: -2` straight to the user's resolver (and therefore to their database), and both it and `resolveArrayConnection` reported `hasNextPage: true` for an empty page.

**Fix** (`src/utils/connections.ts`): clamp the window to the known size of the collection, in both directions. `beforeOffset` is already `Infinity` when no `before` cursor is given, so a single expression covers a stale `after` cursor (which used to invert the window) and a stale `before` cursor (which used to run it off the end):

```ts
let endOffset = Math.max(Math.min(beforeOffset, endOfCollection), startOffset);
```

The `before` half of this landed in a follow-up commit after review caught that the first attempt clamped only the `totalCount` branch. With `last` present, `maxSize < last`, and a `before` cursor past the end, the window fell entirely out of range and returned an empty page where rows existed — `{ before: cursor(6), last: 4 }, maxSize: 2` over `[0, 1, 2, 3]` gave `[]` instead of `[2, 3]`.

**Verified**: `tests/connections.test.ts` — stale `after` and stale `before` cases, plus an in-range `before` control. Failed with `expected -2 to be greater than or equal to 0`, `expected true to be false` and `expected [] to deeply equal [ 2, 3 ]` before their respective fixes.

An exhaustive differential of `offsetForArgs` + `resolveArrayConnection` against `origin/main` across `first`/`last`/`after`/`before`/`maxSize` and array sizes 0–5 covers **69,120 combinations: 2,029 differ, and none return fewer nodes than before.**

### 3. Valid node type names collided with inherited object keys (P2)

`resolveNodes` grouped ids in a plain object keyed by GraphQL typename. Node types whose names exist on `Object.prototype` — `constructor`, `toString`, `hasOwnProperty` — read the inherited value instead of a `Set`.

**Fix** (`src/utils/resolve-nodes.ts`): use a `Map` for the grouping.

**Verified**: `tests/resolve-nodes.test.ts`, parameterised over all three names. Each failed with `idsByType[typename].add is not a function` before the fix.

### 4. Readonly cursor resolver arrays inferred `never` (P2)

`resolveCursorConnection` accepts a resolver returning `readonly unknown[]`, but its internal `NodeType` helper only matched mutable arrays, so a readonly result inferred `never`.

**Fix** (`src/utils/connections.ts`): match readonly arrays in `NodeType`. Mutable arrays remain assignable to `readonly T[]`, so no existing inference changes.

**Verified**: `tests/connections.test.ts` — "infers the node type from a readonly array of rows". `pnpm --filter @pothos/plugin-relay run type` reported `TS2339: Property 'id' does not exist on type 'never'` at both `toCursor: (row) => row.id` and `edge?.node.id` before the fix; clean after.

### 5. Nullable cursor results were typed as non-null connections (P2)

`resolveCursorConnection` hardcoded a non-null return shape even though it accepts a resolver that returns `null` and passes that `null` straight back through (`if (!nodes) return nodes as never`). Strictly typed code could read `result.edges` unguarded, compile, and throw at runtime.

Two things were needed:

- The nullability is now derived from the resolver's return type and unioned in at the outermost level, rather than passed to `ArrayConnectionShape`'s `Nullable` parameter. For this helper `Nullable` was simply hardcoded `false`, so nothing was ever declared to collapse.
- `NodeType` no longer matches the bare `null` member of the resolver's return type. Previously a resolver typed `() => T[] | null` widened the node type to `unknown` (the `null` branch contributed no `infer` candidate), leaving `toCursor` untyped. Nullable *items* are unaffected and still come through as a nullable `node`.

**Verified**: new `tests/connections.test-d.ts` plus a runtime test in `tests/connections.test.ts`.

Before the fix, the type fixture reported:

```
tests/connections.test-d.ts(16,46): error TS18046: 'row' is of type 'unknown'.
tests/connections.test-d.ts(20,24): error TS2349: This expression is not callable.
tests/connections.test-d.ts(22,3): error TS2578: Unused '@ts-expect-error' directive.
tests/connections.test-d.ts(28,55): error TS2344: Type '{ id: string; }' does not satisfy the constraint '"Expected: ..., Actual: unknown"'.
tests/connections.test-d.ts(38,24): error TS2349: This expression is not callable.
tests/connections.test-d.ts(40,3): error TS2578: Unused '@ts-expect-error' directive.
```

The two `Unused '@ts-expect-error' directive` errors *are* the bug: unguarded `result.edges` on a `null`-returning resolver compiled. `This expression is not callable` is `expectTypeOf(result).toBeNullable()`, which vitest only exposes when the type really is nullable. After the fix the fixture compiles clean, and the runtime test shows the same call returning `null` and throwing a `TypeError` on unguarded `.edges`.

This ships as a **patch**: it corrects a type that never matched runtime, so code written against the old type was already crashing. To check that it does not break code that legitimately compiles today, `pnpm turbo run type --filter='@pothos/*'` was run across the whole repo — all 54 type tasks pass, including the website package, which typechecks every documentation example.

### 6. The same nullability bug in `resolveOffsetConnection` (found while fixing #5)

Not one of the six review findings — it surfaced while fixing #5, and was confirmed in scope afterwards.

`resolveOffsetConnection` *already declared* the correct derivation:

```ts
U extends NonNullable<U> ? (Promise<null> extends U ? true : false) : true,
```

It just never reached callers: **intersecting a possibly-null union with an object type drops the null member**, and `& { totalCount: C }` is applied on top of it. So the declared intent had been right all along and silently ineffective — `resolveOffsetConnection({ args: { first: 1 } }, () => null)` typed as a non-null connection.

An earlier revision of this PR blamed `Merge` for the collapse. That was wrong, and is corrected in `858bd4e9f`. Verified against the real `Merge` and `ArrayConnectionShape` under TypeScript 7.0.2:

```ts
type Nullable = ArrayConnectionShape<SchemaTypes, Row, true, false, false>;
export const a: Merge<Nullable> = null;                          // compiles — Merge keeps null
export const c: Nullable & { totalCount: undefined } = null;     // errors — collapses without Merge
```

The real hazard is the intersection, which still lurks anywhere `& { totalCount: C }` or `& NonNullable<Resolved>` is applied to a nullable union. Unioning the nullability in at the outermost level sidesteps it.

**Fix** (`src/utils/connections.ts`): union the nullability in at the outermost level, matching `resolveCursorConnection`, and hoist the shared `ConnectionNullability<U>` helper so both use it.

**The `NodeType` half of #5 was not needed here**, which is worth recording. `resolveOffsetConnection` infers `T` as its own type parameter from `readonly T[]` inside the resolver's parameter type, rather than running the result through a conditional with a bare `null` member. So a `T[] | null` resolver never widened the node type to `unknown`, and `toEqualTypeOf<{ id: string }>()` on `edges[0]?.node` passed both before and after.

**Verified**: `tests/connections.test-d.ts` and a runtime test. Before the fix:

```
tests/connections.test-d.ts(17,24): error TS2349: This expression is not callable.
tests/connections.test-d.ts(19,3): error TS2578: Unused '@ts-expect-error' directive.
tests/connections.test-d.ts(35,24): error TS2349: This expression is not callable.
tests/connections.test-d.ts(37,3): error TS2578: Unused '@ts-expect-error' directive.
```

Same tell as #5: the unused `@ts-expect-error` directives mean unguarded `result.edges` compiled on a `null`-returning resolver, and `toBeNullable()` was not callable because the type was not nullable. No errors on the node-type assertions, confirming the paragraph above. Clean after the fix.

### 7. `any`-typed resolvers were caught by the new nullability (fixed in review)

Review caught that the derivation in #5/#6 was a patch-level break for one case. A distributive conditional takes **both** branches for `any`, and `Promise<null> extends Promise<any>` is true, so `() => any` and `() => Promise<any>` were both reported nullable:

```ts
declare const anyResolver: () => any;
const r = await resolveOffsetConnection({ args: { first: 1 } }, anyResolver);
r.edges;  // TS18047: 'r' is possibly 'null'
```

That code compiles on `main`, never returns null and has no runtime bug, so it must not stop compiling on a patch release. `() => any[]` was never affected.

**Fix** (`src/utils/connections.ts`): guard `ConnectionNullability` with an `any` check on both the resolver's return type and its awaited type (`0 extends 1 & T`).

**Verified**: fixtures pinning `any` and `Promise<any>` for both helpers in `tests/connections.test-d.ts`. All four combinations reported the type as nullable before the guard; clean after. The repo-wide typecheck could not have caught this, because no in-repo consumer uses an `any`-typed resolver.

## Known follow-up, deliberately not in this PR

`resolveCursorConnection` types nullable items as a nullable `node` on a non-null edge (`node: T | null`), but the implementation emits `value == null ? null : { ... }` — a **null edge**, not an edge with a null node. `resolveOffsetConnection` models this correctly, with `NonNullable<T>` plus `{ list: false, items: true }`. Aligning the two would turn `node: T | null` into `edge | null`, a wider blast radius than anything here, so it is left alone and recorded so it is not lost.

## Not addressed here

Only the **P1 "Distinct parsed node IDs return the same entity"** finding (`src/utils/resolve-nodes.ts`) remains out of scope. Request-cache and local-result keys interpolate arbitrary parsed IDs, so `{ key: 1 }` and `{ key: 2 }` both stringify to `[object Object]`, and two `Date` values within the same second collide as well. Fixing it means changing how parsed IDs become identity keys across grouping, results, and the request cache; a separate design doc is being written for it, so `resolve-nodes.ts` is untouched here apart from the `Map` change in finding 3.

## Verification

- `pnpm --filter @pothos/plugin-relay run test` — 6 files, 45 tests passed (baseline was 3 files, 23 tests)
- `pnpm --filter @pothos/plugin-relay run type` — clean
- `pnpm biome check packages/plugin-relay` — clean
- `pnpm turbo run type --filter='...@pothos/plugin-relay'` — 49 tasks, all pass
- `pnpm turbo run type --force --filter='@pothos/*'` — all 54 type tasks pass, cache bypassed.
- `pnpm build && pnpm turbo run test --filter='@pothos/*'` — The only test failure is `@pothos/plugin-prisma-next#test`, which needs the docker-compose Postgres on port 5456 (`ECONNREFUSED 127.0.0.1:5456`); unrelated to these changes and failing the same way on `main`.

Changeset added at `.changeset/relay-review-fixes.md` (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
