### PR TITLE
fix(validation): address 3 findings from the plugin review

### DIFF
--- a/.changeset/validation-review-fixes.md
+++ b/.changeset/validation-review-fixes.md
@@ -1,0 +1,7 @@
+---
+"@pothos/plugin-validation": patch
+---
+
+Run chained input object schemas in declaration order
+Keep chained input type schemas when the input type also sets a `validate` option
+Continue validator chains after a schema successfully transforms a value to `null`

--- a/.changeset/validation-review-fixes.md
+++ b/.changeset/validation-review-fixes.md
@@ -5,3 +5,5 @@
 Run chained input object schemas in declaration order
 Keep chained input type schemas when the input type also sets a `validate` option
 Continue validator chains after a schema successfully transforms a value to `null`
+
+Behavior change: chaining `.validate()` on an input type that also passes a `validate` option previously dropped the chained schemas entirely. They now run, in declaration order, followed by the options schema — the same order already used for arguments and input fields. Because the options schema runs last, a chained schema that reshapes the value (so the options schema no longer matches the reshaped value) can now fail at runtime where it previously silently returned the options schema's output. Note that `.validate()` re-types the input ref while the `validate` option does not, so TypeScript still describes the value as the last chained schema's output in that case.

--- a/packages/plugin-validation/src/index.ts
+++ b/packages/plugin-validation/src/index.ts
@@ -46,11 +46,9 @@ export class PothosValidationPlugin<Types extends SchemaTypes> extends BasePlugi
 
   override onTypeConfig(typeConfig: PothosTypeConfig) {
     if (typeConfig.graphqlKind === 'InputObject') {
-      const extensions = (typeConfig.extensions ?? {}) as {
-        validationSchemas?: StandardSchemaV1[];
-      };
+      const extensions = typeConfig.extensions ?? {};
 
-      const existingSchemas = extensions.validationSchemas ?? [];
+      const existingSchemas = extensions['@pothos/plugin-validation']?.schemas ?? [];
       const optionsSchema = typeConfig.pothosOptions.validate;
 
       if (optionsSchema || existingSchemas.length > 0) {
@@ -59,6 +57,7 @@ export class PothosValidationPlugin<Types extends SchemaTypes> extends BasePlugi
           extensions: {
             ...extensions,
             '@pothos/plugin-validation': {
+              ...extensions['@pothos/plugin-validation'],
               schemas: optionsSchema ? [optionsSchema, ...existingSchemas] : existingSchemas,
             },
           },

--- a/packages/plugin-validation/src/index.ts
+++ b/packages/plugin-validation/src/index.ts
@@ -92,7 +92,8 @@ export class PothosValidationPlugin<Types extends SchemaTypes> extends BasePlugi
 
       const typeSchemas =
         typeConfig.kind === 'InputObject'
-          ? (typeConfig.extensions?.['@pothos/plugin-validation']?.schemas ?? null)
+          ? (typeConfig.extensions?.['@pothos/plugin-validation']?.schemas?.slice().reverse() ??
+            null)
           : null;
 
       return fieldSchemas.length > 0 || typeSchemas

--- a/packages/plugin-validation/src/utils.ts
+++ b/packages/plugin-validation/src/utils.ts
@@ -93,11 +93,6 @@ export function createArgsValidator<Types extends SchemaTypes>(
   };
 }
 
-/**
- * Runs a list of schemas in order, feeding each result into the next. Values are boxed so a schema
- * that successfully returns `null` stays distinct from the `null` `reduceMaybeAsync` uses to stop
- * the chain; a `null` result means a schema reported issues.
- */
 function reduceSchemas(
   schemas: StandardSchemaV1[],
   initialValue: unknown,

--- a/packages/plugin-validation/src/utils.ts
+++ b/packages/plugin-validation/src/utils.ts
@@ -94,11 +94,9 @@ export function createArgsValidator<Types extends SchemaTypes>(
 }
 
 /**
- * Runs a list of schemas in order, feeding each result into the next schema.
- *
- * Values are wrapped so that a schema that successfully returns `null` is not
- * confused with the `null` `reduceMaybeAsync` uses to stop the chain. Returns
- * `null` only when a schema reported issues.
+ * Runs a list of schemas in order, feeding each result into the next. Values are boxed so a schema
+ * that successfully returns `null` stays distinct from the `null` `reduceMaybeAsync` uses to stop
+ * the chain; a `null` result means a schema reported issues.
  */
 function reduceSchemas(
   schemas: StandardSchemaV1[],

--- a/packages/plugin-validation/src/utils.ts
+++ b/packages/plugin-validation/src/utils.ts
@@ -35,15 +35,9 @@ export function createArgsValidator<Types extends SchemaTypes>(
             return value;
           }
 
-          return reduceMaybeAsync(mappings.value.typeSchemas, value, (val, schema) =>
-            completeValue(schema['~standard'].validate(val), (result) => {
-              if (result.issues) {
-                addIssues(result.issues);
-                return null;
-              }
-
-              return result.value;
-            }),
+          return completeValue(
+            reduceSchemas(mappings.value.typeSchemas, value, addIssues),
+            (result) => (result ? result.value : null),
           );
         },
         (mapped, mappings, addIssues) => {
@@ -51,15 +45,9 @@ export function createArgsValidator<Types extends SchemaTypes>(
             return mapped;
           }
 
-          return reduceMaybeAsync(mappings.value.fieldSchemas, mapped, (val, schema) =>
-            completeValue(schema['~standard'].validate(val), (result) => {
-              if (result.issues) {
-                addIssues(result.issues);
-                return null;
-              }
-
-              return result.value;
-            }),
+          return completeValue(
+            reduceSchemas(mappings.value.fieldSchemas, mapped, addIssues),
+            (result) => (result ? result.value : null),
           );
         },
       )
@@ -89,27 +77,47 @@ export function createArgsValidator<Types extends SchemaTypes>(
 
         const issues: StandardSchemaV1.Issue[] = [];
 
-        const validated = reduceMaybeAsync(schemasArray, mapped.value, (val, schema) =>
-          completeValue(schema['~standard'].validate(val), (result) => {
-            if (result.issues) {
-              issues.push(...result.issues);
-              return null;
-            }
-
-            return result.value as Record<string, unknown>;
-          }),
-        );
+        const validated = reduceSchemas(schemasArray, mapped.value, (newIssues) => {
+          issues.push(...newIssues);
+        });
 
         return completeValue(validated, (result) => {
           if (issues.length) {
             throw options.validationError({ issues }, args, context, info);
           }
 
-          return result as Record<string, unknown>;
+          return (result as { value: unknown }).value as Record<string, unknown>;
         });
       },
     );
   };
+}
+
+/**
+ * Runs a list of schemas in order, feeding each result into the next schema.
+ *
+ * Values are wrapped so that a schema that successfully returns `null` is not
+ * confused with the `null` `reduceMaybeAsync` uses to stop the chain. Returns
+ * `null` only when a schema reported issues.
+ */
+function reduceSchemas(
+  schemas: StandardSchemaV1[],
+  initialValue: unknown,
+  addIssues: (issues: readonly StandardSchemaV1.Issue[]) => void,
+): MaybePromise<{ value: unknown } | null> {
+  return reduceMaybeAsync<StandardSchemaV1, { value: unknown }>(
+    schemas,
+    { value: initialValue },
+    (current, schema) =>
+      completeValue(schema['~standard'].validate(current.value), (result) => {
+        if (result.issues) {
+          addIssues(result.issues);
+          return null;
+        }
+
+        return { value: result.value };
+      }),
+  );
 }
 
 export function createInputValueMapper<Types extends SchemaTypes, T, Args extends unknown[] = []>(

--- a/packages/plugin-validation/tests/chained-validation.test.ts
+++ b/packages/plugin-validation/tests/chained-validation.test.ts
@@ -140,4 +140,103 @@ describe('Chained validation', () => {
       `);
     });
   });
+
+  describe('transforms that return null', () => {
+    it('continues the chain after a schema transforms a value to null', async () => {
+      const builder = createBuilder();
+
+      builder.queryType({
+        fields: (t) => ({
+          value: t.int({
+            args: {
+              n: t.arg
+                .int({ required: true })
+                .validate(zod.number().transform(() => null))
+                .validate(zod.null().transform(() => 7)),
+            },
+            resolve: (_root, args) => args.n,
+          }),
+        }),
+      });
+
+      const result = await execute({
+        schema: builder.toSchema(),
+        document: gql`
+          query {
+            value(n: 2)
+          }
+        `,
+        contextValue: {},
+      });
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.value).toBe(7);
+    });
+
+    it('continues the chain after an async schema transforms a value to null', async () => {
+      const builder = createBuilder();
+
+      builder.queryType({
+        fields: (t) => ({
+          value: t.int({
+            args: {
+              n: t.arg
+                .int({ required: true })
+                .validate(zod.number().transform(() => Promise.resolve(null)))
+                .validate(zod.null().transform(() => Promise.resolve(7))),
+            },
+            resolve: (_root, args) => args.n,
+          }),
+        }),
+      });
+
+      const result = await execute({
+        schema: builder.toSchema(),
+        document: gql`
+          query {
+            value(n: 2)
+          }
+        `,
+        contextValue: {},
+      });
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data?.value).toBe(7);
+    });
+
+    it('still reports issues from a schema that rejects a null transform result', async () => {
+      const builder = createBuilder();
+
+      builder.queryType({
+        fields: (t) => ({
+          value: t.int({
+            args: {
+              n: t.arg
+                .int({ required: true })
+                .validate(zod.number().transform(() => null))
+                .validate(zod.number()),
+            },
+            resolve: (_root, args) => args.n,
+          }),
+        }),
+      });
+
+      const result = await execute({
+        schema: builder.toSchema(),
+        document: gql`
+          query {
+            value(n: 2)
+          }
+        `,
+        contextValue: {},
+      });
+
+      expect(result.data?.value).toBeNull();
+      expect(result.errors?.map((error) => error.message)).toMatchInlineSnapshot(`
+        [
+          "Validation error: n: Invalid input: expected number, received null",
+        ]
+      `);
+    });
+  });
 });

--- a/packages/plugin-validation/tests/chained-validation.test.ts
+++ b/packages/plugin-validation/tests/chained-validation.test.ts
@@ -1,0 +1,61 @@
+import SchemaBuilder from '@pothos/core';
+import { execute } from 'graphql';
+import { gql } from 'graphql-tag';
+import * as zod from 'zod';
+import '../src';
+
+function createBuilder() {
+  return new SchemaBuilder<{
+    Scalars: {
+      ID: { Input: bigint | number | string; Output: bigint | number | string };
+    };
+  }>({
+    plugins: ['validation'],
+    validation: {},
+  });
+}
+
+const addOne = zod.object({ n: zod.number() }).transform(({ n }) => ({ n: n + 1 }));
+const timesTwo = zod.object({ n: zod.number() }).transform(({ n }) => ({ n: n * 2 }));
+
+describe('Chained validation', () => {
+  describe('input object chains', () => {
+    it('executes chained input type schemas in declaration order', async () => {
+      const builder = createBuilder();
+
+      const Input = builder
+        .inputType('Input', {
+          fields: (t) => ({
+            n: t.int({ required: true }),
+          }),
+        })
+        .validate(addOne)
+        .validate(timesTwo);
+
+      builder.queryType({
+        fields: (t) => ({
+          value: t.int({
+            args: {
+              input: t.arg({ type: Input, required: true }),
+            },
+            resolve: (_root, args) => args.input.n,
+          }),
+        }),
+      });
+
+      const result = await execute({
+        schema: builder.toSchema(),
+        document: gql`
+          query {
+            value(input: { n: 2 })
+          }
+        `,
+        contextValue: {},
+      });
+
+      expect(result.errors).toBeUndefined();
+      // (2 + 1) * 2, not (2 * 2) + 1
+      expect(result.data?.value).toBe(6);
+    });
+  });
+});

--- a/packages/plugin-validation/tests/chained-validation.test.ts
+++ b/packages/plugin-validation/tests/chained-validation.test.ts
@@ -54,7 +54,6 @@ describe('Chained validation', () => {
       });
 
       expect(result.errors).toBeUndefined();
-      // (2 + 1) * 2, not (2 * 2) + 1
       expect(result.data?.value).toBe(6);
     });
   });
@@ -94,8 +93,6 @@ describe('Chained validation', () => {
       });
 
       expect(result.errors).toBeUndefined();
-      // chained schemas run in declaration order, then the options schema,
-      // consistent with input fields and arguments: (2 + 1) * 2
       expect(result.data?.value).toBe(6);
     });
 

--- a/packages/plugin-validation/tests/chained-validation.test.ts
+++ b/packages/plugin-validation/tests/chained-validation.test.ts
@@ -58,4 +58,86 @@ describe('Chained validation', () => {
       expect(result.data?.value).toBe(6);
     });
   });
+
+  describe('input type validate option combined with chained schemas', () => {
+    it('keeps chained schemas when the input type has a validate option', async () => {
+      const builder = createBuilder();
+
+      const Input = builder
+        .inputType('Input', {
+          fields: (t) => ({
+            n: t.int({ required: true }),
+          }),
+          validate: timesTwo,
+        })
+        .validate(addOne);
+
+      builder.queryType({
+        fields: (t) => ({
+          value: t.int({
+            args: {
+              input: t.arg({ type: Input, required: true }),
+            },
+            resolve: (_root, args) => args.input.n,
+          }),
+        }),
+      });
+
+      const result = await execute({
+        schema: builder.toSchema(),
+        document: gql`
+          query {
+            value(input: { n: 2 })
+          }
+        `,
+        contextValue: {},
+      });
+
+      expect(result.errors).toBeUndefined();
+      // chained schemas run in declaration order, then the options schema,
+      // consistent with input fields and arguments: (2 + 1) * 2
+      expect(result.data?.value).toBe(6);
+    });
+
+    it('still applies chained constraints when the input type has a validate option', async () => {
+      const builder = createBuilder();
+
+      const Input = builder
+        .inputType('Input', {
+          fields: (t) => ({
+            n: t.int({ required: true }),
+          }),
+          validate: zod.object({ n: zod.number() }),
+        })
+        .validate(zod.object({ n: zod.number().min(2) }));
+
+      builder.queryType({
+        fields: (t) => ({
+          value: t.int({
+            args: {
+              input: t.arg({ type: Input, required: true }),
+            },
+            resolve: (_root, args) => args.input.n,
+          }),
+        }),
+      });
+
+      const result = await execute({
+        schema: builder.toSchema(),
+        document: gql`
+          query {
+            value(input: { n: 1 })
+          }
+        `,
+        contextValue: {},
+      });
+
+      expect(result.data?.value).toBeNull();
+      expect(result.errors?.map((error) => error.message)).toMatchInlineSnapshot(`
+        [
+          "Validation error: input.n: Too small: expected number to be >=2",
+        ]
+      `);
+    });
+  });
 });


### PR DESCRIPTION
Fixes the three P2 findings from the `@pothos/plugin-validation` whole-plugin review. Each finding has its own commit with a regression test added first; all tests are new GraphQL-level executions in `packages/plugin-validation/tests/chained-validation.test.ts`.

> [!IMPORTANT]
> Fix 2 changes runtime behavior for a supported combination. See [Behavior change](#behavior-change-input-type-validate-option--chained-validate) below before merging.

## 1. Input object chains executed backwards

`InputObjectRef.validate` prepends each schema, so the stored list is in reverse declaration order. Field schemas were reversed before use, but type schemas were consumed as stored, so input object chains ran last-declared-first.

**Fix:** reverse the stored type schemas at the consumption site in `src/index.ts` (`onOutputFieldConfig`), matching the existing field schema handling.

**Verified:** an add-one then multiply-two chain on `{ n: 2 }` returned `5` before the fix and returns the documented `6` after.

## 2. An input type `validate` option discarded chained validators

`onTypeConfig` read prior schemas from the obsolete `extensions.validationSchemas` key, while `InputObjectRef.validate` stores them under `extensions['@pothos/plugin-validation'].schemas`. When an input type declared both a `validate` option and chained validators, the hook replaced the namespaced storage with only the option schema and every chained validator was silently dropped.

**Fix:** read and merge the namespaced storage, mirroring `onInputFieldConfig` exactly.

**Verified:** two tests — a transform chain that returned `4` (option only) before and now returns `6`, and a chained `min(2)` constraint that was silently skipped before and now rejects `{ n: 1 }` with the expected issue message.

### Behavior change: input type `validate` option + chained `.validate()`

With the storage fixed, chained schemas run in declaration order followed by the options schema. That is the ordering already produced for arguments and input fields (instrumented transforms give `["A", "B", "OPT"]` for all three paths after this PR), so input types now behave consistently with the rest of the plugin.

**This is user-visible in a patch release.** Because the options schema runs last, a chained schema that reshapes the value can now fail at runtime where it previously "worked":

```ts
const reshape = zod.object({ n: zod.number() }).transform(({ n }) => ({ label: String(n) }));
const expectsN = zod.object({ n: zod.number() });

const Input = builder
  .inputType('In', { fields: (t) => ({ n: t.int({ required: true }) }), validate: expectsN })
  .validate(reshape); // TypeScript says args.input is { label: string }
```

For `{ value(input: { n: 2 }) }`:

- **before:** resolves with `{ n: 2 }` — the chained schema was dropped entirely (the bug this PR fixes), so the value silently disagreed with its declared type.
- **after:** `data: null`, `Validation error: input.n: Invalid input: expected number, received undefined` — the options schema now runs against the reshaped value and rejects it.

So this fix trades a silent wrong value for a loud error; it does not resolve the underlying type/runtime mismatch. `.validate<R>()` re-types the ref (`src/global-types.ts:81,93,97`) while the `validate` option does not (`:62,69,77`), so the declared type is always the last chained schema's output even though the options schema produces the runtime value. That mismatch is **pre-existing and plugin-wide** — the same failure already occurs for arguments on `main` — and making the options schema run first everywhere is a larger, breaking change that belongs to a maintainer decision, not to this patch. Raised separately; deliberately unchanged here.

## 3. A successful null transform skipped the rest of the chain

The schema reducers in `src/utils.ts` returned `null` both when a schema reported issues and when a schema successfully transformed a value to `null`, and `reduceMaybeAsync` treats `null` as the signal to stop. Standard Schema allows `null` as a successful output, so a null-producing transform silently skipped every following schema even though the inferred type promised the last schema's output.

**Fix:** a small `reduceSchemas` helper wraps values while reducing, so the failure state stays distinct from valid values. `reduceMaybeAsync` itself is untouched, so its existing tested contract still holds.

**Verified:** three tests — a sync `number -> null -> 7` chain and the async equivalent both returned `null` before and now return `7`; and a schema that rejects `null` after a null transform now reports its issue instead of being skipped.

## Checks

- `pnpm --filter @pothos/plugin-validation run test` — 7 files, 209 tests passing (203 before, 6 added), no type errors
- `pnpm --filter @pothos/plugin-validation run type` — clean
- `pnpm biome check packages/plugin-validation` — clean, no fixes applied
- `pnpm --filter @pothos/plugin-errors run test` (the only dependent package) — 63 passing, 4 skipped, unchanged

The full external Standard Schema provider matrix was not run; tests use zod and the plugin's own execution paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
