### PR TITLE
fix(drizzle): preserve bigint, Date and non-integer node ID values

### DIFF
--- a/.changeset/drizzle-node-id-fixes.md
+++ b/.changeset/drizzle-node-id-fixes.md
@@ -1,0 +1,7 @@
+---
+"@pothos/plugin-drizzle": patch
+---
+
+Preserve bigint and Date values in compound node IDs, which previously threw or came back as a string
+
+Parse numeric node IDs with `Number` rather than `parseInt`, so a non-integer ID no longer truncates

--- a/packages/plugin-drizzle/src/utils/cursors.ts
+++ b/packages/plugin-drizzle/src/utils/cursors.ts
@@ -60,6 +60,41 @@ export function formatIDChunk(value: unknown) {
   }
 }
 
+// A compound ID is a JSON array and stays one: every ID already handed to a client has to keep
+// parsing back into the row it names, byte for byte. JSON on its own cannot carry every column
+// type a compound ID may name -- it throws outright on a bigint, and flattens a Date into a
+// string that comes back out as a string -- so those two are written in a form JSON does hold,
+// and `parseCompoundIDValue` reads back off the column's type. Every other value is written
+// exactly as it was before, so IDs that round tripped before still serialize identically.
+function formatCompoundIDValue(value: unknown) {
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (value instanceof Date) {
+    return Number(value);
+  }
+
+  return value;
+}
+
+function parseCompoundIDValue(value: unknown, field: Column) {
+  if (
+    field.dataType.startsWith('bigint') &&
+    (typeof value === 'string' || typeof value === 'number')
+  ) {
+    return BigInt(value);
+  }
+
+  // the epoch milliseconds `formatCompoundIDValue` wrote. A string here is an ID issued before
+  // this release, which never restored a Date, and is left as it was.
+  if (field.dataType === 'object date' && typeof value === 'number') {
+    return new Date(value);
+  }
+
+  return value;
+}
+
 export function getIDSerializer(fields: Column[], config: PothosDrizzleSchemaConfig) {
   if (fields.length === 0) {
     throw new PothosValidationError('Column serializer must have at least one field');
@@ -67,7 +102,9 @@ export function getIDSerializer(fields: Column[], config: PothosDrizzleSchemaCon
 
   return (value: Record<string, unknown>) => {
     if (fields.length > 1) {
-      return `${JSON.stringify(fields.map((col) => value[config.columnToTsName(col)]))}`;
+      return `${JSON.stringify(
+        fields.map((col) => formatCompoundIDValue(value[config.columnToTsName(col)])),
+      )}`;
     }
 
     return `${formatIDChunk(value[config.columnToTsName(fields[0])])}`;
@@ -212,7 +249,7 @@ export function getIDParser(fields: readonly Column[], config: PothosDrizzleSche
       const record: Record<string, unknown> = {};
 
       fields.forEach((field, i) => {
-        record[config.columnToTsName(field)] = parsed[i];
+        record[config.columnToTsName(field)] = parseCompoundIDValue(parsed[i], field);
       });
 
       return record;

--- a/packages/plugin-drizzle/src/utils/cursors.ts
+++ b/packages/plugin-drizzle/src/utils/cursors.ts
@@ -86,8 +86,9 @@ function parseCompoundIDValue(value: unknown, field: Column) {
     return BigInt(value);
   }
 
-  // the epoch milliseconds `formatCompoundIDValue` wrote. A string here is an ID issued before
-  // this release, which never restored a Date, and is left as it was.
+  // A Date column's value comes back from the epoch milliseconds `formatCompoundIDValue` wrote.
+  // A string here is an ID issued before this release, which never restored a Date, and is left
+  // as it was.
   if (field.dataType === 'object date' && typeof value === 'number') {
     return new Date(value);
   }

--- a/packages/plugin-drizzle/src/utils/cursors.ts
+++ b/packages/plugin-drizzle/src/utils/cursors.ts
@@ -192,7 +192,10 @@ export function parseSerializedIDColumn(id: string, field: Column): unknown {
 
   try {
     if (field.dataType.startsWith('number')) {
-      return Number.parseInt(id, 10);
+      // `Number`, not `parseInt`: a `doublePrecision` ID of `1.75` truncates to `1`, and a large
+      // one written as `1e+21` reads as `1`, so the node looked up is a different row or none.
+      // An integer's digits parse the same either way.
+      return Number(id);
     }
 
     if (field.dataType.startsWith('bigint')) {

--- a/packages/plugin-drizzle/src/utils/cursors.ts
+++ b/packages/plugin-drizzle/src/utils/cursors.ts
@@ -60,8 +60,6 @@ export function formatIDChunk(value: unknown) {
   }
 }
 
-// A compound ID is plain JSON, which refuses a bigint outright and turns a Date into a string, so
-// those two are written as a decimal string and epoch milliseconds and read back off the column.
 function formatCompoundIDValue(value: unknown) {
   if (typeof value === 'bigint') {
     return value.toString();
@@ -82,7 +80,6 @@ function parseCompoundIDValue(value: unknown, field: Column) {
     return BigInt(value);
   }
 
-  // A Date column's value comes back from the epoch milliseconds `formatCompoundIDValue` wrote.
   if (field.dataType === 'object date' && typeof value === 'number') {
     return new Date(value);
   }
@@ -187,8 +184,6 @@ export function parseSerializedIDColumn(id: string, field: Column): unknown {
 
   try {
     if (field.dataType.startsWith('number')) {
-      // `Number`, not `parseInt`: a `doublePrecision` ID of `1.75` truncates to `1`, and a large
-      // one written as `1e+21` reads as `1`, so the node looked up is a different row or none.
       return Number(id);
     }
 

--- a/packages/plugin-drizzle/src/utils/cursors.ts
+++ b/packages/plugin-drizzle/src/utils/cursors.ts
@@ -60,12 +60,8 @@ export function formatIDChunk(value: unknown) {
   }
 }
 
-// A compound ID is a JSON array and stays one: every ID already handed to a client has to keep
-// parsing back into the row it names, byte for byte. JSON on its own cannot carry every column
-// type a compound ID may name -- it throws outright on a bigint, and flattens a Date into a
-// string that comes back out as a string -- so those two are written in a form JSON does hold,
-// and `parseCompoundIDValue` reads back off the column's type. Every other value is written
-// exactly as it was before, so IDs that round tripped before still serialize identically.
+// A compound ID is plain JSON, which refuses a bigint outright and turns a Date into a string, so
+// those two are written as a decimal string and epoch milliseconds and read back off the column.
 function formatCompoundIDValue(value: unknown) {
   if (typeof value === 'bigint') {
     return value.toString();
@@ -87,8 +83,6 @@ function parseCompoundIDValue(value: unknown, field: Column) {
   }
 
   // A Date column's value comes back from the epoch milliseconds `formatCompoundIDValue` wrote.
-  // A string here is an ID issued before this release, which never restored a Date, and is left
-  // as it was.
   if (field.dataType === 'object date' && typeof value === 'number') {
     return new Date(value);
   }
@@ -195,7 +189,6 @@ export function parseSerializedIDColumn(id: string, field: Column): unknown {
     if (field.dataType.startsWith('number')) {
       // `Number`, not `parseInt`: a `doublePrecision` ID of `1.75` truncates to `1`, and a large
       // one written as `1e+21` reads as `1`, so the node looked up is a different row or none.
-      // An integer's digits parse the same either way.
       return Number(id);
     }
 

--- a/packages/plugin-drizzle/tests/node-id-values.test.ts
+++ b/packages/plugin-drizzle/tests/node-id-values.test.ts
@@ -1,7 +1,15 @@
 import SchemaBuilder from '@pothos/core';
 import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
 import { type Column, defineRelations } from 'drizzle-orm';
-import { bigint, getTableConfig, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import {
+  bigint,
+  doublePrecision,
+  getTableConfig,
+  integer,
+  pgTable,
+  text,
+  timestamp,
+} from 'drizzle-orm/pg-core';
 import { describe, expect, it } from 'vitest';
 import DrizzlePlugin from '../src';
 import { getSchemaConfig } from '../src/utils/config';
@@ -12,8 +20,8 @@ import { getIDParser, getIDSerializer } from '../src/utils/cursors';
  * keep parsing back into that same row -- across releases. Two things are pinned here:
  *
  * - every ID shape that already worked keeps its exact bytes (`already issued IDs` below), and
- * - the shapes that could not round trip -- a bigint (which threw) and a Date (which came back
- *   as a string) -- now do.
+ * - the shapes that could not round trip -- a bigint (which threw), a Date (which came back as a
+ *   string) and a non-integer number (which truncated) -- now do.
  */
 const idTest = pgTable('node_id_values', {
   id: integer().primaryKey(),
@@ -21,6 +29,7 @@ const idTest = pgTable('node_id_values', {
   version: integer().notNull(),
   big: bigint({ mode: 'bigint' }).notNull(),
   at: timestamp().notNull(),
+  fraction: doublePrecision().notNull().unique(),
 });
 
 const relations = defineRelations({ idTest });
@@ -73,6 +82,22 @@ describe('compound node IDs', () => {
   it('round trips a Date', () => {
     const fields = [idTest.id, idTest.at];
     const row = { id: 1, at: new Date('2026-01-01T00:00:00.123Z') };
+
+    expect(parse(fields)(serialize(fields)(row))).toEqual(row);
+  });
+});
+
+describe('numeric node IDs', () => {
+  it('round trips a non-integer scalar ID', () => {
+    const fields = [idTest.fraction];
+    const row = { fraction: 1.75 };
+
+    expect(parse(fields)(serialize(fields)(row))).toEqual(row);
+  });
+
+  it('round trips a scalar ID larger than the integer notation', () => {
+    const fields = [idTest.fraction];
+    const row = { fraction: 1e21 };
 
     expect(parse(fields)(serialize(fields)(row))).toEqual(row);
   });

--- a/packages/plugin-drizzle/tests/node-id-values.test.ts
+++ b/packages/plugin-drizzle/tests/node-id-values.test.ts
@@ -1,0 +1,79 @@
+import SchemaBuilder from '@pothos/core';
+import ScopeAuthPlugin from '@pothos/plugin-scope-auth';
+import { type Column, defineRelations } from 'drizzle-orm';
+import { bigint, getTableConfig, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { describe, expect, it } from 'vitest';
+import DrizzlePlugin from '../src';
+import { getSchemaConfig } from '../src/utils/config';
+import { getIDParser, getIDSerializer } from '../src/utils/cursors';
+
+/**
+ * Node IDs are handed out to clients and come back later, so what a row serializes to has to
+ * keep parsing back into that same row -- across releases. Two things are pinned here:
+ *
+ * - every ID shape that already worked keeps its exact bytes (`already issued IDs` below), and
+ * - the shapes that could not round trip -- a bigint (which threw) and a Date (which came back
+ *   as a string) -- now do.
+ */
+const idTest = pgTable('node_id_values', {
+  id: integer().primaryKey(),
+  slug: text().notNull(),
+  version: integer().notNull(),
+  big: bigint({ mode: 'bigint' }).notNull(),
+  at: timestamp().notNull(),
+});
+
+const relations = defineRelations({ idTest });
+
+const builder = new SchemaBuilder<{ DrizzleRelations: typeof relations }>({
+  plugins: [ScopeAuthPlugin, DrizzlePlugin],
+  drizzle: { client: {} as never, relations, getTableConfig },
+  scopeAuth: { authScopes: () => ({}) },
+});
+
+const config = getSchemaConfig(builder);
+
+const serialize = (fields: Column[]) => getIDSerializer(fields, config);
+const parse = (fields: Column[]) => getIDParser(fields, config);
+
+describe('already issued IDs', () => {
+  // Pinned byte for byte: any change here invalidates every ID a client already holds.
+  it('serializes an integer scalar ID as its digits', () => {
+    expect(serialize([idTest.id])({ id: 7 })).toBe('7');
+  });
+
+  it('serializes a string scalar ID verbatim', () => {
+    expect(serialize([idTest.slug])({ slug: 'a-slug' })).toBe('a-slug');
+  });
+
+  it('serializes a compound integer ID as a plain JSON array of numbers', () => {
+    expect(serialize([idTest.id, idTest.version])({ id: 7, version: 3 })).toBe('[7,3]');
+  });
+
+  it('serializes a compound string ID as a plain JSON array of strings', () => {
+    expect(serialize([idTest.slug, idTest.id])({ slug: 'a-slug', id: 7 })).toBe('["a-slug",7]');
+  });
+
+  it('parses those IDs back into the row they came from', () => {
+    expect(parse([idTest.id])('7')).toEqual({ id: 7 });
+    expect(parse([idTest.slug])('a-slug')).toEqual({ slug: 'a-slug' });
+    expect(parse([idTest.id, idTest.version])('[7,3]')).toEqual({ id: 7, version: 3 });
+    expect(parse([idTest.slug, idTest.id])('["a-slug",7]')).toEqual({ slug: 'a-slug', id: 7 });
+  });
+});
+
+describe('compound node IDs', () => {
+  it('round trips a bigint', () => {
+    const fields = [idTest.id, idTest.big];
+    const row = { id: 1, big: BigInt('9007199254740993') };
+
+    expect(parse(fields)(serialize(fields)(row))).toEqual(row);
+  });
+
+  it('round trips a Date', () => {
+    const fields = [idTest.id, idTest.at];
+    const row = { id: 1, at: new Date('2026-01-01T00:00:00.123Z') };
+
+    expect(parse(fields)(serialize(fields)(row))).toEqual(row);
+  });
+});

--- a/packages/plugin-drizzle/tests/node-id-values.test.ts
+++ b/packages/plugin-drizzle/tests/node-id-values.test.ts
@@ -15,14 +15,6 @@ import DrizzlePlugin from '../src';
 import { getSchemaConfig } from '../src/utils/config';
 import { getIDParser, getIDSerializer } from '../src/utils/cursors';
 
-/**
- * Node IDs are handed out to clients and come back later, so what a row serializes to has to
- * keep parsing back into that same row -- across releases. Two things are pinned here:
- *
- * - every ID shape that already worked keeps its exact bytes (`already issued IDs` below), and
- * - the shapes that could not round trip -- a bigint (which threw), a Date (which came back as a
- *   string) and a non-integer number (which truncated) -- now do.
- */
 const idTest = pgTable('node_id_values', {
   id: integer().primaryKey(),
   slug: text().notNull(),
@@ -46,7 +38,6 @@ const serialize = (fields: Column[]) => getIDSerializer(fields, config);
 const parse = (fields: Column[]) => getIDParser(fields, config);
 
 describe('already issued IDs', () => {
-  // Pinned byte for byte: any change here invalidates every ID a client already holds.
   it('serializes an integer scalar ID as its digits', () => {
     expect(serialize([idTest.id])({ id: 7 })).toBe('7');
   });


### PR DESCRIPTION
Two P2 node ID defects in `@pothos/plugin-drizzle`'s `src/utils/cursors.ts`, from the drizzle plugin review. Both are round-trip failures: an ID a row serializes to does not parse back into that row.

### 1. Compound node IDs did not preserve bigint or Date values

`getIDSerializer`'s compound branch was raw `JSON.stringify` of the key columns, and `getIDParser` assigned the JSON values straight back.

- a bigint column threw `Do not know how to serialize a BigInt`, so such a node could not resolve its non-null Relay ID at all;
- a Date column serialized to an ISO string and parsed back as that string, where the column and the `parseId` contract require a Date.

Both types are supported for scalar IDs and accepted by `DrizzleNodeOptions`' unrestricted `Column[]`, so neither was a documented limitation.

A compound ID is still a JSON array. A bigint is now written as its decimal digits, a Date as its epoch milliseconds, and `getIDParser` restores both from the column's data type — the same thing `parseSerializedIDColumn` already does for scalar IDs. Every other value is serialized exactly as before.

### 2. Numeric node IDs truncated non-integer values

`parseSerializedIDColumn` read every `number` column's ID with `parseInt`, which stops at the first non-digit: a unique `doublePrecision` ID of `1.75` came back as `1`, and `1e+21` as `1` too, so a node refetch could miss the row or load a different one. It now uses `Number`, which reads the whole value and parses an integer's digits identically.

### Already-issued IDs are unchanged

**No ID that works today changes, byte for byte.** Only the two currently-broken types get new handling: a bigint could not be serialized at all (it threw), and a Date never round-tripped. Integer, string and every other JSON-safe compound value is written by the same `JSON.stringify` as before, and `Number` parses an integer's digits to the same value `parseInt` did. No versioned ID format was introduced and no ID is re-encoded.

That is pinned rather than asserted: `packages/plugin-drizzle/tests/node-id-values.test.ts`, the `already issued IDs` block, fixes the exact serialized output of an integer scalar ID (`'7'`), a string scalar ID (`'a-slug'`), a compound integer ID (`'[7,3]'`) and a mixed string/integer compound ID (`'["a-slug",7]'`), and checks each parses back into its row. Those five assertions were written against the unfixed code and passed there first, so they are a genuine before/after pin rather than a snapshot of post-fix output. The rest of the file is the failing round trips for bigint, Date, `1.75` and `1e+21`.

Two further points, both verified rather than assumed:

- **A legacy compound Date ID still parses to its ISO string**, exactly as before — the new branch only converts a number. Nothing is lost by that, because such an ID could never have resolved a node in the first place: `parseId` handed the loader an ISO string, and the loader's Date comparison requires both sides to be a `Date`, so the row was found by SQL and then discarded by the JS match.
- **`Number` and `parseInt` diverge only on malformed input**, and in every case `Number` is the better answer: `'0x10'` → `16` (was `0`), `'7abc'` → `NaN` (was `7` — it previously resolved *row 7*), `'Infinity'` → `Infinity` (was `NaN`). None of these can be a legitimately issued ID, since `formatIDChunk` always writes `String(number)`.

One behavior change worth flagging: a compound ID whose `bigint`-dataType column carried a *string* row value now parses to a BigInt instead of staying a string. No stock Drizzle column can produce that — `bigint({mode:'bigint'})`, `bigserial` and `numeric({mode:'bigint'})` all map to a JS bigint, while `numeric()` and `timestamp({mode:'string'})` have string dataTypes and never reach the branch — so a user-defined `customType` is the only theoretical path, and this matches what the scalar path has always done for bigint columns.

### Testing

- `pnpm --filter @pothos/plugin-drizzle run test` — 321 tests in 52 files pass, no type errors (the 4 new round-trip tests fail on `main` for exactly the reported reasons).
- `pnpm --filter @pothos/plugin-drizzle run type` — clean.
- `pnpm biome check packages/plugin-drizzle` — clean.
- No external Postgres was available: the new tests construct real Drizzle pg columns without a database, as the review's reproductions do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
