### PR TITLE
fix(prisma-next): accept omitted optional inputs, correct cross-file helper docs

### DIFF
--- a/.changeset/prisma-next-review-fixes.md
+++ b/.changeset/prisma-next-review-fixes.md
@@ -1,0 +1,6 @@
+---
+"@pothos/plugin-prisma-next": patch
+---
+
+Type an optional `prismaFieldWithInput` input as possibly `undefined`, matching the omitted-arg value GraphQL passes to the resolver
+Correct the cross-file field helper docs: extend a variant with its ref, not its variant-name string

--- a/packages/plugin-prisma-next/docs/interfaces.mdx
+++ b/packages/plugin-prisma-next/docs/interfaces.mdx
@@ -53,10 +53,13 @@ builder.prismaInterfaceField(personIface, 'displayName', (t) =>
 );
 ```
 
-If you pass the contract model name as a string, the plugin looks up
-the registered interface. If only an interface variant is registered
-(no default), pass the ref or the variant name explicitly — otherwise
-Pothos core throws an unresolved-ref error at schema build.
+If you pass the contract model name as a string, the plugin looks up the
+interface registered under that model name. Variants are not part of that
+lookup — each variant gets its own ref — so pass the ref returned by
+`builder.prismaInterface(...)` to extend one. A variant's GraphQL type name
+is not accepted in place of the model name: the string form would create a
+second, unimplemented ref and Pothos core throws `Missing implementations
+for some references` at schema build.
 
 ## Variants on interfaces
 

--- a/packages/plugin-prisma-next/docs/objects.mdx
+++ b/packages/plugin-prisma-next/docs/objects.mdx
@@ -232,5 +232,7 @@ builder.prismaObjectField('User', 'displayName', (t) =>
 ```
 
 The string form requires that `User` has already been registered as a
-prismaObject. If only a variant exists (see [Variants](./variants)),
-pass the variant's ref or variant name explicitly.
+prismaObject under its contract model name. If only a variant exists (see
+[Variants](./variants)), pass the ref returned by `builder.prismaObject(...)`
+— the variant's GraphQL type name is not accepted in place of the model
+name, and passing it would leave an unimplemented ref behind.

--- a/packages/plugin-prisma-next/docs/variants.mdx
+++ b/packages/plugin-prisma-next/docs/variants.mdx
@@ -113,9 +113,9 @@ include, the resolver returns rows shaped as AdminUser.
 ## Extending a variant
 
 `prismaObjectField` / `prismaObjectFields` work on variant refs the same
-way they work on default refs. The string form (passing the model name)
-defaults to the registered ref keyed under that name — pass the variant
-name explicitly if you want to extend a variant:
+way they work on default refs. The string form (passing the contract model
+name) always resolves the ref keyed under that model name, so it can never
+reach a variant. Pass the variant's ref to extend a variant:
 
 ```ts
 builder.prismaObjectField(adminUserRef, 'displayName', (t) =>
@@ -131,7 +131,7 @@ default (e.g. by passing the model name string to `t.relation('user')`
 from somewhere else), the schema build fails with an "unresolved
 ObjectRef" error from Pothos core. Either register a default
 `prismaObject('User', ...)` alongside the variant, or pass the variant
-ref / variant name explicitly everywhere.
+ref explicitly everywhere.
 
 ## Brands for abstract positions
 

--- a/packages/plugin-prisma-next/src/types.ts
+++ b/packages/plugin-prisma-next/src/types.ts
@@ -696,7 +696,12 @@ export type PrismaNextRootFieldWithInputOptions<
   resolve: (
     parent: ParentShape,
     args: InputShapeFromFields<Args> & {
-      [K in InputName]: InputShapeFromFields<Fields> | (true extends ArgRequired ? never : null);
+      // An optional input arg may be omitted entirely, which GraphQL surfaces
+      // as `undefined` rather than `null`. Mirror the input field map above so
+      // resolvers are forced to handle both absences.
+      [K in InputName]:
+        | InputShapeFromFields<Fields>
+        | (true extends ArgRequired ? never : null | undefined);
     },
     context: Types['Context'],
     info: GraphQLResolveInfo,

--- a/packages/plugin-prisma-next/src/types.ts
+++ b/packages/plugin-prisma-next/src/types.ts
@@ -696,8 +696,7 @@ export type PrismaNextRootFieldWithInputOptions<
   resolve: (
     parent: ParentShape,
     args: InputShapeFromFields<Args> & {
-      // An optional input arg may be omitted entirely, which GraphQL surfaces as
-      // `undefined` rather than `null`.
+      // graphql-js leaves an unprovided arg out of `args`: it arrives as `undefined`, not `null`.
       [K in InputName]:
         | InputShapeFromFields<Fields>
         | (true extends ArgRequired ? never : null | undefined);

--- a/packages/plugin-prisma-next/src/types.ts
+++ b/packages/plugin-prisma-next/src/types.ts
@@ -696,7 +696,6 @@ export type PrismaNextRootFieldWithInputOptions<
   resolve: (
     parent: ParentShape,
     args: InputShapeFromFields<Args> & {
-      // graphql-js leaves an unprovided arg out of `args`: it arrives as `undefined`, not `null`.
       [K in InputName]:
         | InputShapeFromFields<Fields>
         | (true extends ArgRequired ? never : null | undefined);

--- a/packages/plugin-prisma-next/src/types.ts
+++ b/packages/plugin-prisma-next/src/types.ts
@@ -696,9 +696,8 @@ export type PrismaNextRootFieldWithInputOptions<
   resolve: (
     parent: ParentShape,
     args: InputShapeFromFields<Args> & {
-      // An optional input arg may be omitted entirely, which GraphQL surfaces
-      // as `undefined` rather than `null`. Mirror the input field map above so
-      // resolvers are forced to handle both absences.
+      // An optional input arg may be omitted entirely, which GraphQL surfaces as
+      // `undefined` rather than `null`.
       [K in InputName]:
         | InputShapeFromFields<Fields>
         | (true extends ArgRequired ? never : null | undefined);

--- a/packages/plugin-prisma-next/tests/interop.test.ts
+++ b/packages/plugin-prisma-next/tests/interop.test.ts
@@ -63,6 +63,61 @@ describe('plugin interop', () => {
     });
   });
 
+  it('prismaFieldWithInput hands the resolver `undefined` when an optional input is omitted', async () => {
+    const builder = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
+      plugins: [WithInputPlugin, prismaNextPlugin],
+      prismaNext: { contract: ctx.contract },
+    });
+
+    builder.prismaObject('User', {
+      fields: (t) => ({
+        id: t.exposeID('id'),
+      }),
+    });
+
+    const seen: unknown[] = [];
+
+    builder.queryType({
+      fields: (t) => ({
+        userByOptionalInput: t.prismaFieldWithInput({
+          type: 'User',
+          nullable: true,
+          argOptions: { required: false },
+          input: {
+            email: t.input.string({ required: true }),
+          },
+          resolve: ((_parent: unknown, args: { input?: { email: string } | null }) => {
+            // An omitted optional arg is `undefined`, not `null` — a resolver
+            // that only guards against `null` would throw here.
+            seen.push(args.input);
+            const email = args.input?.email ?? 'alice@example.com';
+            return ctx.ormClient.User.where((u) => u.email.eq(email));
+          }) as never,
+        }),
+      }),
+    });
+
+    const schema = builder.toSchema();
+
+    const omitted = await execute({
+      schema,
+      document: parse('{ userByOptionalInput { id } }'),
+      contextValue: {},
+    });
+    expect(omitted.errors).toBeUndefined();
+    expect(omitted.data).toEqual({ userByOptionalInput: { id: 'u-alice' } });
+
+    const explicitNull = await execute({
+      schema,
+      document: parse('{ userByOptionalInput(input: null) { id } }'),
+      contextValue: {},
+    });
+    expect(explicitNull.errors).toBeUndefined();
+    expect(explicitNull.data).toEqual({ userByOptionalInput: { id: 'u-alice' } });
+
+    expect(seen).toEqual([undefined, null]);
+  });
+
   it('t.relation forwards errors plugin options through to the field config', () => {
     // Errors plugin reads `errors:` on a field's options to wrap the
     // resolver in a try/catch and turn returned errors into a union.

--- a/packages/plugin-prisma-next/tests/interop.test.ts
+++ b/packages/plugin-prisma-next/tests/interop.test.ts
@@ -87,8 +87,6 @@ describe('plugin interop', () => {
             email: t.input.string({ required: true }),
           },
           resolve: ((_parent: unknown, args: { input?: { email: string } | null }) => {
-            // An omitted optional arg is `undefined`, not `null` — a resolver
-            // that only guards against `null` would throw here.
             seen.push(args.input);
             const email = args.input?.email ?? 'alice@example.com';
             return ctx.ormClient.User.where((u) => u.email.eq(email));

--- a/packages/plugin-prisma-next/tests/types.test-d.ts
+++ b/packages/plugin-prisma-next/tests/types.test-d.ts
@@ -311,9 +311,6 @@ describe('t.prismaFieldWithInput typing — optional input arg', () => {
   it('types an optional input as possibly omitted as well as null', () => {
     withInputBuilder.queryType({
       fields: (t) => ({
-        // `argOptions.required: false` makes `input` optional in the schema, so
-        // a query may omit it entirely. GraphQL then hands the resolver
-        // `undefined`, not `null`.
         optionalInput: t.prismaFieldWithInput({
           type: 'User',
           nullable: true,

--- a/packages/plugin-prisma-next/tests/types.test-d.ts
+++ b/packages/plugin-prisma-next/tests/types.test-d.ts
@@ -1,5 +1,6 @@
 import SchemaBuilder from '@pothos/core';
 import RelayPlugin from '@pothos/plugin-relay';
+import WithInputPlugin from '@pothos/plugin-with-input';
 import { describe, expectTypeOf, it } from 'vitest';
 import prismaNextPlugin from '../src';
 import type { Contract } from './fixtures/sample-contract';
@@ -13,6 +14,11 @@ const builder = new SchemaBuilder<{ PrismaNextContract: Contract }>({
 const relayBuilder = new SchemaBuilder<{ PrismaNextContract: Contract }>({
   plugins: [RelayPlugin, prismaNextPlugin],
   relay: {},
+  prismaNext: { contract: null as never },
+});
+
+const withInputBuilder = new SchemaBuilder<{ PrismaNextContract: Contract }>({
+  plugins: [WithInputPlugin, prismaNextPlugin],
   prismaNext: { contract: null as never },
 });
 
@@ -295,6 +301,66 @@ describe('t.prismaField typing — resolver shape', () => {
         users: t.prismaField({
           type: ['User'],
           resolve: (() => [] as never) as never,
+        }),
+      }),
+    });
+  });
+});
+
+describe('t.prismaFieldWithInput typing — optional input arg', () => {
+  it('types an optional input as possibly omitted as well as null', () => {
+    withInputBuilder.queryType({
+      fields: (t) => ({
+        // `argOptions.required: false` makes `input` optional in the schema, so
+        // a query may omit it entirely. GraphQL then hands the resolver
+        // `undefined`, not `null`.
+        optionalInput: t.prismaFieldWithInput({
+          type: 'User',
+          nullable: true,
+          argOptions: { required: false },
+          input: { email: t.input.string({ required: true }) },
+          resolve: (_parent, args) => {
+            expectTypeOf(args.input).toEqualTypeOf<{ email: string } | null | undefined>();
+            return null as never;
+          },
+        }),
+      }),
+    });
+  });
+
+  it('rejects a null-only guard, which leaves the omitted case unhandled', () => {
+    withInputBuilder.queryType({
+      fields: (t) => ({
+        nullGuardOnly: t.prismaFieldWithInput({
+          type: 'User',
+          nullable: true,
+          argOptions: { required: false },
+          input: { email: t.input.string({ required: true }) },
+          resolve: (_parent, args) => {
+            const input = args.input;
+            if (input === null) {
+              return null as never;
+            }
+            // @ts-expect-error — `input` is still possibly `undefined`.
+            const email: string = input.email;
+            return email as never;
+          },
+        }),
+      }),
+    });
+  });
+
+  it('keeps a required input free of null and undefined', () => {
+    withInputBuilder.queryType({
+      fields: (t) => ({
+        requiredInput: t.prismaFieldWithInput({
+          type: 'User',
+          nullable: true,
+          input: { email: t.input.string({ required: true }) },
+          resolve: (_parent, args) => {
+            expectTypeOf(args.input).toEqualTypeOf<{ email: string }>();
+            return null as never;
+          },
         }),
       }),
     });


### PR DESCRIPTION
Two findings from the `@pothos/plugin-prisma-next` whole-plugin review. Both are contained to this private, staged package (the prisma-next RC9 pin is intentional and untouched).

## 1. Optional generated input omitted `undefined` (P2, `src/types.ts`)

`PrismaNextRootFieldWithInputOptions` re-declares `resolve` in order to constrain the return type, and while doing so typed an optional generated input as `Shape | null`. GraphQL passes `undefined` — not `null` — when an optional arg is omitted, so a resolver guarding only `args.input === null` compiled cleanly and then threw at runtime.

**Fix:** preserve the `undefined` that the input field map immediately above already carries. One-line type correction; a patch, because the type never matched runtime.

**Verification (red before, green after):**

- Reproduced first: the null-only guard resolver compiled with zero `tsc` diagnostics on `tsconfig.type.json`, and the valid query `{ userMaybe { id } }` (input omitted) failed with `Cannot read properties of undefined (reading 'email')` against the real on-disk SQLite RC9 fixture.
- Added type fixtures in `tests/types.test-d.ts`: the resolver's `args.input` must be `{ email: string } | null | undefined`; a null-only guard leaves `input` possibly `undefined` (`@ts-expect-error`); a required input stays free of both. Without the fix these produce two `tsc` errors (the `expectTypeOf` mismatch and an unused `@ts-expect-error`).
- Added a runtime case in `tests/interop.test.ts` that resolves the field both with the input omitted and with `input: null`, and pins what the resolver actually saw: `[undefined, null]`.

## 2. Variant-name string advice was unsupported (P3, docs)

`docs/interfaces.mdx`, `docs/objects.mdx` and `docs/variants.mdx` told readers they could pass a variant's name string to the cross-file field helpers.

**Checked against the source before rewriting:** the helpers accept `type: M | PrismaNextObjectRef<...>` / `PrismaNextInterfaceRef<...>` (`src/global-types.ts:148,160,171,183`). The string path goes through `getRefFromContractModel` / `getInterfaceRefFromContractModel`, a per-builder cache keyed by contract model name (`src/utils/refs.ts`), while `definePrismaNextType` gives every variant a **fresh, uncached** ref (`src/schema-builder.ts`). A variant name can therefore never reach the variant.

Confirmed empirically with a throwaway fixture: `prismaObjectField('AdminUser', ...)` fails schema build with `Missing implementations for some references (ObjectRef<AdminUser>)`, and `prismaInterfaceField('PublicPerson', ...)` with `InterfaceRef<PublicPerson>`.

**Fix:** recommend the variant ref, and say what happens if you pass the name instead.

Doc-sync note: the repo convention is that plugin docs are duplicated into each package's README. I checked — this package's `README.md` is an 87-line overview that does not carry these passages, and the prisma-next docs are not mirrored under `website/content/docs` (the package is private/staged). `packages/plugin-prisma-next/docs/` is the only copy, so there is nothing to keep in sync here.

## Intentionally not addressed

Two type-inference findings from the same review are held back for separate design work and are **not** touched by this PR:

- **resolveNode result shape lost** (`src/connection-helpers.ts:60-63,115-117`, mapping at `:221-224`) — needs a transformed-node generic threaded through the helper while original rows are retained for cursor encoding.
- **String cross-file helper promises undeclared columns** (`src/global-types.ts:148,160,171,183`) — the parent `Shape` defaults to the full `Row` rather than a dependency-only shape.

Shared Relay object-ID issues stay under the relay plugin and are not duplicated here.

## Test / type / lint results

| Command | Result |
| --- | --- |
| `pnpm --filter @pothos/plugin-prisma-next run test` | 374 passed, 13 skipped; `Type Errors  no errors`. Baseline on `origin/main` was 370 passed / 13 skipped, so the 4 new cases are the only delta. |
| `pnpm --filter @pothos/plugin-prisma-next run type` | passes — both `tsconfig.type.json` and `tsconfig.scope-auth.json` |
| `pnpm biome check packages/plugin-prisma-next` | clean, 76 files, no fixes applied |

Environment caveats, reported honestly and unchanged from baseline:

- `tests/postgres-runtime.test.ts` fails at `beforeAll` with `ECONNREFUSED 127.0.0.1:5456` — no PostgreSQL server is available in this environment. It fails identically on unmodified `origin/main`; its 13 tests are skipped. **Not certified by this PR.**
- `tests/optional-plugins.test.ts` needs a built `lib/index.js`; it passed here because `pnpm build` was run first, but no PostgreSQL and no full release/provider matrix run was performed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
