### PR TITLE
fix(errors): address 3 findings from the plugin review

### DIFF
--- a/.changeset/errors-review-fixes.md
+++ b/.changeset/errors-review-fixes.md
@@ -1,0 +1,7 @@
+---
+"@pothos/plugin-errors": patch
+---
+
+- Resolve promised list items before matching them against declared error types, so fulfilled and rejected declared errors become union members instead of GraphQL errors
+- Keep builder level `defaultResultOptions.fields` and `defaultUnionOptions.extensions` (and their `defaultItem*` equivalents) on generated success and union types
+- Wrap non-extensible (frozen) declared errors without violating Proxy invariants

--- a/.changeset/errors-review-fixes.md
+++ b/.changeset/errors-review-fixes.md
@@ -2,6 +2,6 @@
 "@pothos/plugin-errors": patch
 ---
 
-- Resolve promised list items before matching them against declared error types, so fulfilled and rejected declared errors become union members instead of GraphQL errors
-- Keep builder level `defaultResultOptions.fields` and `defaultUnionOptions.extensions` (and their `defaultItem*` equivalents) on generated success and union types
+- Resolve promised list items before matching them against declared error types, so fulfilled and rejected declared errors become union members instead of GraphQL errors. Errors are now only wrapped at the list level the generated item union actually covers, so errors and rejections in nested lists are reported with their original message instead of becoming invalid values for the real item type
+- Keep builder level `defaultResultOptions.fields` and `defaultUnionOptions.extensions` (and their `defaultItem*` equivalents) on generated success and union types. Note that this changes the generated SDL: schemas that configure `defaultResultOptions.fields` or `defaultItemResultOptions.fields` will gain those fields on every generated `*Success` type, where they were previously dropped
 - Wrap non-extensible (frozen) declared errors without violating Proxy invariants

--- a/packages/plugin-errors/src/index.ts
+++ b/packages/plugin-errors/src/index.ts
@@ -35,6 +35,21 @@ const pluginName = 'errors';
 
 export default pluginName;
 
+// Number of list levels in a field type. The generated item error union sits
+// one level in from the innermost list, so this tells the item wrapper which
+// level of a nested list its error types actually apply to.
+function getListDepth<Types extends SchemaTypes>(type: PothosOutputFieldType<Types>): number {
+  let depth = 0;
+  let current = type;
+
+  while (current.kind === 'List') {
+    depth += 1;
+    current = current.type;
+  }
+
+  return depth;
+}
+
 export class PothosErrorsPlugin<Types extends SchemaTypes> extends BasePlugin<Types> {
   override wrapIsTypeOf(
     isTypeOf: GraphQLIsTypeOfFn<unknown, Types['Context']> | undefined,
@@ -66,13 +81,15 @@ export class PothosErrorsPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
         | undefined;
 
       if (errorTypes) {
-        const isListField = fieldConfig.type.kind === 'List';
+        const listDepth = getListDepth(fieldConfig.type);
 
         return {
           ...fieldConfig,
           extensions: {
             ...fieldConfig.extensions,
-            ...(isListField ? { pothosItemErrors: errorTypes } : { pothosErrors: errorTypes }),
+            ...(listDepth > 0
+              ? { pothosItemErrors: errorTypes, pothosItemErrorsDepth: listDepth - 1 }
+              : { pothosErrors: errorTypes }),
           },
         };
       }
@@ -177,6 +194,8 @@ export class PothosErrorsPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
     const pothosItemErrors = fieldConfig.extensions?.pothosItemErrors as
       | (typeof Error)[]
       | undefined;
+    const pothosItemErrorsDepth =
+      (fieldConfig.extensions?.pothosItemErrorsDepth as number | undefined) ?? 0;
     const onResolvedError = this.builder.options.errors?.onResolvedError;
 
     if (!pothosErrors && !pothosItemErrors) {
@@ -192,7 +211,7 @@ export class PothosErrorsPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
         const result = (await resolver(source, args, context, info)) as never;
 
         if (pothosItemErrors && result && typeof result === 'object' && Symbol.iterator in result) {
-          return yieldErrors(result, pothosItemErrors, onResolvedError);
+          return yieldErrors(result, pothosItemErrors, onResolvedError, pothosItemErrorsDepth);
         }
 
         if (
@@ -201,7 +220,7 @@ export class PothosErrorsPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
           typeof result === 'object' &&
           Symbol.asyncIterator in result
         ) {
-          return yieldAsyncErrors(result, pothosItemErrors, onResolvedError);
+          return yieldAsyncErrors(result, pothosItemErrors, onResolvedError, pothosItemErrorsDepth);
         }
 
         if (

--- a/packages/plugin-errors/src/index.ts
+++ b/packages/plugin-errors/src/index.ts
@@ -78,7 +78,6 @@ export class PothosErrorsPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
         | undefined;
 
       if (errorTypes) {
-        // `pothosItemErrorsDepth` is the number of list levels above the items the union covers.
         const listDepth = getListDepth(fieldConfig.type);
 
         return {

--- a/packages/plugin-errors/src/index.ts
+++ b/packages/plugin-errors/src/index.ts
@@ -35,9 +35,6 @@ const pluginName = 'errors';
 
 export default pluginName;
 
-// Number of list levels in a field type. The generated item error union sits
-// one level in from the innermost list, so this tells the item wrapper which
-// level of a nested list its error types actually apply to.
 function getListDepth<Types extends SchemaTypes>(type: PothosOutputFieldType<Types>): number {
   let depth = 0;
   let current = type;
@@ -81,6 +78,7 @@ export class PothosErrorsPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
         | undefined;
 
       if (errorTypes) {
+        // `pothosItemErrorsDepth` is the number of list levels above the items the union covers.
         const listDepth = getListDepth(fieldConfig.type);
 
         return {

--- a/packages/plugin-errors/src/index.ts
+++ b/packages/plugin-errors/src/index.ts
@@ -308,8 +308,11 @@ export class PothosErrorsPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
     > = {} as never,
   ) {
     const errorBuilderOptions = this.builder.options.errors;
-    const { name: getResultName = defaultResultName, ...defaultResultOptions } =
-      builderResultOptions ?? {};
+    const {
+      name: getResultName = defaultResultName,
+      fields: defaultResultFields,
+      ...defaultResultOptions
+    } = builderResultOptions ?? {};
     const { name: getUnionName = defaultUnionName, ...defaultUnionOptions } =
       builderUnionOptions ?? {};
 
@@ -358,6 +361,7 @@ export class PothosErrorsPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
           ...defaultResultOptions,
           ...resultObjectOptions,
           fields: (t) => ({
+            ...defaultResultFields?.(t as never),
             ...resultFieldOptions?.(t),
             [dataFieldName]: t.field({
               ...dataField,
@@ -379,6 +383,7 @@ export class PothosErrorsPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
         ...defaultUnionOptions,
         ...unionOptions,
         extensions: {
+          ...defaultUnionOptions.extensions,
           ...unionOptions.extensions,
           getDataloader,
           pothosIndirectInclude: {

--- a/packages/plugin-errors/src/utils.ts
+++ b/packages/plugin-errors/src/utils.ts
@@ -98,6 +98,30 @@ export function wrapErrorIfMatches(
   return value;
 }
 
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    ((typeof value === 'object' && value !== null) || typeof value === 'function') &&
+    typeof (value as PromiseLike<unknown>).then === 'function'
+  );
+}
+
+function wrapItem(
+  item: unknown,
+  pothosErrors: (new (...args: never[]) => unknown)[],
+  onResolvedError?: (error: Error) => void,
+): unknown {
+  if (
+    item !== null &&
+    typeof item === 'object' &&
+    !(item instanceof Error) &&
+    Symbol.iterator in item
+  ) {
+    return [...yieldErrors(item as Iterable<unknown>, pothosErrors, onResolvedError)];
+  }
+
+  return wrapErrorIfMatches(item, pothosErrors, onResolvedError);
+}
+
 export function* yieldErrors(
   result: Iterable<unknown>,
   pothosErrors: (new (...args: never[]) => unknown)[],
@@ -105,15 +129,13 @@ export function* yieldErrors(
 ): Generator<unknown> {
   try {
     for (const item of result) {
-      if (
-        item !== null &&
-        typeof item === 'object' &&
-        !(item instanceof Error) &&
-        Symbol.iterator in item
-      ) {
-        yield [...yieldErrors(item as Iterable<unknown>, pothosErrors, onResolvedError)];
+      if (isThenable(item)) {
+        yield Promise.resolve(item).then(
+          (value) => wrapItem(value, pothosErrors, onResolvedError),
+          (error: unknown) => wrapOrThrow(error, pothosErrors, onResolvedError),
+        );
       } else {
-        yield wrapErrorIfMatches(item, pothosErrors, onResolvedError);
+        yield wrapItem(item, pothosErrors, onResolvedError);
       }
     }
   } catch (error: unknown) {

--- a/packages/plugin-errors/src/utils.ts
+++ b/packages/plugin-errors/src/utils.ts
@@ -126,18 +126,26 @@ function isThenable(value: unknown): value is PromiseLike<unknown> {
   );
 }
 
+function isNestedList(item: unknown): item is Iterable<unknown> {
+  return (
+    item !== null && typeof item === 'object' && !(item instanceof Error) && Symbol.iterator in item
+  );
+}
+
+// `depth` is the number of list levels between the items being iterated and the
+// items the generated error union actually covers. Errors are only wrapped at
+// that depth; at any other level they are left alone so they are reported as
+// ordinary errors rather than becoming invalid values for the real item type.
 function wrapItem(
   item: unknown,
   pothosErrors: (new (...args: never[]) => unknown)[],
   onResolvedError?: (error: Error) => void,
+  depth = 0,
 ): unknown {
-  if (
-    item !== null &&
-    typeof item === 'object' &&
-    !(item instanceof Error) &&
-    Symbol.iterator in item
-  ) {
-    return [...yieldErrors(item as Iterable<unknown>, pothosErrors, onResolvedError)];
+  if (depth > 0) {
+    return isNestedList(item)
+      ? [...yieldErrors(item, pothosErrors, onResolvedError, depth - 1)]
+      : item;
   }
 
   return wrapErrorIfMatches(item, pothosErrors, onResolvedError);
@@ -147,19 +155,30 @@ export function* yieldErrors(
   result: Iterable<unknown>,
   pothosErrors: (new (...args: never[]) => unknown)[],
   onResolvedError?: (error: Error) => void,
+  depth = 0,
 ): Generator<unknown> {
   try {
     for (const item of result) {
       if (isThenable(item)) {
         yield Promise.resolve(item).then(
-          (value) => wrapItem(value, pothosErrors, onResolvedError),
-          (error: unknown) => wrapOrThrow(error, pothosErrors, onResolvedError),
+          (value) => wrapItem(value, pothosErrors, onResolvedError, depth),
+          (error: unknown) => {
+            if (depth > 0) {
+              throw error;
+            }
+
+            return wrapOrThrow(error, pothosErrors, onResolvedError);
+          },
         );
       } else {
-        yield wrapItem(item, pothosErrors, onResolvedError);
+        yield wrapItem(item, pothosErrors, onResolvedError, depth);
       }
     }
   } catch (error: unknown) {
+    if (depth > 0) {
+      throw error;
+    }
+
     yield wrapOrThrow(error, pothosErrors, onResolvedError);
   }
 }
@@ -168,10 +187,12 @@ export async function* yieldAsyncErrors(
   result: AsyncIterable<unknown>,
   pothosErrors: (new (...args: never[]) => unknown)[],
   onResolvedError?: (error: Error) => void,
+  depth = 0,
 ): AsyncGenerator<unknown> {
   try {
     for await (const item of result) {
       if (
+        depth > 0 &&
         item !== null &&
         typeof item === 'object' &&
         !(item instanceof Error) &&
@@ -182,22 +203,20 @@ export async function* yieldAsyncErrors(
           item as AsyncIterable<unknown>,
           pothosErrors,
           onResolvedError,
+          depth - 1,
         )) {
           nestedResults.push(nested);
         }
         yield nestedResults;
-      } else if (
-        item !== null &&
-        typeof item === 'object' &&
-        !(item instanceof Error) &&
-        Symbol.iterator in item
-      ) {
-        yield [...yieldErrors(item as Iterable<unknown>, pothosErrors, onResolvedError)];
       } else {
-        yield wrapErrorIfMatches(item, pothosErrors, onResolvedError);
+        yield wrapItem(item, pothosErrors, onResolvedError, depth);
       }
     }
   } catch (error: unknown) {
+    if (depth > 0) {
+      throw error;
+    }
+
     yield wrapOrThrow(error, pothosErrors, onResolvedError);
   }
 }

--- a/packages/plugin-errors/src/utils.ts
+++ b/packages/plugin-errors/src/utils.ts
@@ -35,7 +35,6 @@ export const defaultGetListItemResultName: GetTypeName = ({ parentTypeName, fiel
 export const defaultGetListItemUnionName: GetTypeName = ({ parentTypeName, fieldName }) =>
   `${parentTypeName}${capitalize(fieldName)}ItemResult`;
 
-// A non-extensible target forces a Proxy's `getPrototypeOf` to report the target's own prototype.
 function createProxyTarget(target: {}): {} {
   if (Object.isExtensible(target)) {
     return target;

--- a/packages/plugin-errors/src/utils.ts
+++ b/packages/plugin-errors/src/utils.ts
@@ -35,8 +35,29 @@ export const defaultGetListItemResultName: GetTypeName = ({ parentTypeName, fiel
 export const defaultGetListItemUnionName: GetTypeName = ({ parentTypeName, fieldName }) =>
   `${parentTypeName}${capitalize(fieldName)}ItemResult`;
 
+// Proxy invariants require `getPrototypeOf` to return the real prototype of a
+// non-extensible target, which would make the wrapped error visible as an Error
+// again. Wrapping an extensible copy of the error keeps the invariants intact.
+function createProxyTarget(target: {}): {} {
+  if (Object.isExtensible(target)) {
+    return target;
+  }
+
+  const copy = Object.create(Object.getPrototypeOf(target) as object | null) as {};
+
+  for (const key of Reflect.ownKeys(target)) {
+    const descriptor = Object.getOwnPropertyDescriptor(target, key);
+
+    if (descriptor) {
+      Object.defineProperty(copy, key, { ...descriptor, configurable: true });
+    }
+  }
+
+  return copy;
+}
+
 export function createErrorProxy(target: {}, ref: unknown, state: { wrapped: boolean }): {} {
-  return new Proxy(target, {
+  return new Proxy(createProxyTarget(target), {
     get(err, val, receiver) {
       if (val === unwrapError) {
         return () => {

--- a/packages/plugin-errors/src/utils.ts
+++ b/packages/plugin-errors/src/utils.ts
@@ -35,9 +35,7 @@ export const defaultGetListItemResultName: GetTypeName = ({ parentTypeName, fiel
 export const defaultGetListItemUnionName: GetTypeName = ({ parentTypeName, fieldName }) =>
   `${parentTypeName}${capitalize(fieldName)}ItemResult`;
 
-// Proxy invariants require `getPrototypeOf` to return the real prototype of a
-// non-extensible target, which would make the wrapped error visible as an Error
-// again. Wrapping an extensible copy of the error keeps the invariants intact.
+// A non-extensible target forces a Proxy's `getPrototypeOf` to report the target's own prototype.
 function createProxyTarget(target: {}): {} {
   if (Object.isExtensible(target)) {
     return target;
@@ -132,10 +130,6 @@ function isNestedList(item: unknown): item is Iterable<unknown> {
   );
 }
 
-// `depth` is the number of list levels between the items being iterated and the
-// items the generated error union actually covers. Errors are only wrapped at
-// that depth; at any other level they are left alone so they are reported as
-// ordinary errors rather than becoming invalid values for the real item type.
 function wrapItem(
   item: unknown,
   pothosErrors: (new (...args: never[]) => unknown)[],

--- a/packages/plugin-errors/tests/frozen-errors.test.ts
+++ b/packages/plugin-errors/tests/frozen-errors.test.ts
@@ -1,0 +1,119 @@
+import SchemaBuilder from '@pothos/core';
+import { graphql } from 'graphql';
+import ErrorPlugin from '../src';
+
+describe('frozen errors', () => {
+  function createBuilder() {
+    const builder = new SchemaBuilder<{}>({ plugins: [ErrorPlugin] });
+
+    builder.objectType(Error, {
+      name: 'BaseError',
+      fields: (t) => ({
+        message: t.exposeString('message'),
+      }),
+    });
+
+    return builder;
+  }
+
+  it('wraps a thrown frozen declared error', async () => {
+    const builder = createBuilder();
+
+    builder.queryType({
+      fields: (t) => ({
+        value: t.int({
+          errors: { types: [Error] },
+          resolve: () => {
+            throw Object.freeze(new Error('bad'));
+          },
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ value { __typename ... on BaseError { message } } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ value: { __typename: 'BaseError', message: 'bad' } });
+  });
+
+  it('wraps a thrown non-extensible declared error subclass', async () => {
+    const builder = createBuilder();
+
+    class CustomError extends Error {
+      code: string;
+
+      constructor(message: string, code: string) {
+        super(message);
+        this.code = code;
+      }
+    }
+
+    builder.objectType(CustomError, {
+      name: 'CustomError',
+      isTypeOf: (value) => value instanceof CustomError,
+      fields: (t) => ({
+        message: t.exposeString('message'),
+        code: t.exposeString('code'),
+      }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        value: t.int({
+          errors: { types: [CustomError] },
+          resolve: () => {
+            throw Object.preventExtensions(new CustomError('bad', 'CODE'));
+          },
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ value { __typename ... on CustomError { message code } } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      value: { __typename: 'CustomError', message: 'bad', code: 'CODE' },
+    });
+  });
+
+  it('wraps a frozen declared error returned as a list item', async () => {
+    const builder = createBuilder();
+    const Success = builder.objectRef<{ value: number }>('Success').implement({
+      isTypeOf: (value) => typeof value === 'object' && value !== null && 'value' in value,
+      fields: (t) => ({
+        value: t.exposeInt('value'),
+      }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        results: t.errorUnionListField({
+          types: [Success, Error],
+          resolve: () => [{ value: 1 }, Object.freeze(new Error('bad'))],
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ results { __typename ... on BaseError { message } ... on Success { value } } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      results: [
+        { __typename: 'Success', value: 1 },
+        { __typename: 'BaseError', message: 'bad' },
+      ],
+    });
+  });
+});

--- a/packages/plugin-errors/tests/generated-type-defaults.test.ts
+++ b/packages/plugin-errors/tests/generated-type-defaults.test.ts
@@ -1,0 +1,138 @@
+import SchemaBuilder from '@pothos/core';
+import type { GraphQLObjectType } from 'graphql';
+import ErrorPlugin from '../src';
+
+describe('generated type defaults', () => {
+  it('applies default result fields and default union extensions', () => {
+    const builder = new SchemaBuilder<{}>({
+      plugins: [ErrorPlugin],
+      errors: {
+        defaultTypes: [Error],
+        defaultResultOptions: {
+          fields: (t) => ({
+            marker: t.boolean({ resolve: () => true }),
+          }),
+        },
+        defaultUnionOptions: {
+          extensions: { marker: 'preserved' },
+        },
+      },
+    });
+
+    builder.objectType(Error, {
+      name: 'BaseError',
+      fields: (t) => ({
+        message: t.exposeString('message'),
+      }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        value: t.int({
+          errors: {},
+          resolve: () => 1,
+        }),
+      }),
+    });
+
+    const schema = builder.toSchema();
+
+    expect(
+      (schema.getType('QueryValueSuccess') as GraphQLObjectType).getFields().marker,
+    ).toBeDefined();
+    expect(schema.getType('QueryValueResult')?.extensions.marker).toBe('preserved');
+  });
+
+  it('applies default item result fields and default item union extensions', () => {
+    const builder = new SchemaBuilder<{}>({
+      plugins: [ErrorPlugin],
+      errors: {
+        defaultTypes: [Error],
+        defaultItemResultOptions: {
+          fields: (t) => ({
+            marker: t.boolean({ resolve: () => true }),
+          }),
+        },
+        defaultItemUnionOptions: {
+          extensions: { marker: 'preserved' },
+        },
+      },
+    });
+
+    builder.objectType(Error, {
+      name: 'BaseError',
+      fields: (t) => ({
+        message: t.exposeString('message'),
+      }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        values: t.intList({
+          itemErrors: {},
+          resolve: () => [1],
+        }),
+      }),
+    });
+
+    const schema = builder.toSchema();
+
+    expect(
+      (schema.getType('QueryValuesItemSuccess') as GraphQLObjectType).getFields().marker,
+    ).toBeDefined();
+    expect(schema.getType('QueryValuesItemResult')?.extensions.marker).toBe('preserved');
+  });
+
+  it('lets field level options override the defaults', () => {
+    const builder = new SchemaBuilder<{}>({
+      plugins: [ErrorPlugin],
+      errors: {
+        defaultTypes: [Error],
+        defaultResultOptions: {
+          description: 'default description',
+          fields: (t) => ({
+            marker: t.boolean({ resolve: () => true }),
+          }),
+        },
+        defaultUnionOptions: {
+          extensions: { marker: 'preserved', overridden: 'default' },
+        },
+      },
+    });
+
+    builder.objectType(Error, {
+      name: 'BaseError',
+      fields: (t) => ({
+        message: t.exposeString('message'),
+      }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        value: t.int({
+          errors: {
+            result: {
+              description: 'field description',
+              fields: (t) => ({
+                fieldMarker: t.boolean({ resolve: () => true }),
+              }),
+            },
+            union: {
+              extensions: { overridden: 'field' },
+            },
+          },
+          resolve: () => 1,
+        }),
+      }),
+    });
+
+    const schema = builder.toSchema();
+    const successType = schema.getType('QueryValueSuccess') as GraphQLObjectType;
+
+    expect(successType.description).toBe('field description');
+    expect(successType.getFields().marker).toBeDefined();
+    expect(successType.getFields().fieldMarker).toBeDefined();
+    expect(schema.getType('QueryValueResult')?.extensions.marker).toBe('preserved');
+    expect(schema.getType('QueryValueResult')?.extensions.overridden).toBe('field');
+  });
+});

--- a/packages/plugin-errors/tests/promise-list-items.test.ts
+++ b/packages/plugin-errors/tests/promise-list-items.test.ts
@@ -165,7 +165,6 @@ describe('nested list items', () => {
 
     builder.queryType({
       fields: (t) => ({
-        // Nested lists work at runtime but are not expressible in `TypeParam`, hence the cast.
         values: t.field({
           type: [['Int']],
           nullable: { list: true, items: { list: true, items: true } },

--- a/packages/plugin-errors/tests/promise-list-items.test.ts
+++ b/packages/plugin-errors/tests/promise-list-items.test.ts
@@ -1,0 +1,151 @@
+import SchemaBuilder from '@pothos/core';
+import { graphql } from 'graphql';
+import ErrorPlugin from '../src';
+
+describe('promised list items', () => {
+  function createBuilder() {
+    const builder = new SchemaBuilder<{}>({ plugins: [ErrorPlugin] });
+
+    builder.objectType(Error, {
+      name: 'BaseError',
+      fields: (t) => ({
+        message: t.exposeString('message'),
+      }),
+    });
+
+    return builder;
+  }
+
+  it('wraps a synchronous declared Error in an explicit error union list', async () => {
+    const builder = createBuilder();
+    const Success = builder.objectRef<{ value: number }>('Success').implement({
+      isTypeOf: (value) => typeof value === 'object' && value !== null && 'value' in value,
+      fields: (t) => ({
+        value: t.exposeInt('value'),
+      }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        results: t.errorUnionListField({
+          types: [Success, Error],
+          resolve: () => [{ value: 1 }, new Error('expected')],
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ results { __typename ... on BaseError { message } ... on Success { value } } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      results: [
+        { __typename: 'Success', value: 1 },
+        { __typename: 'BaseError', message: 'expected' },
+      ],
+    });
+  });
+
+  it.each([
+    'fulfilled',
+    'rejected',
+  ] as const)('wraps a %s Error promise in an explicit error union list', async (mode) => {
+    const builder = createBuilder();
+    const Success = builder.objectRef<{ value: number }>('Success').implement({
+      isTypeOf: (value) => typeof value === 'object' && value !== null && 'value' in value,
+      fields: (t) => ({
+        value: t.exposeInt('value'),
+      }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        results: t.errorUnionListField({
+          types: [Success, Error],
+          resolve: () => [
+            Promise.resolve({ value: 1 }),
+            mode === 'fulfilled'
+              ? Promise.resolve(new Error('expected'))
+              : Promise.reject(new Error('expected')),
+          ],
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: '{ results { __typename ... on BaseError { message } ... on Success { value } } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      results: [
+        { __typename: 'Success', value: 1 },
+        { __typename: 'BaseError', message: 'expected' },
+      ],
+    });
+  });
+
+  it('wraps a rejected item promise for a scalar list with itemErrors', async () => {
+    const builder = createBuilder();
+
+    builder.queryType({
+      fields: (t) => ({
+        values: t.intList({
+          itemErrors: { types: [Error] },
+          resolve: () => [Promise.resolve(1), Promise.reject(new Error('expected'))],
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source:
+        '{ values { __typename ... on BaseError { message } ... on QueryValuesItemSuccess { data } } }',
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      values: [
+        { __typename: 'QueryValuesItemSuccess', data: 1 },
+        { __typename: 'BaseError', message: 'expected' },
+      ],
+    });
+  });
+
+  it('rethrows rejected item promises that do not match a declared error', async () => {
+    const builder = createBuilder();
+
+    class CustomError extends Error {}
+
+    builder.objectType(CustomError, {
+      name: 'CustomError',
+      fields: (t) => ({
+        message: t.exposeString('message'),
+      }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        values: t.intList({
+          itemErrors: { types: [CustomError] },
+          resolve: () => [Promise.resolve(1), Promise.reject(new Error('unmatched'))],
+        }),
+      }),
+    });
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source:
+        '{ values { __typename ... on CustomError { message } ... on QueryValuesItemSuccess { data } } }',
+      contextValue: {},
+    });
+
+    expect(result.errors?.[0]?.message).toBe('unmatched');
+  });
+});

--- a/packages/plugin-errors/tests/promise-list-items.test.ts
+++ b/packages/plugin-errors/tests/promise-list-items.test.ts
@@ -149,3 +149,148 @@ describe('promised list items', () => {
     expect(result.errors?.[0]?.message).toBe('unmatched');
   });
 });
+
+describe('nested list items', () => {
+  function createNestedBuilder(
+    resolve: () => unknown[],
+  ): PothosSchemaTypes.SchemaBuilder<PothosSchemaTypes.ExtendDefaultTypes<{}>> {
+    const builder = new SchemaBuilder<{}>({ plugins: [ErrorPlugin] });
+
+    builder.objectType(Error, {
+      name: 'BaseError',
+      fields: (t) => ({
+        message: t.exposeString('message'),
+      }),
+    });
+
+    builder.queryType({
+      fields: (t) => ({
+        // Nested lists are supported at runtime but are not expressible in
+        // `TypeParam`, so these options are cast.
+        values: t.field({
+          type: [['Int']],
+          nullable: { list: true, items: { list: true, items: true } },
+          itemErrors: { types: [Error] },
+          resolve,
+        } as never),
+      }),
+    });
+
+    return builder;
+  }
+
+  const source =
+    '{ values { __typename ... on BaseError { message } ... on QueryValuesItemSuccess { data } } }';
+
+  it('reports errors thrown for inner list items', async () => {
+    const builder = createNestedBuilder(() => [[1, new Error('inner-sync')]]);
+
+    const result = await graphql({ schema: builder.toSchema(), source, contextValue: {} });
+
+    expect(result.errors?.map((error) => error.message)).toEqual(['inner-sync']);
+    expect(result.data).toEqual({
+      values: [{ __typename: 'QueryValuesItemSuccess', data: [1, null] }],
+    });
+  });
+
+  it('reports rejections for inner list items', async () => {
+    const builder = createNestedBuilder(() => [[1, Promise.reject(new Error('inner-async'))]]);
+
+    const result = await graphql({ schema: builder.toSchema(), source, contextValue: {} });
+
+    expect(result.errors?.map((error) => error.message)).toEqual(['inner-async']);
+    expect(result.data).toEqual({
+      values: [{ __typename: 'QueryValuesItemSuccess', data: [1, null] }],
+    });
+  });
+
+  it('still wraps declared errors at the item level of a nested list', async () => {
+    const builder = createNestedBuilder(() => [
+      [1, 2],
+      new Error('outer'),
+      Promise.reject(new Error('outer-async')),
+    ]);
+
+    const result = await graphql({ schema: builder.toSchema(), source, contextValue: {} });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      values: [
+        { __typename: 'QueryValuesItemSuccess', data: [1, 2] },
+        { __typename: 'BaseError', message: 'outer' },
+        { __typename: 'BaseError', message: 'outer-async' },
+      ],
+    });
+  });
+
+  function createNestedUnionBuilder(resolve: () => unknown[]) {
+    const builder = new SchemaBuilder<{}>({ plugins: [ErrorPlugin] });
+
+    builder.objectType(Error, {
+      name: 'BaseError',
+      fields: (t) => ({
+        message: t.exposeString('message'),
+      }),
+    });
+
+    const Item = builder.objectRef<{ value: number }>('Item').implement({
+      isTypeOf: (value) => typeof value === 'object' && value !== null && 'value' in value,
+      fields: (t) => ({
+        value: t.exposeInt('value'),
+      }),
+    });
+
+    const ItemResult = builder.errorUnion('ItemResult', { types: [Item, Error] });
+
+    builder.queryType({
+      fields: (t) => ({
+        rows: t.field({
+          type: t.listRef(t.listRef(ItemResult)),
+          resolve: resolve as never,
+        }),
+      }),
+    });
+
+    return builder;
+  }
+
+  const rowsSource = '{ rows { __typename ... on BaseError { message } ... on Item { value } } }';
+
+  it('wraps declared errors at the level the error union covers', async () => {
+    const builder = createNestedUnionBuilder(() => [
+      [{ value: 1 }, new Error('inner'), Promise.reject(new Error('inner-async'))],
+    ]);
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: rowsSource,
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      rows: [
+        [
+          { __typename: 'Item', value: 1 },
+          { __typename: 'BaseError', message: 'inner' },
+          { __typename: 'BaseError', message: 'inner-async' },
+        ],
+      ],
+    });
+  });
+
+  it('reports rejections above the level the error union covers', async () => {
+    const builder = createNestedUnionBuilder(() => [
+      [{ value: 1 }],
+      Promise.reject(new Error('row-async')),
+    ]);
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: rowsSource,
+      contextValue: {},
+    });
+
+    expect(result.errors?.map((error) => error.message)).toEqual(['row-async']);
+  });
+});

--- a/packages/plugin-errors/tests/promise-list-items.test.ts
+++ b/packages/plugin-errors/tests/promise-list-items.test.ts
@@ -165,8 +165,7 @@ describe('nested list items', () => {
 
     builder.queryType({
       fields: (t) => ({
-        // Nested lists are supported at runtime but are not expressible in
-        // `TypeParam`, so these options are cast.
+        // Nested lists work at runtime but are not expressible in `TypeParam`, hence the cast.
         values: t.field({
           type: [['Int']],
           nullable: { list: true, items: { list: true, items: true } },


### PR DESCRIPTION
Addresses the three P2 findings from the `@pothos/plugin-errors` review. Each finding has its own commit with a regression test added first.

### 1. Promised list items bypass typed error handling

`yieldErrors` (`src/utils.ts`) handed each list item straight to `wrapErrorIfMatches`. A `Promise` is never an instance of a declared error class, and a later rejection could not be caught by the generator's synchronous `try`/`catch`. Explicit error-union list items and scalar `itemErrors` lists containing fulfilled or rejected declared errors surfaced as GraphQL errors/nulls instead of union members.

**Fix:** item promises are resolved first; fulfillment and rejection both go through the same matching/wrapping logic (rejections via `wrapOrThrow`, so unmatched errors still propagate as ordinary GraphQL errors).

**Follow-up in `d96659736` — depth guard.** The first version of this fix wrapped at every depth of a nested list, because `wrapItem` recursed into inner iterables. For a nested list the generated item union only covers one level, so wrapping below it produced an error proxy where the real item type was expected (`Int cannot represent non-integer value: {}`) — pre-existing for synchronous inner errors, but routing rejected promises down the same path extended it to rejections and lost the rejection reason, a regression against `main`. The list level the item union actually covers is now computed in `onOutputFieldConfig` (`pothosItemErrorsDepth`: `0` for the `itemErrors` path, `listDepth - 1` for a field whose type already contains an error union) and threaded through `yieldErrors`/`yieldAsyncErrors`. Errors are wrapped only at that level; errors and rejections at any other level are left untouched so GraphQL reports them with their original message. This also fixes the pre-existing synchronous case.

**Verified:** `tests/promise-list-items.test.ts` — fulfilled and rejected `Error` promises in `errorUnionListField`, a rejected promise in a scalar `intList` with `itemErrors`, nested-list cases for both an inner thrown error and an inner rejection, item-level wrapping in a nested list, wrapping at the covered level of `listRef(listRef(errorUnion))` and a rejection above it, plus two controls (the pre-existing synchronous `Error` case and an unmatched rejection that must stay an ordinary error). Against `main`'s sources 6 of these 10 fail; the two nested rejection cases pass on `main` and still pass here, which is what pins the regression.

The existing 2D/3D/mixed nested `errorUnion` tests in `tests/manual-error-union.test.ts` cover the depth-1 and depth-2 wrapping the guard must preserve, and pass unchanged.

### 2. Generated-type defaults lose fields/extensions

`createResultType` (`src/index.ts`) spread `defaultResultOptions` and then replaced its `fields` callback, and spread `defaultUnionOptions` and then replaced its `extensions`. Builder-level `defaultResultOptions.fields` and `defaultUnionOptions.extensions` (and the `defaultItem*` equivalents, which share this code path) were silently dropped from generated success/union types whenever the field had no override.

**Fix:** default fields are invoked before field-specific fields, and default extensions merged before field-specific and plugin extensions, so field-level options still win.

**Schema-shape change:** this is the intended fix, but it changes the generated SDL. Anyone who already sets `errors.defaultResultOptions.fields` or `errors.defaultItemResultOptions.fields` has had it silently ignored; after this patch those fields appear on every generated `*Success` type, so SDL snapshots and schema-diff checks downstream will show new fields. Called out in the changeset. No public type changed — the one `as never` cast is internal to `createResultType` and only bridges the `{}` vs `unknown` parent-shape variance between the builder-level option type and the generated object ref.

**Verified:** `tests/generated-type-defaults.test.ts` — defaults applied for generated result/union types, the same for the item variants, and a precedence test showing field-level `result`/`union` options override the defaults while non-conflicting defaults survive. All three failed before the fix.

### 3. Frozen declared errors violate Proxy invariants

`createErrorProxy` (`src/utils.ts`) returned a wrapped prototype from its `getPrototypeOf` trap even when the proxy target was non-extensible, which JavaScript forbids. Throwing `Object.freeze(new Error('bad'))` from a field with declared error types produced `'getPrototypeOf' on proxy: proxy target is non-extensible but the trap did not return its actual prototype` instead of the declared typed error.

**Fix:** non-extensible errors are wrapped through an extensible copy carrying the same prototype and own property descriptors, so the trap stays legal and the error still resolves as its declared type. Extensible errors keep the original path, so the copy only runs where `main` always threw.

**Verified:** `tests/frozen-errors.test.ts` — a thrown frozen built-in `Error`, a thrown `Object.preventExtensions` custom subclass (checking a custom own property is still readable), and a frozen error returned as an explicit error-union list item. All three failed with the invariant `TypeError` before the fix.

### Checks

- `pnpm --filter @pothos/plugin-errors run test` — 9 files, 79 passed / 4 skipped (baseline was 6 files, 63 passed / 4 skipped)
- `pnpm --filter @pothos/plugin-errors run type` — clean
- `pnpm biome check packages/plugin-errors` — clean
- Dependent suites after a rebuild: `@pothos/core` (66), `@pothos/plugin-dataloader` (18), `@pothos/plugin-sub-graph` (5) all pass

Changeset at `.changeset/errors-review-fixes.md` (patch), including the SDL note for fix 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
