### PR TITLE
fix(zod): address findings from the plugin review

### DIFF
--- a/.changeset/zod-review-fixes.md
+++ b/.changeset/zod-review-fixes.md
@@ -1,0 +1,8 @@
+---
+"@pothos/plugin-zod": patch
+---
+
+Apply `min`, `max`, `minLength` and `maxLength` constraints when the bound is `0`
+Run every constraint in a refinement array, including arrays that mix tuples and bare functions
+Treat a `[false, { message }]` boolean constraint as disabled, matching a bare `false`
+Validate arguments before a subscription's source stream is created, not only in the resolver

--- a/packages/plugin-zod/src/createZodSchema.ts
+++ b/packages/plugin-zod/src/createZodSchema.ts
@@ -100,17 +100,45 @@ export function refine(
     return validator;
   }
 
-  if (typeof options.refine === 'function') {
-    return validator.refine(options.refine as () => boolean);
+  return normalizeRefinements(options.refine as RefineConstraint).reduce(
+    (prev, [refineFn, opts]) => prev.refine(refineFn, opts),
+    validator,
+  );
+}
+
+type RefineFn = () => boolean;
+type RefineTuple = [refine: RefineFn, options?: { message?: string; path?: string[] }];
+
+/**
+ * `[refineFn, options]` and `[refineFn, refineFn]` are both valid, so an array is only a single
+ * refinement tuple when its second entry (if any) is an options object.
+ */
+function isRefineTuple(refine: unknown[]): refine is RefineTuple {
+  if (typeof refine[0] !== 'function') {
+    return false;
   }
 
-  if (typeof options.refine?.[0] === 'function') {
-    return validator.refine(...(options.refine as [() => boolean, { message?: string }]));
+  return (
+    refine.length < 2 ||
+    (refine.length === 2 &&
+      typeof refine[1] === 'object' &&
+      refine[1] !== null &&
+      !Array.isArray(refine[1]))
+  );
+}
+
+function normalizeRefinements(refine: RefineConstraint): RefineTuple[] {
+  if (typeof refine === 'function') {
+    return [[refine as RefineFn]];
   }
 
-  const refinements = options.refine as [() => boolean, { message?: string }][];
+  if (isRefineTuple(refine)) {
+    return [refine];
+  }
 
-  return refinements.reduce((prev, [refineFn, opts]) => prev.refine(refineFn, opts), validator);
+  return (refine as (RefineFn | RefineTuple)[]).map((constraint) =>
+    typeof constraint === 'function' ? [constraint] : constraint,
+  );
 }
 
 export const createNumberValidator = validatorCreator(

--- a/packages/plugin-zod/src/createZodSchema.ts
+++ b/packages/plugin-zod/src/createZodSchema.ts
@@ -142,11 +142,6 @@ function normalizeRefinements(refine: RefineConstraint): RefineTuple[] {
   );
 }
 
-/**
- * Boolean constraints may be given as a bare boolean, or as a `[enabled, options]` tuple. In the
- * tuple form the flag itself decides whether the constraint applies, so `[false, { message }]`
- * disables it just like a bare `false`.
- */
 function isFlagEnabled(constraint: Constraint<boolean> | undefined): boolean {
   return Array.isArray(constraint) ? constraint[0] : !!constraint;
 }

--- a/packages/plugin-zod/src/createZodSchema.ts
+++ b/packages/plugin-zod/src/createZodSchema.ts
@@ -119,13 +119,13 @@ export const createNumberValidator = validatorCreator(
   (options: NumberValidationOptions) => {
     let validator = zod.number();
 
-    if (options.min) {
+    if (options.min !== undefined) {
       validator = Array.isArray(options.min)
         ? validator.min(Number(options.min[0]), options.min[1])
         : validator.min(Number(options.min));
     }
 
-    if (options.max) {
+    if (options.max !== undefined) {
       validator = Array.isArray(options.max)
         ? validator.max(Number(options.max[0]), options.max[1])
         : validator.max(Number(options.max));
@@ -174,13 +174,13 @@ export const createStringValidator = validatorCreator(
         : validator.length(options.length);
     }
 
-    if (options.minLength) {
+    if (options.minLength !== undefined) {
       validator = Array.isArray(options.minLength)
         ? validator.min(options.minLength[0], options.minLength[1])
         : validator.min(options.minLength);
     }
 
-    if (options.maxLength) {
+    if (options.maxLength !== undefined) {
       validator = Array.isArray(options.maxLength)
         ? validator.max(options.maxLength[0], options.maxLength[1])
         : validator.max(options.maxLength);
@@ -232,13 +232,13 @@ export function createArrayValidator(
       : validator.length(options.length);
   }
 
-  if (options.minLength) {
+  if (options.minLength !== undefined) {
     validator = Array.isArray(options.minLength)
       ? validator.min(options.minLength[0], options.minLength[1])
       : validator.min(options.minLength);
   }
 
-  if (options.maxLength) {
+  if (options.maxLength !== undefined) {
     validator = Array.isArray(options.maxLength)
       ? validator.max(options.maxLength[0], options.maxLength[1])
       : validator.max(options.maxLength);

--- a/packages/plugin-zod/src/createZodSchema.ts
+++ b/packages/plugin-zod/src/createZodSchema.ts
@@ -3,6 +3,7 @@ import * as zod from 'zod';
 import type {
   ArrayValidationOptions,
   BaseValidationOptions,
+  Constraint,
   NumberValidationOptions,
   RefineConstraint,
   StringValidationOptions,
@@ -141,6 +142,15 @@ function normalizeRefinements(refine: RefineConstraint): RefineTuple[] {
   );
 }
 
+/**
+ * Boolean constraints may be given as a bare boolean, or as a `[enabled, options]` tuple. In the
+ * tuple form the flag itself decides whether the constraint applies, so `[false, { message }]`
+ * disables it just like a bare `false`.
+ */
+function isFlagEnabled(constraint: Constraint<boolean> | undefined): boolean {
+  return Array.isArray(constraint) ? constraint[0] : !!constraint;
+}
+
 export const createNumberValidator = validatorCreator(
   'number',
   numberValidations,
@@ -168,9 +178,10 @@ export const createNumberValidator = validatorCreator(
     ] as const;
 
     for (const constraint of booleanConstraints) {
-      if (options[constraint]) {
-        const value = options[constraint];
-        validator = validator[constraint](Array.isArray(value) ? value[1] : {});
+      const value = options[constraint];
+
+      if (isFlagEnabled(value)) {
+        validator = validator[constraint](Array.isArray(value) ? (value[1] ?? {}) : {});
       }
     }
 
@@ -223,10 +234,10 @@ export const createStringValidator = validatorCreator(
     const booleanConstraints = ['email', 'url', 'uuid'] as const;
 
     for (const constraint of booleanConstraints) {
-      if (options[constraint]) {
-        const value = options[constraint];
+      const value = options[constraint];
 
-        validator = validator[constraint](Array.isArray(value) ? value[1] : {});
+      if (isFlagEnabled(value)) {
+        validator = validator[constraint](Array.isArray(value) ? (value[1] ?? {}) : {});
       }
     }
 

--- a/packages/plugin-zod/src/createZodSchema.ts
+++ b/packages/plugin-zod/src/createZodSchema.ts
@@ -110,10 +110,6 @@ export function refine(
 type RefineFn = () => boolean;
 type RefineTuple = [refine: RefineFn, options?: { message?: string; path?: string[] }];
 
-/**
- * `[refineFn, options]` and `[refineFn, refineFn]` are both valid, so an array is only a single
- * refinement tuple when its second entry (if any) is an options object.
- */
 function isRefineTuple(refine: unknown[]): refine is RefineTuple {
   if (typeof refine[0] !== 'function') {
     return false;

--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -71,6 +71,44 @@ export class PothosZodPlugin<Types extends SchemaTypes> extends BasePlugin<Types
     resolver: GraphQLFieldResolver<unknown, Types['Context'], object>,
     fieldConfig: PothosOutputFieldConfig<Types>,
   ): GraphQLFieldResolver<unknown, Types['Context'], object> {
+    const validateArgs = this.createArgsValidator(fieldConfig);
+
+    if (!validateArgs) {
+      return resolver;
+    }
+
+    return async (parent, rawArgs, context, info) =>
+      resolver(parent, await validateArgs(rawArgs, context, info), context, info);
+  }
+
+  /**
+   * Subscriptions resolve arguments twice: once when the source stream is created, and again for
+   * each event. Both are validated, and because graphql coerces the raw arguments separately for
+   * each call, any transform in the validator is applied exactly once to each of them.
+   */
+  override wrapSubscribe(
+    subscribe: GraphQLFieldResolver<unknown, Types['Context'], object> | undefined,
+    fieldConfig: PothosOutputFieldConfig<Types>,
+  ): GraphQLFieldResolver<unknown, Types['Context'], object> | undefined {
+    if (!subscribe) {
+      return subscribe;
+    }
+
+    const validateArgs = this.createArgsValidator(fieldConfig);
+
+    if (!validateArgs) {
+      return subscribe;
+    }
+
+    return async (parent, rawArgs, context, info) =>
+      subscribe(parent, await validateArgs(rawArgs, context, info), context, info);
+  }
+
+  private createArgsValidator(
+    fieldConfig: PothosOutputFieldConfig<Types>,
+  ):
+    | ((rawArgs: object, context: Types['Context'], info: GraphQLResolveInfo) => Promise<object>)
+    | null {
     // Only used to check if validation is required
     const argMap = mapInputFields(
       fieldConfig.args,
@@ -80,7 +118,7 @@ export class PothosZodPlugin<Types extends SchemaTypes> extends BasePlugin<Types
     );
 
     if (!argMap && !fieldConfig.pothosOptions.validate) {
-      return resolver;
+      return null;
     }
 
     const args: Record<string, zod.ZodType<unknown>> = {};
@@ -124,15 +162,10 @@ export class PothosZodPlugin<Types extends SchemaTypes> extends BasePlugin<Types
         }
       };
 
-    return async (parent, rawArgs, context, info) =>
-      resolver(
-        parent,
-        (await (validatorWithErrorHandling
-          ? validatorWithErrorHandling(rawArgs, context, info)
-          : validator.parseAsync(rawArgs))) as object,
-        context,
-        info,
-      );
+    return async (rawArgs, context, info) =>
+      (await (validatorWithErrorHandling
+        ? validatorWithErrorHandling(rawArgs, context, info)
+        : validator.parseAsync(rawArgs))) as object;
   }
 
   createValidator(

--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -82,9 +82,8 @@ export class PothosZodPlugin<Types extends SchemaTypes> extends BasePlugin<Types
   }
 
   /**
-   * Subscriptions resolve arguments twice: once when the source stream is created, and again for
-   * each event. Both are validated, and because graphql coerces the raw arguments separately for
-   * each call, any transform in the validator is applied exactly once to each of them.
+   * graphql coerces the raw arguments separately for the source stream and for each event, so
+   * validating both applies any transform in the validator exactly once to each.
    */
   override wrapSubscribe(
     subscribe: GraphQLFieldResolver<unknown, Types['Context'], object> | undefined,

--- a/packages/plugin-zod/src/index.ts
+++ b/packages/plugin-zod/src/index.ts
@@ -81,10 +81,6 @@ export class PothosZodPlugin<Types extends SchemaTypes> extends BasePlugin<Types
       resolver(parent, await validateArgs(rawArgs, context, info), context, info);
   }
 
-  /**
-   * graphql coerces the raw arguments separately for the source stream and for each event, so
-   * validating both applies any transform in the validator exactly once to each.
-   */
   override wrapSubscribe(
     subscribe: GraphQLFieldResolver<unknown, Types['Context'], object> | undefined,
     fieldConfig: PothosOutputFieldConfig<Types>,

--- a/packages/plugin-zod/tests/boolean-flags.test.ts
+++ b/packages/plugin-zod/tests/boolean-flags.test.ts
@@ -1,0 +1,35 @@
+import { createZodSchema } from '../src';
+
+describe('boolean constraint flags', () => {
+  it('treats a false tuple flag like a bare false flag on numbers', () => {
+    const bare = createZodSchema({ type: 'number', positive: false }, true);
+    const tuple = createZodSchema(
+      { type: 'number', positive: [false, { message: 'disabled' }] },
+      true,
+    );
+
+    expect(bare.safeParse(-1).success).toBe(true);
+    expect(tuple.safeParse(-1).success).toBe(true);
+  });
+
+  it('treats a false tuple flag like a bare false flag on strings', () => {
+    const bare = createZodSchema({ type: 'string', email: false }, true);
+    const tuple = createZodSchema(
+      { type: 'string', email: [false, { message: 'disabled' }] },
+      true,
+    );
+
+    expect(bare.safeParse('not an email').success).toBe(true);
+    expect(tuple.safeParse('not an email').success).toBe(true);
+  });
+
+  it('still enables constraints for a true tuple flag', () => {
+    const validator = createZodSchema(
+      { type: 'number', positive: [true, { message: 'must be positive' }] },
+      true,
+    );
+
+    expect(validator.safeParse(-1).error?.issues[0].message).toBe('must be positive');
+    expect(validator.safeParse(1).success).toBe(true);
+  });
+});

--- a/packages/plugin-zod/tests/refinements.test.ts
+++ b/packages/plugin-zod/tests/refinements.test.ts
@@ -1,0 +1,69 @@
+import SchemaBuilder from '@pothos/core';
+import { graphql } from 'graphql';
+import ZodPlugin, { createZodSchema } from '../src';
+
+describe('refinement arrays', () => {
+  it('runs every bare function in a refinement array', async () => {
+    const builder = new SchemaBuilder({ plugins: [ZodPlugin] });
+    const calls: string[] = [];
+
+    builder.queryType({
+      fields: (t) => ({
+        value: t.int({
+          args: {
+            n: t.arg.int({
+              required: true,
+              validate: {
+                refine: [
+                  (n) => {
+                    calls.push('first');
+                    return n > 0;
+                  },
+                  (n) => {
+                    calls.push('second');
+                    return n < 2;
+                  },
+                ],
+              },
+            }),
+          },
+          resolve: (_parent, { n }) => n,
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ value(n: 3) }',
+      contextValue: {},
+    });
+
+    expect(calls).toEqual(['first', 'second']);
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('allows tuple and bare refinements in the same array', () => {
+    const validator = createZodSchema(
+      {
+        refine: [
+          [(value: unknown) => value !== 'a', { message: 'not a' }],
+          (value: unknown) => value !== 'b',
+        ],
+      },
+      true,
+    );
+
+    expect(validator.safeParse('a').error?.issues[0].message).toBe('not a');
+    expect(validator.safeParse('b').success).toBe(false);
+    expect(validator.safeParse('c').success).toBe(true);
+  });
+
+  it('still treats a single refinement tuple as one refinement', () => {
+    const validator = createZodSchema({
+      refine: [(value: unknown) => value !== 'a', { message: 'not a' }],
+    });
+
+    expect(validator.safeParse('a').error?.issues[0].message).toBe('not a');
+    expect(validator.safeParse('b').success).toBe(true);
+  });
+});

--- a/packages/plugin-zod/tests/subscriptions.test.ts
+++ b/packages/plugin-zod/tests/subscriptions.test.ts
@@ -1,0 +1,91 @@
+import SchemaBuilder from '@pothos/core';
+import { type ExecutionResult, parse, subscribe } from 'graphql';
+import * as zod from 'zod';
+import ZodPlugin from '../src';
+
+async function* once<T>(value: T) {
+  yield await Promise.resolve(value);
+}
+
+async function run(schema: Parameters<typeof subscribe>[0]['schema'], source: string) {
+  const result = await subscribe({ schema, document: parse(source), contextValue: {} });
+
+  if (Symbol.asyncIterator in result) {
+    const events: ExecutionResult[] = [];
+
+    for await (const event of result) {
+      events.push(event);
+      break;
+    }
+
+    await result.return?.();
+
+    return { events, errors: undefined };
+  }
+
+  return { events: [], errors: result.errors };
+}
+
+describe('subscriptions', () => {
+  it('validates arguments before creating the source stream', async () => {
+    const builder = new SchemaBuilder({ plugins: [ZodPlugin] });
+    const observed: number[] = [];
+
+    builder.queryType({ fields: (t) => ({ ok: t.boolean({ resolve: () => true }) }) });
+    builder.subscriptionType({
+      fields: (t) => ({
+        watch: t.int({
+          args: { value: t.arg.int({ required: true, validate: { min: 1 } }) },
+          subscribe: (_root, { value }) => {
+            observed.push(value);
+
+            return once(value);
+          },
+          resolve: (value: number) => value,
+        }),
+      }),
+    });
+
+    const { errors } = await run(builder.toSchema(), 'subscription { watch(value: -1) }');
+
+    expect(observed).toEqual([]);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('applies a transform exactly once for subscribe and for resolve', async () => {
+    const builder = new SchemaBuilder({ plugins: [ZodPlugin] });
+    const subscribeArgs: string[] = [];
+    const resolveArgs: string[] = [];
+
+    builder.queryType({ fields: (t) => ({ ok: t.boolean({ resolve: () => true }) }) });
+    builder.subscriptionType({
+      fields: (t) => ({
+        watch: t.string({
+          args: {
+            value: t.arg.string({
+              required: true,
+              validate: { schema: zod.string().transform((value) => `${value}!`) },
+            }),
+          },
+          subscribe: (_root, { value }) => {
+            subscribeArgs.push(value);
+
+            return once(value);
+          },
+          resolve: (value: string, { value: arg }) => {
+            resolveArgs.push(arg);
+
+            return value;
+          },
+        }),
+      }),
+    });
+
+    const { events, errors } = await run(builder.toSchema(), 'subscription { watch(value: "x") }');
+
+    expect(errors).toBeUndefined();
+    expect(subscribeArgs).toEqual(['x!']);
+    expect(resolveArgs).toEqual(['x!']);
+    expect(events[0]?.data).toEqual({ watch: 'x!' });
+  });
+});

--- a/packages/plugin-zod/tests/zero-bounds.test.ts
+++ b/packages/plugin-zod/tests/zero-bounds.test.ts
@@ -1,0 +1,69 @@
+import SchemaBuilder from '@pothos/core';
+import { graphql } from 'graphql';
+import ZodPlugin, { createZodSchema } from '../src';
+
+describe('zero bounds', () => {
+  it('enforces a zero minimum on numbers', async () => {
+    const builder = new SchemaBuilder({ plugins: [ZodPlugin] });
+
+    builder.queryType({
+      fields: (t) => ({
+        value: t.int({
+          args: { n: t.arg.int({ required: true, validate: { min: 0 } }) },
+          resolve: (_parent, { n }) => n,
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ value(n: -1) }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('enforces a zero maximum on numbers', async () => {
+    const builder = new SchemaBuilder({ plugins: [ZodPlugin] });
+
+    builder.queryType({
+      fields: (t) => ({
+        value: t.int({
+          args: { n: t.arg.int({ required: true, validate: { max: 0 } }) },
+          resolve: (_parent, { n }) => n,
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ value(n: 1) }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toHaveLength(1);
+  });
+
+  it('enforces zero length bounds on strings', () => {
+    expect(createZodSchema({ type: 'string', maxLength: 0 }, true).safeParse('a').success).toBe(
+      false,
+    );
+    expect(createZodSchema({ type: 'string', minLength: 0 }, true).safeParse('').success).toBe(
+      true,
+    );
+  });
+
+  it('enforces zero length bounds on arrays', () => {
+    expect(createZodSchema({ type: 'array', maxLength: 0 }, true).safeParse([1]).success).toBe(
+      false,
+    );
+  });
+
+  it('still enforces zero tuple bounds', () => {
+    expect(
+      createZodSchema({ type: 'number', min: [0, { message: 'minimum' }] }, true).safeParse(-1)
+        .success,
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Addresses the four P2 findings from the whole-plugin review of `@pothos/plugin-zod`. Each finding gets its own commit with a regression test; no surrounding code was refactored.

### 1. Zero numeric and length bounds were ignored

`min`, `max`, `minLength` and `maxLength` were tested for truthiness, so a bound of `0` was silently dropped: `{ min: 0 }` accepted `-1`, `{ maxLength: 0 }` accepted `"a"`. They now test for presence, matching the `length` handling that was already correct (and the tuple forms, which already worked).

*Verified by* `tests/zero-bounds.test.ts` — numeric `min`/`max` of zero through a real schema, string and array `maxLength` of zero, plus a control asserting the tuple form still works. Four of the five assertions failed before the fix.

### 2. Refinement arrays skipped constraints or threw

An array of bare functions was mistaken for a single `[refineFn, options]` tuple, so only the first function ran and the second was handed to zod as refinement options. An array mixing tuples and bare functions threw `TypeError: function is not iterable` while building the schema. Both formats are documented. A `normalizeRefinements` helper now disambiguates: an array is a single tuple only when its second entry (if any) is an options object.

*Verified by* `tests/refinements.test.ts` — both failures reproduced first (`['first']` instead of `['first', 'second']`, and the `TypeError`), plus a test pinning the single-tuple form.

### 3. False boolean tuple flags enabled constraints

`positive: [false, { message }]` enabled the constraint, while a bare `positive: false` disabled it. The flag is now read out of the tuple before the constraint is applied.

*Verified by* `tests/boolean-flags.test.ts` — a numeric and a string flag, each compared against its bare-boolean equivalent, plus a test that `[true, { message }]` still applies the constraint and its message.

### 4. Subscription source arguments were unvalidated

Only `resolve` was wrapped, so a `subscribe` callback received `-1` despite `min: 1` and started its stream before any event-time validation could reject the arguments. The validator construction is extracted into a private `createArgsValidator`, and `wrapSubscribe` now uses it too.

On the transform-once concern: graphql coerces the raw arguments separately for the source stream and for each event, so `subscribe` and `resolve` each validate raw arguments exactly once — a transform is never applied to an already transformed value. This is asserted rather than assumed.

*Verified by* `tests/subscriptions.test.ts` — one test that `subscribe` is never called and an error is returned for an invalid argument, and one that a `schema` transform produces `'x!'` (not `'x!!'`) in both `subscribe` and `resolve`. Both failed before the fix.

### Verification

- `pnpm --filter @pothos/plugin-zod run test` — 19 passed (6 baseline + 13 new), no type errors
- `pnpm --filter @pothos/plugin-zod run type` — clean
- `pnpm biome check packages/plugin-zod` — clean
- `pnpm --filter @pothos/plugin-with-input run test` — 3 passed (only other package depending on this plugin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
