### PR TITLE
fix(prisma-utils): address 3 findings from the plugin review

### DIFF
--- a/.changeset/prisma-utils-review-fixes.md
+++ b/.changeset/prisma-utils-review-fixes.md
@@ -1,0 +1,7 @@
+---
+"@pothos/plugin-prisma-utils": patch
+---
+
+- `prismaOrderBy` no longer creates a field for entries explicitly set to `false`
+- `prismaOrderBy` scalar field callbacks that omit `type` now default to the order enum instead of failing schema construction
+- `prismaListFilter` now types its operations as optional (and infers op names from `as const` tuples), matching the optional fields it creates at runtime

--- a/.changeset/prisma-utils-review-fixes.md
+++ b/.changeset/prisma-utils-review-fixes.md
@@ -2,6 +2,14 @@
 "@pothos/plugin-prisma-utils": patch
 ---
 
-- `prismaOrderBy` no longer creates a field for entries explicitly set to `false`
+- `prismaOrderBy` no longer creates a field for entries explicitly set to `false`.
+
+  Behaviour change: if _every_ entry is `false` (or `fields` is empty), the resulting
+  input object now has no fields. `builder.toSchema()` still succeeds, but the schema
+  is invalid — `validateSchema()` reports `Input Object type <Name>OrderBy must define
+  one or more fields.` and every query fails with that error. Previously an all-`false`
+  `fields` map produced a working order-by input. Omit the `prismaOrderBy` call
+  entirely when no fields are enabled.
+
 - `prismaOrderBy` scalar field callbacks that omit `type` now default to the order enum instead of failing schema construction
 - `prismaListFilter` now types its operations as optional (and infers op names from `as const` tuples), matching the optional fields it creates at runtime

--- a/packages/plugin-prisma-utils/src/global-types.ts
+++ b/packages/plugin-prisma-utils/src/global-types.ts
@@ -45,7 +45,7 @@ declare global {
       ) => InputObjectRef<
         Types,
         {
-          [K in Ops extends string[] ? Ops[number] : keyof Ops]: InputShapeFromTypeParam<
+          [K in Ops extends readonly string[] ? Ops[number] : keyof Ops]?: InputShapeFromTypeParam<
             Types,
             Type,
             true

--- a/packages/plugin-prisma-utils/src/schema-builder.ts
+++ b/packages/plugin-prisma-utils/src/schema-builder.ts
@@ -281,9 +281,6 @@ schemaBuilder.prismaOrderBy = function prismaOrderBy<
           fieldDefs[field] = t.field({
             required: false,
             ...fieldOptions,
-            // Scalar field callbacks return options without a `type` (see
-            // `PrismaOrderByFields`), and sort by the order enum. Relation callbacks
-            // provide the nested order-by input themselves.
             type: fieldType ?? this.orderByEnum(),
           });
         } else if (typeof fieldOption === 'boolean') {

--- a/packages/plugin-prisma-utils/src/schema-builder.ts
+++ b/packages/plugin-prisma-utils/src/schema-builder.ts
@@ -284,6 +284,10 @@ schemaBuilder.prismaOrderBy = function prismaOrderBy<
             type: fieldType,
           });
         } else if (typeof fieldOption === 'boolean') {
+          if (!fieldOption) {
+            continue;
+          }
+
           fieldDefs[field] = t.field({
             required: false,
             type: this.orderByEnum(),

--- a/packages/plugin-prisma-utils/src/schema-builder.ts
+++ b/packages/plugin-prisma-utils/src/schema-builder.ts
@@ -275,13 +275,16 @@ schemaBuilder.prismaOrderBy = function prismaOrderBy<
       for (const [field, fieldOption] of Object.entries(fieldMap)) {
         if (typeof fieldOption === 'function') {
           const { type: fieldType, ...fieldOptions } = (
-            fieldOption as () => PothosSchemaTypes.InputFieldOptions<SchemaTypes>
+            fieldOption as () => Partial<PothosSchemaTypes.InputFieldOptions<SchemaTypes>>
           )();
 
           fieldDefs[field] = t.field({
             required: false,
             ...fieldOptions,
-            type: fieldType,
+            // Scalar field callbacks return options without a `type` (see
+            // `PrismaOrderByFields`), and sort by the order enum. Relation callbacks
+            // provide the nested order-by input themselves.
+            type: fieldType ?? this.orderByEnum(),
           });
         } else if (typeof fieldOption === 'boolean') {
           if (!fieldOption) {

--- a/packages/plugin-prisma-utils/tests/input-helpers.test.ts
+++ b/packages/plugin-prisma-utils/tests/input-helpers.test.ts
@@ -1,0 +1,43 @@
+import SchemaBuilder from '@pothos/core';
+import type { PrismaModelTypes } from '@pothos/plugin-prisma';
+import type { GraphQLInputObjectType } from 'graphql';
+import { describe, expect, it } from 'vitest';
+import PrismaUtils from '../src';
+
+// These tests only exercise the input-helper builders, which never touch the prisma
+// client or the database, so they run without a generated client.
+type ItemModel = PrismaModelTypes & {
+  Name: 'Item';
+  OrderBy: { id?: 'asc' | 'desc'; value?: 'asc' | 'desc' };
+  ListRelations: never;
+  RelationName: never;
+};
+
+function createBuilder() {
+  return new SchemaBuilder<{ PrismaTypes: { Item: ItemModel } }>({
+    plugins: [PrismaUtils],
+    prisma: {
+      client: {} as never,
+      dmmf: { datamodel: { models: [] } } as never,
+    },
+  });
+}
+
+function inputFields(builder: ReturnType<typeof createBuilder>, name: string) {
+  return (builder.toSchema().getType(name) as GraphQLInputObjectType).getFields();
+}
+
+describe('prismaOrderBy', () => {
+  it('omits fields that are explicitly disabled with false', () => {
+    const builder = createBuilder();
+    const OrderBy = builder.prismaOrderBy('Item', { fields: { id: true, value: false } });
+
+    builder.queryType({
+      fields: (t) => ({
+        hello: t.string({ args: { order: t.arg({ type: OrderBy }) }, resolve: () => '' }),
+      }),
+    });
+
+    expect(Object.keys(inputFields(builder, 'ItemOrderBy'))).toEqual(['id']);
+  });
+});

--- a/packages/plugin-prisma-utils/tests/input-helpers.test.ts
+++ b/packages/plugin-prisma-utils/tests/input-helpers.test.ts
@@ -4,8 +4,6 @@ import { type GraphQLInputObjectType, graphql } from 'graphql';
 import { describe, expect, expectTypeOf, it } from 'vitest';
 import PrismaUtils from '../src';
 
-// These tests only exercise the input-helper builders, which never touch the prisma
-// client or the database, so they run without a generated client.
 type ItemModel = PrismaModelTypes & {
   Name: 'Item';
   OrderBy: { id?: 'asc' | 'desc'; value?: 'asc' | 'desc' };
@@ -71,8 +69,6 @@ describe('prismaListFilter', () => {
         hello: t.int({
           args: { filter: t.arg({ type: ItemListFilter, required: true }) },
           resolve: (_parent, args) => {
-            // `some` is absent for `filter: {}`, so it must be optional in the arg type
-            // rather than something resolvers may dereference unguarded.
             expectTypeOf(args.filter.some).toEqualTypeOf<{ id?: number | null } | undefined>();
             expect(args.filter.some).toBeUndefined();
 

--- a/packages/plugin-prisma-utils/tests/input-helpers.test.ts
+++ b/packages/plugin-prisma-utils/tests/input-helpers.test.ts
@@ -1,7 +1,7 @@
 import SchemaBuilder from '@pothos/core';
 import type { PrismaModelTypes } from '@pothos/plugin-prisma';
-import type { GraphQLInputObjectType } from 'graphql';
-import { describe, expect, it } from 'vitest';
+import { type GraphQLInputObjectType, graphql } from 'graphql';
+import { describe, expect, expectTypeOf, it } from 'vitest';
 import PrismaUtils from '../src';
 
 // These tests only exercise the input-helper builders, which never touch the prisma
@@ -57,5 +57,50 @@ describe('prismaOrderBy', () => {
 
     expect(field.type.toString()).toBe('OrderBy');
     expect(field.description).toBe('Sort ID');
+  });
+});
+
+describe('prismaListFilter', () => {
+  it('types operations as optional because they are optional at runtime', async () => {
+    const builder = createBuilder();
+    const ItemWhere = builder.inputType('ItemWhere', { fields: (t) => ({ id: t.int() }) });
+    const ItemListFilter = builder.prismaListFilter(ItemWhere, { ops: ['some'] });
+
+    builder.queryType({
+      fields: (t) => ({
+        hello: t.int({
+          args: { filter: t.arg({ type: ItemListFilter, required: true }) },
+          resolve: (_parent, args) => {
+            // `some` is absent for `filter: {}`, so it must be optional in the arg type
+            // rather than something resolvers may dereference unguarded.
+            expectTypeOf(args.filter.some).toEqualTypeOf<{ id?: number | null } | undefined>();
+            expect(args.filter.some).toBeUndefined();
+
+            return args.filter.some?.id ?? 0;
+          },
+        }),
+      }),
+    });
+
+    await expect(
+      graphql({ schema: builder.toSchema(), source: '{ hello(filter: {}) }' }),
+    ).resolves.toEqual({ data: { hello: 0 } });
+  });
+
+  it('infers operation names from a readonly ops tuple', () => {
+    const builder = createBuilder();
+    const ItemWhere = builder.inputType('ItemWhere', { fields: (t) => ({ id: t.int() }) });
+    const ItemListFilter = builder.prismaListFilter(ItemWhere, { ops: ['some', 'none'] as const });
+
+    builder.queryType({
+      fields: (t) => ({
+        hello: t.int({
+          args: { filter: t.arg({ type: ItemListFilter, required: true }) },
+          resolve: (_parent, args) => args.filter.some?.id ?? args.filter.none?.id ?? 0,
+        }),
+      }),
+    });
+
+    expect(Object.keys(inputFields(builder, 'ListItemWhere')).sort()).toEqual(['none', 'some']);
   });
 });

--- a/packages/plugin-prisma-utils/tests/input-helpers.test.ts
+++ b/packages/plugin-prisma-utils/tests/input-helpers.test.ts
@@ -40,4 +40,22 @@ describe('prismaOrderBy', () => {
 
     expect(Object.keys(inputFields(builder, 'ItemOrderBy'))).toEqual(['id']);
   });
+
+  it('uses the order enum for scalar option callbacks that omit a type', () => {
+    const builder = createBuilder();
+    const OrderBy = builder.prismaOrderBy('Item', {
+      fields: { id: () => ({ description: 'Sort ID' }) },
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        hello: t.string({ args: { order: t.arg({ type: OrderBy }) }, resolve: () => '' }),
+      }),
+    });
+
+    const field = inputFields(builder, 'ItemOrderBy').id;
+
+    expect(field.type.toString()).toBe('OrderBy');
+    expect(field.description).toBe('Sort ID');
+  });
 });


### PR DESCRIPTION
Addresses the three P2 findings from the `@pothos/plugin-prisma-utils` whole-plugin review. All three are mechanical; no semantics were redesigned.

New focused tests live in `packages/plugin-prisma-utils/tests/input-helpers.test.ts`. They exercise only the input-helper builders, which never touch the Prisma client, so they need no database.

## 1. `prismaOrderBy` included fields set to `false`

`src/schema-builder.ts` created an input field for every boolean entry, so `fields: { id: true, value: false }` exposed both `id` and `value`. `PrismaOrderByFields` admits booleans precisely so options can be disabled conditionally, and sibling helpers skip falsy entries.

**Fix:** skip `false` entries before building the field.

**Verified:** `omits fields that are explicitly disabled with false` — failed before with `expected [ 'id', 'value' ] to deeply equal [ 'id' ]`, passes now.

### Behaviour change to be aware of

This fix has a degenerate case that is a **user-visible break shipping as a patch**. If *every* entry is `false`, the input object is now built with zero fields:

```ts
builder.prismaOrderBy('Item', { fields: { id: false, value: false } })
```

`builder.toSchema()` does **not** throw — the invalid schema builds silently, `printSchema` emits a bodyless `input ItemOrderBy`, and `validateSchema()` reports `Input Object type ItemOrderBy must define one or more fields.` Every subsequent query then fails with that same message as a top-level error. Before this fix that schema worked, because the `false` entries still produced fields.

`fields: {}` was already broken this way, so this is the existing behaviour of an empty field map rather than a new failure mode — but it is now reachable through a new path. Callers should omit the `prismaOrderBy` call entirely when no fields are enabled. Called out in the changeset.

## 2. Scalar `orderBy` option callbacks could not build

`PrismaOrderByFields` lets a scalar field pass a callback returning `Omit<InputFieldOptions, 'type'>`, but `prismaOrderBy` destructured `type` from every callback result and forwarded `undefined`. An accepted `id: () => ({ description: 'Sort ID' })` compiled and then failed schema construction with `<unnamed ref or enum> has not been implemented`.

**Fix:** fall back to `orderByEnum()` when a callback omits a type. Relation callbacks, which supply their own nested order-by input, are unchanged.

**Verified:** `uses the order enum for scalar option callbacks that omit a type` — failed before with the `PothosSchemaError` above, now builds and asserts both the `OrderBy` field type and the callback-supplied description.

## 3. `prismaListFilter` typed optional operations as required

`src/global-types.ts` declared the returned shape with required mapped keys even though the runtime creates every operation field with `required: false`. `args.filter.some.id` type-checked under strict TypeScript, while the valid query `{ hello(filter: {}) }` threw `Cannot read properties of undefined (reading 'id')`. The same mapped type also tested `Ops extends string[]`, so an `as const` ops tuple fell through to `keyof Ops` and produced array keys (`0`, `length`, `at`, ...) instead of operation names — the sibling helpers already use `readonly string[]`.

**Fix:** mark the mapped keys optional and test `Ops extends readonly string[]`.

`T | undefined` exactly describes the runtime domain, with no missing `null`: for `{ hello(filter: {}) }` the resolver sees `args.filter.some === undefined`, and `filter: { some: null }` also arrives as `undefined` because Pothos strips the explicit null.

This is a type-level tightening: code that dereferenced an operation unguarded stops compiling, but that code was already crashing at runtime for an empty filter.

**Verified:** two assertions, which are **type-level only**. Both are inert as vitest tests — they pass at runtime even with the fix reverted, and vitest's `typecheck` only covers `*.test-d.ts`, so it never looks at this file. The guard that actually enforces them is the package's separate `pnpm run type` script (`tsc --project tsconfig.type.json`), which runs in CI. With the fix reverted, that script reports on the new test file:

```
tests/input-helpers.test.ts(76,58): error TS2344: Type '{ id?: number | null | undefined; } | undefined' does not satisfy the constraint '{ id: "Expected: never, Actual: null" | ... }'
tests/input-helpers.test.ts(99,75): error TS2339: Property 'none' does not exist on type '{ [x: number]: ...; at: ...; concat: ...; ... 29 more ...; }'
```

Both are clean with the fix. Separately, at runtime, `{ hello(filter: {}) }` now resolves to `{ data: { hello: 0 } }`.

## Test / type / lint results

`pnpm --filter @pothos/plugin-prisma-utils run test`: **4 files / 10 tests green.**

An earlier revision of this description claimed three of the four suites could not run because the generated Prisma client was absent. That was wrong, and it is corrected here: the missing `generated.js` was an artifact of gitignored fixtures not being present in the worktree this branch was prepared in, not a property of the repo. The suite's `prisma migrate reset -f` step is intentional and operates on a seeded test database only.

`pnpm --filter @pothos/plugin-prisma-utils run type`: clean — zero errors in `src/` and zero in the new test file.

`pnpm biome check packages/plugin-prisma-utils`: clean, 31 files, no fixes applied.

`pnpm turbo run build --filter=@pothos/plugin-prisma-utils`: succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
