### PR TITLE
fix(prisma): keep Decimal node IDs exact

### DIFF
--- a/.changeset/prisma-decimal-node-ids.md
+++ b/.changeset/prisma-decimal-node-ids.md
@@ -1,0 +1,5 @@
+---
+"@pothos/plugin-prisma": patch
+---
+
+Keep Decimal node ids exact instead of rounding them through a float when parsing

--- a/packages/plugin-prisma/src/util/cursors.ts
+++ b/packages/plugin-prisma/src/util/cursors.ts
@@ -66,8 +66,13 @@ export function parseID(id: string, dataType: string): unknown {
     case 'Boolean':
       return id !== 'false';
     case 'Float':
-    case 'Decimal':
       return Number.parseFloat(id);
+    // A `Decimal` carries more digits than a `number` holds, and `serializeID` writes all of
+    // them out. Reading one back as a float rounded the id to a value the row does not have.
+    // Prisma takes a decimal string wherever it takes a `Decimal`, so hand the digits over
+    // untouched.
+    case 'Decimal':
+      return id;
     case 'DateTime':
       return new Date(id);
     case 'Json':

--- a/packages/plugin-prisma/src/util/cursors.ts
+++ b/packages/plugin-prisma/src/util/cursors.ts
@@ -67,8 +67,6 @@ export function parseID(id: string, dataType: string): unknown {
       return id !== 'false';
     case 'Float':
       return Number.parseFloat(id);
-    // A `Decimal` carries more digits than a `number` holds, and Prisma takes a decimal string
-    // wherever it takes a `Decimal`, so the digits are handed over untouched.
     case 'Decimal':
       return id;
     case 'DateTime':

--- a/packages/plugin-prisma/src/util/cursors.ts
+++ b/packages/plugin-prisma/src/util/cursors.ts
@@ -67,10 +67,8 @@ export function parseID(id: string, dataType: string): unknown {
       return id !== 'false';
     case 'Float':
       return Number.parseFloat(id);
-    // A `Decimal` carries more digits than a `number` holds, and `serializeID` writes all of
-    // them out. Reading one back as a float rounded the id to a value the row does not have.
-    // Prisma takes a decimal string wherever it takes a `Decimal`, so hand the digits over
-    // untouched.
+    // A `Decimal` carries more digits than a `number` holds, and Prisma takes a decimal string
+    // wherever it takes a `Decimal`, so the digits are handed over untouched.
     case 'Decimal':
       return id;
     case 'DateTime':

--- a/packages/plugin-prisma/tests/cursor-and-id-types.test.ts
+++ b/packages/plugin-prisma/tests/cursor-and-id-types.test.ts
@@ -62,6 +62,11 @@ class FakeDecimal {
   toFixed() {
     return this.digits;
   }
+
+  // A `Decimal` prints its exact digits, which is what `serializeID` writes into a node id.
+  toString() {
+    return this.digits;
+  }
 }
 
 describe('compound cursors', () => {
@@ -228,5 +233,97 @@ describe('node ids', () => {
       meta: { a: 1 },
       n: 3,
     });
+  });
+});
+
+describe('decimal node ids', () => {
+  // More digits than a `number` holds. The serializer already writes them all out; the parser
+  // used to read them back through `Number.parseFloat` and round them away, so the id named a
+  // value the row does not have.
+  const digits = '0.1234567890123456789012345';
+
+  it('round trips a Decimal id without losing digits', () => {
+    const builder = builderFor([{ name: 'amount', type: 'Decimal', isId: true }]);
+
+    const id = getDefaultIDSerializer(
+      'Model',
+      'amount',
+      builder,
+    )({
+      amount: new FakeDecimal(digits),
+    }) as string;
+
+    expect(id).toBe(digits);
+    expect(getDefaultIDParser('Model', 'amount', builder)(id)).toBe(digits);
+  });
+
+  it('round trips a compound id containing a Decimal without losing digits', () => {
+    const builder = builderFor(
+      [
+        { name: 'amount', type: 'Decimal' },
+        { name: 'n', type: 'Int' },
+      ],
+      { name: null, fields: ['amount', 'n'] },
+    );
+
+    const id = getDefaultIDSerializer(
+      'Model',
+      'amount_n',
+      builder,
+    )({ amount: new FakeDecimal(digits), n: 1 }) as string;
+
+    expect(getDefaultIDParser('Model', 'amount_n', builder)(id)).toEqual({ amount: digits, n: 1 });
+  });
+
+  // A `Float` column really is a double, so it keeps reading back as a number.
+  it('still reads a Float id as a number', () => {
+    const builder = builderFor([{ name: 'views', type: 'Float', isId: true }]);
+
+    expect(getDefaultIDParser('Model', 'views', builder)('1.75')).toBe(1.75);
+  });
+});
+
+// Every id the plugin can already issue and read has to keep the bytes it has: a client holding
+// one hands it straight back, and a stored id has to keep naming the same row.
+describe('ids issued before this release', () => {
+  const intBuilder = builderFor([{ name: 'id', type: 'Int', isId: true }]);
+  const stringBuilder = builderFor([{ name: 'slug', type: 'String', isId: true }]);
+  const compoundBuilder = builderFor(
+    [
+      { name: 'id', type: 'Int' },
+      { name: 'slug', type: 'String' },
+    ],
+    { name: null, fields: ['id', 'slug'] },
+  );
+  const decimalBuilder = builderFor([{ name: 'amount', type: 'Decimal', isId: true }]);
+
+  it('writes an Int id, a String id and a compound id byte for byte as it always has', () => {
+    expect(getDefaultIDSerializer('Model', 'id', intBuilder)({ id: 42 })).toBe('42');
+    expect(getDefaultIDSerializer('Model', 'slug', stringBuilder)({ slug: 'ada' })).toBe('ada');
+    expect(
+      getDefaultIDSerializer('Model', 'id_slug', compoundBuilder)({ id: 42, slug: 'ada' }),
+    ).toBe('["42","ada"]');
+  });
+
+  it('writes a Decimal id byte for byte as it always has', () => {
+    expect(
+      getDefaultIDSerializer('Model', 'amount', decimalBuilder)({ amount: new FakeDecimal('1.5') }),
+    ).toBe('1.5');
+  });
+
+  it('reads an Int id, a String id and a compound id back to exactly what it always did', () => {
+    expect(getDefaultIDParser('Model', 'id', intBuilder)('42')).toBe(42);
+    expect(getDefaultIDParser('Model', 'slug', stringBuilder)('ada')).toBe('ada');
+    expect(getDefaultIDParser('Model', 'id_slug', compoundBuilder)('["42","ada"]')).toEqual({
+      id: 42,
+      slug: 'ada',
+    });
+  });
+
+  // A `Decimal` that a double holds exactly now reads back as its digits rather than as a
+  // `number`. Prisma takes a decimal string wherever it takes a `Decimal`, and the value it
+  // names is the one the old id named.
+  it('reads a Decimal id back to the same value it always named', () => {
+    expect(Number(getDefaultIDParser('Model', 'amount', decimalBuilder)('1.5'))).toBe(1.5);
   });
 });

--- a/packages/plugin-prisma/tests/cursor-and-id-types.test.ts
+++ b/packages/plugin-prisma/tests/cursor-and-id-types.test.ts
@@ -63,7 +63,6 @@ class FakeDecimal {
     return this.digits;
   }
 
-  // A `Decimal` prints its exact digits, which is what `serializeID` writes into a node id.
   toString() {
     return this.digits;
   }
@@ -237,9 +236,7 @@ describe('node ids', () => {
 });
 
 describe('decimal node ids', () => {
-  // More digits than a `number` holds. The serializer already writes them all out; the parser
-  // used to read them back through `Number.parseFloat` and round them away, so the id named a
-  // value the row does not have.
+  // More digits than a `number` holds.
   const digits = '0.1234567890123456789012345';
 
   it('round trips a Decimal id without losing digits', () => {
@@ -275,7 +272,6 @@ describe('decimal node ids', () => {
     expect(getDefaultIDParser('Model', 'amount_n', builder)(id)).toEqual({ amount: digits, n: 1 });
   });
 
-  // A `Float` column really is a double, so it keeps reading back as a number.
   it('still reads a Float id as a number', () => {
     const builder = builderFor([{ name: 'views', type: 'Float', isId: true }]);
 
@@ -283,8 +279,6 @@ describe('decimal node ids', () => {
   });
 });
 
-// Every id the plugin can already issue and read has to keep the bytes it has: a client holding
-// one hands it straight back, and a stored id has to keep naming the same row.
 describe('ids issued before this release', () => {
   const intBuilder = builderFor([{ name: 'id', type: 'Int', isId: true }]);
   const stringBuilder = builderFor([{ name: 'slug', type: 'String', isId: true }]);
@@ -320,9 +314,6 @@ describe('ids issued before this release', () => {
     });
   });
 
-  // A `Decimal` that a double holds exactly now reads back as its digits rather than as a
-  // `number`. Prisma takes a decimal string wherever it takes a `Decimal`, and the value it
-  // names is the one the old id named.
   it('reads a Decimal id back to the same value it always named', () => {
     expect(Number(getDefaultIDParser('Model', 'amount', decimalBuilder)('1.5'))).toBe(1.5);
   });

--- a/packages/plugin-prisma/tests/cursor-and-id-types.test.ts
+++ b/packages/plugin-prisma/tests/cursor-and-id-types.test.ts
@@ -236,7 +236,6 @@ describe('node ids', () => {
 });
 
 describe('decimal node ids', () => {
-  // More digits than a `number` holds.
   const digits = '0.1234567890123456789012345';
 
   it('round trips a Decimal id without losing digits', () => {


### PR DESCRIPTION
## The bug

`parseID` in `packages/plugin-prisma/src/util/cursors.ts` read a `Decimal` node ID back with `Number.parseFloat`, sharing the `Float` case. A `Decimal` carries more digits than a double holds, and `serializeID` already writes all of them out (`String(id)`), so a supported unique value of `0.1234567890123456789012345` was issued as an ID in full and parsed back as `0.12345678901234568` — an ID naming a value the row does not have. Refetching that node could miss it, or find a different row whose value happens to equal the rounded one. Compound unique IDs containing a `Decimal` had the same problem, since each part is parsed through `parseID`.

## The fix

Split `Decimal` out of the `Float` case and return the digits untouched. Prisma accepts a decimal string wherever it accepts a `Decimal`, so the exact value reaches the `where` clause. `Float` is a real double column and keeps parsing as a number.

The change is three lines in `parseID`; nothing else in the plugin was touched.

## Already-issued IDs are unchanged

**Serialization is not touched at all**, so every ID this plugin has ever issued keeps its exact bytes. Parsing is unchanged for `Int`, `String`, `BigInt`, `Boolean`, `Float`, `DateTime`, `Json`, `Bytes` and the default case.

This is pinned by the new `ids issued before this release` block in `packages/plugin-prisma/tests/cursor-and-id-types.test.ts`, which asserts the exact serialized output and the exact parsed values for:

- an `Int` scalar ID (`42` → `'42'` → `42`)
- a `String` scalar ID (`'ada'` → `'ada'` → `'ada'`)
- a compound unique key of the two (`{ id: 42, slug: 'ada' }` → `'["42","ada"]'` → `{ id: 42, slug: 'ada' }`)
- a `Decimal` a double holds exactly (`1.5` → `'1.5'`, still naming `1.5`)

Those assertions pass both before and after the fix — they were written and run against the unfixed code first.

The one observable difference is that a parsed `Decimal` is now its digit string rather than a `number`. That is the fix itself: a `Decimal` needing more precision than a double simply has no working round trip today, so there is no behaviour there to preserve, and for a `Decimal` that does fit a double the string and the number name the same value to Prisma.

## Tests

New cases in `packages/plugin-prisma/tests/cursor-and-id-types.test.ts`:

- a `Decimal` scalar node ID round trips with all its digits (failed before the fix with exactly the rounding above)
- a compound node ID containing a `Decimal` round trips with all its digits (same)
- a `Float` ID still reads back as a number
- the byte-identical pinning block described above

`tests/cursor-and-id-types.test.ts`: 25 tests passing before, 32 passing after.

The full `@pothos/plugin-prisma` suite cannot run end to end in this environment: 33 of 40 suites fail at import because the generated Prisma client and datamodel (`tests/client/client.js`, `tests/generated.js`) are not present in this checkout. That failure is pre-existing and unrelated to this change — all 33 are the same missing-module import error. The 7 suites that do run pass (76 tests). `pnpm --filter @pothos/plugin-prisma run type` fails for the same reason (`TS2307` on the generated client, plus 3 cascading errors inside `tests/prisma-types-from-client/index.test-d.ts`); no type error touches `src/util/cursors.ts` or the test file changed here, and vitest's own typecheck of the changed test file reports no errors. `pnpm biome check packages/plugin-prisma` is clean.

## Not in scope

The other two findings from the same prisma review are deliberately **not** addressed here and are held back for separate design work:

- Custom `relatedConnection` fallback cannot plan its nodes (`src/util/map-query.ts`)
- Async custom node IDs are not awaited for fallback lookups (`src/schema-builder.ts`)

Neither file is modified by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
