### PR TITLE
fix(dataloader): address 3 findings from the plugin review

### DIFF
--- a/.changeset/dataloader-review-fixes.md
+++ b/.changeset/dataloader-review-fixes.md
@@ -1,0 +1,7 @@
+---
+"@pothos/plugin-dataloader": patch
+---
+
+Support iterable (non-array) results from list field resolvers in the loader wrappers
+Load ids nested inside lists of lists instead of only the outer list
+Preserve caller provided extensions on `loadableUnion`

--- a/.changeset/dataloader-review-fixes.md
+++ b/.changeset/dataloader-review-fixes.md
@@ -3,5 +3,5 @@
 ---
 
 Support iterable (non-array) results from list field resolvers in the loader wrappers
-Load ids nested inside lists of lists instead of only the outer list, passing `Error` values through so they are still reported at their own path
+Load ids nested inside lists of lists instead of only the outer list, keeping each list position's error and nullability boundary intact
 Preserve caller provided extensions on `loadableUnion`

--- a/.changeset/dataloader-review-fixes.md
+++ b/.changeset/dataloader-review-fixes.md
@@ -3,5 +3,5 @@
 ---
 
 Support iterable (non-array) results from list field resolvers in the loader wrappers
-Load ids nested inside lists of lists instead of only the outer list
+Load ids nested inside lists of lists instead of only the outer list, passing `Error` values through so they are still reported at their own path
 Preserve caller provided extensions on `loadableUnion`

--- a/packages/plugin-dataloader/src/field-builder.ts
+++ b/packages/plugin-dataloader/src/field-builder.ts
@@ -85,7 +85,10 @@ fieldBuilderProto.loadable = function loadable<
       const loader = getLoader(args, context, info);
 
       if (Array.isArray(type)) {
-        return rejectErrors((ids as Key[]).map((id) => (id == null ? id : loader.load(id))));
+        // list resolvers are allowed to return any Iterable, so consume it before mapping
+        const keys = Array.isArray(ids) ? (ids as Key[]) : [...(ids as unknown as Iterable<Key>)];
+
+        return rejectErrors(keys.map((id) => (id == null ? id : loader.load(id))));
       }
 
       return loader.load(ids as Key);

--- a/packages/plugin-dataloader/src/field-builder.ts
+++ b/packages/plugin-dataloader/src/field-builder.ts
@@ -11,6 +11,7 @@ import {
   type TypeParam,
 } from '@pothos/core';
 import type { GraphQLResolveInfo } from 'graphql';
+import { isIterableList } from './list-utils.js';
 import type {
   LoadableFieldOptions,
   LoadableGroupFieldOptions,
@@ -85,8 +86,14 @@ fieldBuilderProto.loadable = function loadable<
       const loader = getLoader(args, context, info);
 
       if (Array.isArray(type)) {
+        if (!isIterableList(ids)) {
+          // The field is a list but the resolver didn't return one. Hand the value back so
+          // graphql-js reports that, rather than loading keys that were never asked for.
+          return ids;
+        }
+
         // list resolvers are allowed to return any Iterable, so consume it before mapping
-        const keys = Array.isArray(ids) ? (ids as Key[]) : [...(ids as unknown as Iterable<Key>)];
+        const keys = Array.isArray(ids) ? (ids as Key[]) : [...(ids as Iterable<Key>)];
 
         return rejectErrors(keys.map((id) => (id == null ? id : loader.load(id))));
       }

--- a/packages/plugin-dataloader/src/field-builder.ts
+++ b/packages/plugin-dataloader/src/field-builder.ts
@@ -87,12 +87,9 @@ fieldBuilderProto.loadable = function loadable<
 
       if (Array.isArray(type)) {
         if (!isIterableList(ids)) {
-          // The field is a list but the resolver didn't return one. Hand the value back so
-          // graphql-js reports that, rather than loading keys that were never asked for.
           return ids;
         }
 
-        // list resolvers are allowed to return any Iterable, so consume it before mapping
         const keys = Array.isArray(ids) ? (ids as Key[]) : [...(ids as Iterable<Key>)];
 
         return rejectErrors(keys.map((id) => (id == null ? id : loader.load(id))));

--- a/packages/plugin-dataloader/src/index.ts
+++ b/packages/plugin-dataloader/src/index.ts
@@ -94,6 +94,12 @@ export class PothosDataloaderPlugin<Types extends SchemaTypes> extends BasePlugi
         return result;
       }
 
+      // An Error in a list position is how graphql-js is told to null that position and report the
+      // error at its own path, so it is passed through rather than being treated as a nested list.
+      if (result instanceof Error) {
+        return result;
+      }
+
       if (isThenable(result)) {
         return result.then((results) => loadResults(results, loader, depth));
       }

--- a/packages/plugin-dataloader/src/index.ts
+++ b/packages/plugin-dataloader/src/index.ts
@@ -10,18 +10,13 @@ import SchemaBuilder, {
 } from '@pothos/core';
 import type DataLoader from 'dataloader';
 import type { GraphQLFieldResolver } from 'graphql';
+import { isIterableList } from './list-utils.js';
 
 export * from './refs/index.js';
 export * from './types.js';
 export * from './util.js';
 
 const pluginName = 'dataloader';
-
-// Resolvers for list fields are allowed to return any Iterable. Strings are deliberately excluded
-// so a string returned where a list was expected is not spread into its characters.
-function isIterableList(value: unknown): value is Iterable<unknown> {
-  return typeof value === 'object' && value !== null && Symbol.iterator in value;
-}
 
 export class PothosDataloaderPlugin<Types extends SchemaTypes> extends BasePlugin<Types> {
   override wrapResolve(

--- a/packages/plugin-dataloader/src/index.ts
+++ b/packages/plugin-dataloader/src/index.ts
@@ -17,6 +17,22 @@ export * from './types.js';
 export * from './util.js';
 
 const pluginName = 'dataloader';
+
+// Resolvers for list fields are allowed to return any Iterable, but the loader wrappers below need
+// to be able to map over the results, so non-array iterables are consumed into an array first.
+// Anything that isn't iterable is passed through unchanged so it fails the way it did before.
+function toResolvedList(value: unknown): unknown[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+
+  if (typeof value === 'object' && value !== null && Symbol.iterator in value) {
+    return [...(value as Iterable<unknown>)];
+  }
+
+  return value as unknown[];
+}
+
 export class PothosDataloaderPlugin<Types extends SchemaTypes> extends BasePlugin<Types> {
   override wrapResolve(
     resolver: GraphQLFieldResolver<unknown, Types['Context'], object>,
@@ -65,14 +81,17 @@ export class PothosDataloaderPlugin<Types extends SchemaTypes> extends BasePlugi
       return (parent, args, context, info) => {
         const loader = getDataloader(context);
         const promiseOrResults = resolver(parent, args, context, info) as MaybePromise<
-          unknown[] | null | undefined
+          Iterable<unknown> | null | undefined
         >;
 
+        const loadList = (results: Iterable<unknown> | null | undefined) =>
+          results == null ? results : toResolvedList(results).map((item) => loadIfID(item, loader));
+
         if (isThenable(promiseOrResults)) {
-          return promiseOrResults.then((results) => results?.map((item) => loadIfID(item, loader)));
+          return promiseOrResults.then(loadList);
         }
 
-        return promiseOrResults?.map((item) => loadIfID(item, loader));
+        return loadList(promiseOrResults);
       };
     }
 

--- a/packages/plugin-dataloader/src/index.ts
+++ b/packages/plugin-dataloader/src/index.ts
@@ -65,8 +65,6 @@ export class PothosDataloaderPlugin<Types extends SchemaTypes> extends BasePlugi
       }
     }
 
-    // Follows the list shape the field was configured with, so that ids nested inside lists of
-    // lists are loaded rather than being treated as already loaded results.
     function loadResults(
       result: unknown,
       loader: DataLoader<unknown, unknown>,
@@ -80,8 +78,7 @@ export class PothosDataloaderPlugin<Types extends SchemaTypes> extends BasePlugi
         return result;
       }
 
-      // An Error in a list position is how graphql-js is told to null that position and report the
-      // error at its own path, so it is passed through rather than being treated as a nested list.
+      // An Error in a list position is how graphql-js is told to null that position.
       if (result instanceof Error) {
         return result;
       }
@@ -91,22 +88,16 @@ export class PothosDataloaderPlugin<Types extends SchemaTypes> extends BasePlugi
       }
 
       if (!isIterableList(result)) {
-        // The schema says this position is a list but the value isn't one. Hand it back unchanged
-        // so graphql-js reports that at this position, rather than throwing out of the whole field.
         return result;
       }
 
       const items = Array.isArray(result) ? result : [...result];
 
       return items.map((item) =>
-        // Only positions that are themselves lists can fail while being consumed. Leaf positions
-        // are never iterated, so they keep propagating the way they always have.
         depth > 1 ? loadNestedList(item, loader, depth - 1) : loadIfID(item, loader),
       );
     }
 
-    // Contains a failure at the list position it happened in, so graphql-js keeps its usual
-    // nullability boundary and the sibling rows survive.
     function loadNestedList(
       result: unknown,
       loader: DataLoader<unknown, unknown>,

--- a/packages/plugin-dataloader/src/index.ts
+++ b/packages/plugin-dataloader/src/index.ts
@@ -17,19 +17,10 @@ export * from './util.js';
 
 const pluginName = 'dataloader';
 
-// Resolvers for list fields are allowed to return any Iterable, but the loader wrappers below need
-// to be able to map over the results, so non-array iterables are consumed into an array first.
-// Anything that isn't iterable is passed through unchanged so it fails the way it did before.
-function toResolvedList(value: unknown): unknown[] {
-  if (Array.isArray(value)) {
-    return value;
-  }
-
-  if (typeof value === 'object' && value !== null && Symbol.iterator in value) {
-    return [...(value as Iterable<unknown>)];
-  }
-
-  return value as unknown[];
+// Resolvers for list fields are allowed to return any Iterable. Strings are deliberately excluded
+// so a string returned where a list was expected is not spread into its characters.
+function isIterableList(value: unknown): value is Iterable<unknown> {
+  return typeof value === 'object' && value !== null && Symbol.iterator in value;
 }
 
 export class PothosDataloaderPlugin<Types extends SchemaTypes> extends BasePlugin<Types> {
@@ -104,7 +95,33 @@ export class PothosDataloaderPlugin<Types extends SchemaTypes> extends BasePlugi
         return result.then((results) => loadResults(results, loader, depth));
       }
 
-      return toResolvedList(result).map((item) => loadResults(item, loader, depth - 1));
+      if (!isIterableList(result)) {
+        // The schema says this position is a list but the value isn't one. Hand it back unchanged
+        // so graphql-js reports that at this position, rather than throwing out of the whole field.
+        return result;
+      }
+
+      const items = Array.isArray(result) ? result : [...result];
+
+      return items.map((item) =>
+        // Only positions that are themselves lists can fail while being consumed. Leaf positions
+        // are never iterated, so they keep propagating the way they always have.
+        depth > 1 ? loadNestedList(item, loader, depth - 1) : loadIfID(item, loader),
+      );
+    }
+
+    // Contains a failure at the list position it happened in, so graphql-js keeps its usual
+    // nullability boundary and the sibling rows survive.
+    function loadNestedList(
+      result: unknown,
+      loader: DataLoader<unknown, unknown>,
+      depth: number,
+    ): unknown {
+      try {
+        return loadResults(result, loader, depth);
+      } catch (error) {
+        return error instanceof Error ? error : new Error(String(error));
+      }
     }
 
     return (parent, args, context, info) =>

--- a/packages/plugin-dataloader/src/index.ts
+++ b/packages/plugin-dataloader/src/index.ts
@@ -4,7 +4,6 @@ import './schema-builder.js';
 import SchemaBuilder, {
   BasePlugin,
   isThenable,
-  type MaybePromise,
   type PothosOutputFieldConfig,
   type SchemaTypes,
   unwrapOutputFieldType,
@@ -38,7 +37,10 @@ export class PothosDataloaderPlugin<Types extends SchemaTypes> extends BasePlugi
     resolver: GraphQLFieldResolver<unknown, Types['Context'], object>,
     fieldConfig: PothosOutputFieldConfig<Types>,
   ): GraphQLFieldResolver<unknown, Types['Context'], object> {
-    const isList = fieldConfig.type.kind === 'List';
+    let listDepth = 0;
+    for (let type = fieldConfig.type; type.kind === 'List'; type = type.type) {
+      listDepth += 1;
+    }
 
     const config = this.buildCache.getTypeConfig(unwrapOutputFieldType(fieldConfig.type));
 
@@ -77,26 +79,30 @@ export class PothosDataloaderPlugin<Types extends SchemaTypes> extends BasePlugi
       }
     }
 
-    if (isList) {
-      return (parent, args, context, info) => {
-        const loader = getDataloader(context);
-        const promiseOrResults = resolver(parent, args, context, info) as MaybePromise<
-          Iterable<unknown> | null | undefined
-        >;
+    // Follows the list shape the field was configured with, so that ids nested inside lists of
+    // lists are loaded rather than being treated as already loaded results.
+    function loadResults(
+      result: unknown,
+      loader: DataLoader<unknown, unknown>,
+      depth: number,
+    ): unknown {
+      if (depth === 0) {
+        return loadIfID(result, loader);
+      }
 
-        const loadList = (results: Iterable<unknown> | null | undefined) =>
-          results == null ? results : toResolvedList(results).map((item) => loadIfID(item, loader));
+      if (result == null) {
+        return result;
+      }
 
-        if (isThenable(promiseOrResults)) {
-          return promiseOrResults.then(loadList);
-        }
+      if (isThenable(result)) {
+        return result.then((results) => loadResults(results, loader, depth));
+      }
 
-        return loadList(promiseOrResults);
-      };
+      return toResolvedList(result).map((item) => loadResults(item, loader, depth - 1));
     }
 
     return (parent, args, context, info) =>
-      loadIfID(resolver(parent, args, context, info), getDataloader(context));
+      loadResults(resolver(parent, args, context, info), getDataloader(context), listDepth);
   }
 }
 

--- a/packages/plugin-dataloader/src/index.ts
+++ b/packages/plugin-dataloader/src/index.ts
@@ -78,7 +78,6 @@ export class PothosDataloaderPlugin<Types extends SchemaTypes> extends BasePlugi
         return result;
       }
 
-      // An Error in a list position is how graphql-js is told to null that position.
       if (result instanceof Error) {
         return result;
       }

--- a/packages/plugin-dataloader/src/list-utils.ts
+++ b/packages/plugin-dataloader/src/list-utils.ts
@@ -1,8 +1,6 @@
-// Internal helpers shared by the loader wrappers. Not re-exported from the package entry point.
+/** Internal list helpers shared by the loader wrappers. */
 
-// Resolvers for list fields are allowed to return any Iterable. Strings are deliberately excluded
-// so a string returned where a list was expected is not spread into its characters, which would
-// turn a wrong-shaped resolver result into plausible looking keys.
+// Strings are excluded: a string in a list position must not be spread into its characters.
 export function isIterableList(value: unknown): value is Iterable<unknown> {
   return typeof value === 'object' && value !== null && Symbol.iterator in value;
 }

--- a/packages/plugin-dataloader/src/list-utils.ts
+++ b/packages/plugin-dataloader/src/list-utils.ts
@@ -1,0 +1,8 @@
+// Internal helpers shared by the loader wrappers. Not re-exported from the package entry point.
+
+// Resolvers for list fields are allowed to return any Iterable. Strings are deliberately excluded
+// so a string returned where a list was expected is not spread into its characters, which would
+// turn a wrong-shaped resolver result into plausible looking keys.
+export function isIterableList(value: unknown): value is Iterable<unknown> {
+  return typeof value === 'object' && value !== null && Symbol.iterator in value;
+}

--- a/packages/plugin-dataloader/src/list-utils.ts
+++ b/packages/plugin-dataloader/src/list-utils.ts
@@ -1,6 +1,3 @@
-/** Internal list helpers shared by the loader wrappers. */
-
-// Strings are excluded: a string in a list position must not be spread into its characters.
 export function isIterableList(value: unknown): value is Iterable<unknown> {
   return typeof value === 'object' && value !== null && Symbol.iterator in value;
 }

--- a/packages/plugin-dataloader/src/schema-builder.ts
+++ b/packages/plugin-dataloader/src/schema-builder.ts
@@ -135,6 +135,7 @@ schemaBuilderProto.loadableUnion = function loadableUnion<
   const unionRef = this.unionType(name, {
     ...options,
     extensions: {
+      ...options.extensions,
       getDataloader,
       cacheResolved: typeof cacheResolved === 'function' ? cacheResolved : cacheResolved && toKey,
     },

--- a/packages/plugin-dataloader/tests/review-fixes.test.ts
+++ b/packages/plugin-dataloader/tests/review-fixes.test.ts
@@ -168,3 +168,31 @@ describe('iterable resolver results', () => {
     expect(result.data).toEqual({ users: [{ id: 1 }, { id: 2 }] });
   });
 });
+
+describe('loadableUnion extensions', () => {
+  it('preserves extensions passed by the caller', () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    const User = builder
+      .objectRef<{ id: number }>('User')
+      .implement({ fields: (t) => ({ id: t.exposeInt('id', { nullable: false }) }) });
+
+    const Result = builder.loadableUnion('Result', {
+      types: [User],
+      resolveType: () => User,
+      load: async (ids: number[]) => ids.map((id) => ({ id })),
+      extensions: { reviewMarker: 'preserved' },
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        result: t.field({ type: Result, nullable: false, resolve: () => 1 }),
+      }),
+    });
+
+    const type = builder.toSchema().getType('Result')!;
+
+    expect(type.extensions.reviewMarker).toBe('preserved');
+    expect(type.extensions.getDataloader).toBeTypeOf('function');
+  });
+});

--- a/packages/plugin-dataloader/tests/review-fixes.test.ts
+++ b/packages/plugin-dataloader/tests/review-fixes.test.ts
@@ -117,6 +117,106 @@ describe('nested list output', () => {
     expect(result.errors?.map((error) => error.message)).toEqual(['user failed']);
     expect(result.errors?.[0].path).toEqual(['users', 1]);
   });
+
+  it('reports a non-iterable in a nullable inner list position at its own path', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    const User = builder.loadableObject('User', {
+      load: async (ids: number[]) => ids.map((id) => ({ id })),
+      fields: (t) => ({ id: t.exposeInt('id', { nullable: false }) }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        matrix: t.field({
+          type: t.listRef(t.listRef(User), { nullable: true }),
+          resolve: () => [[{ id: 1 }], 42] as never,
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ matrix { id } }',
+      contextValue: {},
+    });
+
+    expect(result.data).toEqual({ matrix: [[{ id: 1 }], null] });
+    expect(result.errors?.map((error) => error.message)).toEqual([
+      'Expected Iterable, but did not find one for field "Query.matrix".',
+    ]);
+    expect(result.errors?.[0].path).toEqual(['matrix', 1]);
+  });
+
+  it('reports a throwing iterator in a nullable inner list position at its own path', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    const User = builder.loadableObject('User', {
+      load: async (ids: number[]) => ids.map((id) => ({ id })),
+      fields: (t) => ({ id: t.exposeInt('id', { nullable: false }) }),
+    });
+
+    const throwingRow = {
+      [Symbol.iterator]: () => ({
+        next: () => {
+          throw new Error('iterator failed');
+        },
+      }),
+    };
+
+    builder.queryType({
+      fields: (t) => ({
+        matrix: t.field({
+          type: t.listRef(t.listRef(User), { nullable: true }),
+          resolve: () => [[{ id: 1 }], throwingRow] as never,
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ matrix { id } }',
+      contextValue: {},
+    });
+
+    expect(result.data).toEqual({ matrix: [[{ id: 1 }], null] });
+    expect(result.errors?.map((error) => error.message)).toEqual(['iterator failed']);
+    expect(result.errors?.[0].path).toEqual(['matrix', 1]);
+  });
+
+  it('never iterates leaf positions, so neither failure mode exists at depth 0', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    const User = builder.loadableObject('User', {
+      load: async (ids: number[]) => ids.map((id) => ({ id })),
+      fields: (t) => ({ id: t.exposeInt('id', { nullable: false }) }),
+    });
+
+    const userWithThrowingIterator = {
+      id: 2,
+      [Symbol.iterator]: () => {
+        throw new Error('should never be iterated');
+      },
+    };
+
+    builder.queryType({
+      fields: (t) => ({
+        users: t.field({
+          type: t.listRef(User, { nullable: true }),
+          resolve: () => [{ id: 1 }, userWithThrowingIterator] as never,
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ users { id } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ users: [{ id: 1 }, { id: 2 }] });
+  });
 });
 
 describe('iterable resolver results', () => {

--- a/packages/plugin-dataloader/tests/review-fixes.test.ts
+++ b/packages/plugin-dataloader/tests/review-fixes.test.ts
@@ -298,6 +298,66 @@ describe('iterable resolver results', () => {
     expect(result.data).toEqual({ numbers: [1, 2] });
   });
 
+  it('accepts a generator of keys from a t.loadable list field', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    function* keys() {
+      yield 1;
+      yield 2;
+    }
+
+    builder.queryType({
+      fields: (t) => ({
+        numbers: t.loadable({
+          type: ['Int'],
+          nullable: false,
+          load: async (ids: number[]) => ids,
+          resolve: () => keys(),
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ numbers }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ numbers: [1, 2] });
+  });
+
+  it('does not spread a string returned for a t.loadable list field', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    const load = vi.fn(async (ids: string[]) => ids);
+
+    builder.queryType({
+      fields: (t) => ({
+        names: t.loadable({
+          type: ['String'],
+          nullable: false,
+          load,
+          resolve: () => 'abc' as never,
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ names }',
+      contextValue: {},
+    });
+
+    // `names` is non-nullable, so the error nulls the whole response rather than fabricating keys
+    expect(result.data).toBeNull();
+    expect(result.errors?.map((error) => error.message)).toEqual([
+      'Expected Iterable, but did not find one for field "Query.names".',
+    ]);
+    expect(result.errors?.[0].path).toEqual(['names']);
+    expect(load).not.toHaveBeenCalled();
+  });
+
   it('still supports an iterable of already loaded objects', async () => {
     const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
 

--- a/packages/plugin-dataloader/tests/review-fixes.test.ts
+++ b/packages/plugin-dataloader/tests/review-fixes.test.ts
@@ -1,6 +1,67 @@
 import SchemaBuilder from '@pothos/core';
 import { graphql } from 'graphql';
+import { vi } from 'vitest';
 import DataloaderPlugin from '../src';
+
+describe('nested list output', () => {
+  it('loads ids nested inside a list of lists', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    const load = vi.fn(async (ids: number[]) => ids.map((id) => ({ id })));
+
+    const User = builder.loadableObject('User', {
+      load,
+      fields: (t) => ({ id: t.exposeInt('id', { nullable: false }) }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        matrix: t.field({
+          type: t.listRef(t.listRef(User)),
+          resolve: () => [[1, 2], [3]],
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ matrix { id } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ matrix: [[{ id: 1 }, { id: 2 }], [{ id: 3 }]] });
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(load.mock.calls[0][0]).toEqual([1, 2, 3]);
+  });
+
+  it('loads ids nested inside iterables of iterables', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    const User = builder.loadableObject('User', {
+      load: async (ids: number[]) => ids.map((id) => ({ id })),
+      fields: (t) => ({ id: t.exposeInt('id', { nullable: false }) }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        matrix: t.field({
+          type: t.listRef(t.listRef(User)),
+          resolve: () => Promise.resolve(new Set([new Set([1, 2]), new Set([3])])),
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ matrix { id } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ matrix: [[{ id: 1 }, { id: 2 }], [{ id: 3 }]] });
+  });
+});
 
 describe('iterable resolver results', () => {
   it('loads ids from an iterable returned by a list field of loadable objects', async () => {

--- a/packages/plugin-dataloader/tests/review-fixes.test.ts
+++ b/packages/plugin-dataloader/tests/review-fixes.test.ts
@@ -349,7 +349,6 @@ describe('iterable resolver results', () => {
       contextValue: {},
     });
 
-    // `names` is non-nullable, so the error nulls the whole response rather than fabricating keys
     expect(result.data).toBeNull();
     expect(result.errors?.map((error) => error.message)).toEqual([
       'Expected Iterable, but did not find one for field "Query.names".',

--- a/packages/plugin-dataloader/tests/review-fixes.test.ts
+++ b/packages/plugin-dataloader/tests/review-fixes.test.ts
@@ -1,0 +1,109 @@
+import SchemaBuilder from '@pothos/core';
+import { graphql } from 'graphql';
+import DataloaderPlugin from '../src';
+
+describe('iterable resolver results', () => {
+  it('loads ids from an iterable returned by a list field of loadable objects', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    const User = builder.loadableObject('User', {
+      load: async (ids: number[]) => ids.map((id) => ({ id })),
+      fields: (t) => ({ id: t.exposeInt('id', { nullable: false }) }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        users: t.field({
+          type: [User],
+          resolve: () => new Set([1, 2]),
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ users { id } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ users: [{ id: 1 }, { id: 2 }] });
+  });
+
+  it('loads ids from a promise of an iterable', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    const User = builder.loadableObject('User', {
+      load: async (ids: number[]) => ids.map((id) => ({ id })),
+      fields: (t) => ({ id: t.exposeInt('id', { nullable: false }) }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        users: t.field({
+          type: [User],
+          resolve: () => Promise.resolve(new Set([1, 2])),
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ users { id } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ users: [{ id: 1 }, { id: 2 }] });
+  });
+
+  it('accepts an iterable of keys from a t.loadable list field', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    builder.queryType({
+      fields: (t) => ({
+        numbers: t.loadable({
+          type: ['Int'],
+          nullable: false,
+          load: async (ids: number[]) => ids,
+          resolve: () => new Set([1, 2]),
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ numbers }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ numbers: [1, 2] });
+  });
+
+  it('still supports an iterable of already loaded objects', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    const User = builder
+      .objectRef<{ id: number }>('User')
+      .implement({ fields: (t) => ({ id: t.exposeInt('id', { nullable: false }) }) });
+
+    builder.queryType({
+      fields: (t) => ({
+        users: t.field({
+          type: [User],
+          resolve: () => new Set([{ id: 1 }, { id: 2 }]),
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ users { id } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ users: [{ id: 1 }, { id: 2 }] });
+  });
+});

--- a/packages/plugin-dataloader/tests/review-fixes.test.ts
+++ b/packages/plugin-dataloader/tests/review-fixes.test.ts
@@ -61,6 +61,62 @@ describe('nested list output', () => {
     expect(result.errors).toBeUndefined();
     expect(result.data).toEqual({ matrix: [[{ id: 1 }, { id: 2 }], [{ id: 3 }]] });
   });
+
+  it('reports an Error returned for a nullable inner list at its own path', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    const User = builder.loadableObject('User', {
+      load: async (ids: number[]) => ids.map((id) => ({ id })),
+      fields: (t) => ({ id: t.exposeInt('id', { nullable: false }) }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        matrix: t.field({
+          type: t.listRef(t.listRef(User), { nullable: true }),
+          resolve: () => [[{ id: 1 }], new Error('row failed')] as never,
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ matrix { id } }',
+      contextValue: {},
+    });
+
+    expect(result.data).toEqual({ matrix: [[{ id: 1 }], null] });
+    expect(result.errors?.map((error) => error.message)).toEqual(['row failed']);
+    expect(result.errors?.[0].path).toEqual(['matrix', 1]);
+  });
+
+  it('reports an Error returned for a nullable list item at its own path', async () => {
+    const builder = new SchemaBuilder<{ Context: {} }>({ plugins: [DataloaderPlugin] });
+
+    const User = builder.loadableObject('User', {
+      load: async (ids: number[]) => ids.map((id) => ({ id })),
+      fields: (t) => ({ id: t.exposeInt('id', { nullable: false }) }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        users: t.field({
+          type: t.listRef(User, { nullable: true }),
+          resolve: () => [{ id: 1 }, new Error('user failed')] as never,
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ users { id } }',
+      contextValue: {},
+    });
+
+    expect(result.data).toEqual({ users: [{ id: 1 }, null] });
+    expect(result.errors?.map((error) => error.message)).toEqual(['user failed']);
+    expect(result.errors?.[0].path).toEqual(['users', 1]);
+  });
 });
 
 describe('iterable resolver results', () => {


### PR DESCRIPTION
Addresses the three P2 findings from the `@pothos/plugin-dataloader` whole-plugin review, plus three follow-up fixes for regressions independent reviews found in this branch. Each commit carries a regression test that was confirmed failing before the fix.

## 1. Iterable list results fail in loader wrappers

List field resolvers may return any `Iterable`, but both loader wrappers called `.map` on the resolver result directly.

- `src/index.ts` — a `Set` of ids from a list field of loadable objects threw `promiseOrResults?.map is not a function`.
- `src/field-builder.ts` — a `Set` of keys from a `t.loadable` list field threw `ids.map is not a function`.

**Fix** — consume non-array iterables into an array before mapping, on both the sync and promise paths.

**Verified by** new tests covering a `Set` from a list of loadable objects, a `Promise<Set>`, and a `Set` and a generator from a `t.loadable` list field. A control test asserting an ordinary object-list `Set` keeps working passed throughout.

**Follow-up (sixth commit) — strings.** Strings are iterable, and the two wrappers disagreed about them: `index.ts` excluded strings, `field-builder.ts` did not. So a string returned where a key list was expected was spread into its characters and each one loaded — `resolve: () => 'abc'` on a `t.loadable({ type: ['String'] })` field returned `["a", "b", "c"]` with **no error**, having called the batch function with three keys nobody asked for. On `main` the same code failed loudly with `ids.map is not a function`, so this branch had turned a reported error into a successful response carrying invented data.

The guard now lives in one place (`src/list-utils.ts`, internal) and both wrappers use it, so the two paths cannot drift again. A value that is not an iterable list is handed back unchanged so graphql-js reports it. TypeScript already rejects that resolver return type — the reproduction needs `as never` — so the realistic trigger is an `any`/`unknown` return from an untyped client or a JS consumer.

## 2. Nested output lists leave ids unresolved

`src/index.ts` mapped only the outer list, so for a field typed `t.listRef(t.listRef(User))` the inner arrays were handed to `loadIfID` as if they were already-loaded results and the ids inside them were never loaded.

**Fix** — walk the configured `PothosOutputFieldType` to get the list depth and recurse to that depth, handling promises and iterables at each level, instead of special-casing a single level.

**Verified by** a test resolving `[[1, 2], [3]]` that failed with `Cannot return null for non-nullable field User.id.` before the fix; it now resolves and asserts the loader batched into a single call with `[1, 2, 3]`. A second test covers nested iterables behind a promise.

**Follow-up (fourth commit) — `Error` values.** graphql-js treats an `Error` in a list position as an instruction to null that position and report the error at its own indexed path. Recursing meant an `Error` returned for a nullable inner list was handed to `.map`, which threw at the outer field and nulled the whole list, losing the sibling rows. Reproduced with `t.listRef(t.listRef(User), { nullable: true })` resolving `[[{ id: 1 }], new Error('row failed')]` — `matrix` came back `null` instead of `[[{ id: 1 }], null]`. `Error` values are now passed through untouched above the leaf.

**Follow-up (fifth commit) — the general class.** The `Error` guard only covered failures the resolver authored deliberately. Two accidental ones still escaped the position they happened in and took the whole field with them:

- a **non-iterable** in an inner list position (`[[{ id: 1 }], 42]`) — spreading it threw;
- an inner value whose **iterator throws** partway — consuming it threw.

Both are now contained at their own index. A non-iterable is handed back unchanged so graphql-js reports its own `Expected Iterable, but did not find one for field "Query.matrix".` at `['matrix', 1]`, matching the pre-recursion behaviour; a throw while consuming a nested list is caught and returned as an `Error` for that position. As a side effect, a non-iterable returned for the *outermost* list now also produces that clean graphql error at the field path instead of leaking the internal `promiseOrResults?.map is not a function` into the client response.

Leaf positions are deliberately untouched. They are never iterated — `loadIfID` only branches on `typeof` — so neither failure mode reaches them, and a test pins that: a leaf object carrying a throwing `Symbol.iterator` resolves normally.

## 3. `loadableUnion` drops caller extensions

`src/schema-builder.ts` replaced `extensions` after spreading the options, so caller metadata was dropped from the built union type.

**Fix** — merge `...options.extensions` before the loader metadata, matching what `loadableObject`, `loadableInterface` and `loadableNode` already do.

**Verified by** a test asserting a custom extension survives on the built `Result` union, which failed before the fix; it also asserts `getDataloader` is still installed.

## Verification

```
pnpm --filter @pothos/plugin-dataloader run test   # 6 files, 32 tests passed (18 at baseline), no type errors
pnpm --filter @pothos/plugin-dataloader run type   # clean
pnpm biome check packages/plugin-dataloader        # clean
pnpm turbo run test                                # 61 tasks pass
```

Two packages are excluded from the monorepo run for environmental reasons unrelated to this change: `@pothos/plugin-prisma-next`'s Postgres tests need a local database on port 5456 (`ECONNREFUSED 127.0.0.1:5456`), and `@pothos/plugin-prisma-utils`' test script begins with a destructive `prisma migrate reset -f`.

## Out of scope

- **Async iterable list results** are also part of the public resolver contract (`AsyncIterableResolverResult` in core) and still throw in the loader wrapper — unchanged by this PR. Supporting them means wrapping the result in an async generator, which is more than these mechanical fixes.
- Documented behaviour left alone: sort-mode batch failure on an `Error`, missing-key nulls, fresh request context, and `byPath` requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
