### PR TITLE
fix(relay): key node identity on the raw global ID

### DIFF
--- a/.changeset/relay-node-identity.md
+++ b/.changeset/relay-node-identity.md
@@ -7,3 +7,7 @@ nodes whose `id.parse` results stringify alike no longer collapse onto one entit
 `parse` results like `{ key: 1 }` and `{ key: 2 }` both became `Type:[object Object]`, and two
 `Date`s in the same second both became the same key, so a `nodes` query could return the same
 row twice. Cache keys are unchanged for nodes without an `id.parse`.
+
+Also apply `id.parse` to node ids supplied to `t.node`/`t.nodeList` as a `GlobalIDShape`
+(`{ id, type }`). That path previously skipped `parse` and handed `loadOne`/`loadMany` a raw
+id, despite both being typed to receive the parsed `IDShape`.

--- a/.changeset/relay-node-identity.md
+++ b/.changeset/relay-node-identity.md
@@ -1,0 +1,9 @@
+---
+"@pothos/plugin-relay": patch
+---
+
+Key node identity on the raw (pre-parse) global ID instead of the parsed `id`, so distinct
+nodes whose `id.parse` results stringify alike no longer collapse onto one entity. Previously
+`parse` results like `{ key: 1 }` and `{ key: 2 }` both became `Type:[object Object]`, and two
+`Date`s in the same second both became the same key, so a `nodes` query could return the same
+row twice. Cache keys are unchanged for nodes without an `id.parse`.

--- a/packages/plugin-relay/src/field-builder.ts
+++ b/packages/plugin-relay/src/field-builder.ts
@@ -17,7 +17,11 @@ import type {
   GlobalIDShape,
 } from './types.js';
 import { capitalize, resolveNodes } from './utils/index.js';
-import { internalDecodeGlobalID, internalEncodeGlobalID } from './utils/internal.js';
+import {
+  internalDecodeGlobalID,
+  internalEncodeGlobalID,
+  internalNormalizeGlobalIDShape,
+} from './utils/internal.js';
 
 const fieldBuilderProto = RootFieldBuilder.prototype as PothosSchemaTypes.RootFieldBuilder<
   SchemaTypes,
@@ -124,10 +128,13 @@ fieldBuilderProto.node = function node({ id, ...options }) {
       const globalID =
         typeof rawID === 'string'
           ? internalDecodeGlobalID(this.builder, rawID, context, info, true)
-          : rawID && {
-              id: rawID.id,
-              typename: this.builder.configStore.getTypeConfig(rawID.type).name,
-            };
+          : rawID &&
+            internalNormalizeGlobalIDShape(
+              this.builder.configStore.getTypeConfig(rawID.type).name,
+              rawID.id,
+              context,
+              info,
+            );
 
       return (await resolveNodes(this.builder, context, info, [globalID]))[0];
     },
@@ -161,10 +168,13 @@ fieldBuilderProto.nodeList = function nodeList({ ids, ...options }) {
       const globalIds = rawIds.map((id) =>
         typeof id === 'string'
           ? internalDecodeGlobalID(this.builder, id, context, info, true)
-          : id && {
-              id: id.id,
-              typename: this.builder.configStore.getTypeConfig(id.type).name,
-            },
+          : id &&
+            internalNormalizeGlobalIDShape(
+              this.builder.configStore.getTypeConfig(id.type).name,
+              id.id,
+              context,
+              info,
+            ),
       );
 
       return resolveNodes(this.builder, context, info, globalIds);

--- a/packages/plugin-relay/src/utils/internal.ts
+++ b/packages/plugin-relay/src/utils/internal.ts
@@ -14,6 +14,37 @@ export function internalEncodeGlobalID<Types extends SchemaTypes>(
   return encodeGlobalID(typename, id);
 }
 
+function getParseGlobalID(typename: string, info: PartialResolveInfo) {
+  return info.schema.getType(typename)?.extensions?.pothosParseGlobalID as
+    | ((id: string, ctx: object) => unknown)
+    | undefined;
+}
+
+/**
+ * Normalizes a `GlobalIDShape` (`{ id, type }`) the same way a global ID string is normalized.
+ *
+ * `GlobalIDShape.id` is an `ID` scalar, never an already-parsed `IDShape`, so a node type
+ * configuring `id.parse` must have it applied here too — otherwise `loadOne`/`loadMany` receive
+ * a raw id through this path and the parsed id through the string path, despite being typed to
+ * always receive the parsed one.
+ */
+export function internalNormalizeGlobalIDShape(
+  typename: string,
+  id: unknown,
+  ctx: object,
+  info: PartialResolveInfo,
+): { id: unknown; rawId?: string; typename: string } {
+  const parseID = getParseGlobalID(typename, info);
+
+  if (!parseID) {
+    return { typename, id };
+  }
+
+  const rawId = String(id);
+
+  return { typename, id: parseID(rawId, ctx), rawId };
+}
+
 export function internalDecodeGlobalID<Types extends SchemaTypes>(
   builder: PothosSchemaTypes.SchemaBuilder<Types>,
   globalID: string,
@@ -49,10 +80,7 @@ export function internalDecodeGlobalID<Types extends SchemaTypes>(
   }
 
   if (parseIdsForTypes) {
-    const parseID = info.schema.getType(decoded.typename)?.extensions?.pothosParseGlobalID as (
-      id: string,
-      ctx: object,
-    ) => string;
+    const parseID = getParseGlobalID(decoded.typename, info);
 
     if (parseID) {
       return {

--- a/packages/plugin-relay/src/utils/internal.ts
+++ b/packages/plugin-relay/src/utils/internal.ts
@@ -39,6 +39,9 @@ export function internalDecodeGlobalID<Types extends SchemaTypes>(
       return {
         ...decoded,
         id: entry.parseId(decoded.id, ctx),
+        // The parsed id may be any shape, and is not usable as an identity. Keep the
+        // decoded global ID so node identity never depends on the parse result.
+        rawId: decoded.id,
       };
     }
 
@@ -55,6 +58,7 @@ export function internalDecodeGlobalID<Types extends SchemaTypes>(
       return {
         ...decoded,
         id: parseID(decoded.id, ctx),
+        rawId: decoded.id,
       };
     }
   }

--- a/packages/plugin-relay/src/utils/internal.ts
+++ b/packages/plugin-relay/src/utils/internal.ts
@@ -20,14 +20,6 @@ function getParseGlobalID(typename: string, info: PartialResolveInfo) {
     | undefined;
 }
 
-/**
- * Normalizes a `GlobalIDShape` (`{ id, type }`) the same way a global ID string is normalized.
- *
- * `GlobalIDShape.id` is an `ID` scalar, never an already-parsed `IDShape`, so a node type
- * configuring `id.parse` must have it applied here too — otherwise `loadOne`/`loadMany` receive
- * a raw id through this path and the parsed id through the string path, despite being typed to
- * always receive the parsed one.
- */
 export function internalNormalizeGlobalIDShape(
   typename: string,
   id: unknown,
@@ -70,8 +62,6 @@ export function internalDecodeGlobalID<Types extends SchemaTypes>(
       return {
         ...decoded,
         id: entry.parseId(decoded.id, ctx),
-        // The parsed id may be any shape, and is not usable as an identity. Keep the
-        // decoded global ID so node identity never depends on the parse result.
         rawId: decoded.id,
       };
     }

--- a/packages/plugin-relay/src/utils/resolve-nodes.ts
+++ b/packages/plugin-relay/src/utils/resolve-nodes.ts
@@ -90,10 +90,6 @@ export async function resolveUncachedNodesForType<Types extends SchemaTypes>(
   info: GraphQLResolveInfo,
   ids: readonly unknown[],
   type: OutputType<Types> | string,
-  /**
-   * Request cache keys for each entry of `ids`, in the same order. Defaults to
-   * `${typename}:${id}`.
-   */
   keys?: readonly string[],
 ): Promise<unknown[]> {
   const requestCache = getRequestCache(context);

--- a/packages/plugin-relay/src/utils/resolve-nodes.ts
+++ b/packages/plugin-relay/src/utils/resolve-nodes.ts
@@ -12,15 +12,26 @@ import type { NodeObjectOptions } from '../types.js';
 
 const getRequestCache = createContextCache(() => new Map<string, MaybePromise<unknown>>());
 
+// A node's identity is the global ID the client sent, not whatever `id.parse` turned it into.
+// `rawId` is only absent for callers that build global IDs themselves (or never parse), where
+// `id` is already the raw value, so this produces the same key strings as before.
+function nodeCacheKey(typename: string, globalID: { id: unknown; rawId?: string }) {
+  return `${typename}:${globalID.rawId ?? globalID.id}`;
+}
+
 export async function resolveNodes<Types extends SchemaTypes>(
   builder: PothosSchemaTypes.SchemaBuilder<Types>,
   context: object,
   info: GraphQLResolveInfo,
-  globalIDs: ({ id: unknown; typename: string } | null | undefined)[],
+  globalIDs: ({ id: unknown; rawId?: string; typename: string } | null | undefined)[],
 ): Promise<MaybePromise<unknown>[]> {
   const requestCache = getRequestCache(context);
-  const idsByType = new Map<string, Set<unknown>>();
-  const results: Record<string, MaybePromise<unknown>> = {};
+  // The inner Map goes from a node's identity key to its (possibly parsed) id. `id.parse`
+  // may return any shape, so the parsed value is never a usable identity: `{ key: 1 }` and
+  // `{ key: 2 }` both stringify to `[object Object]`. The key is always derived from the
+  // raw, pre-parse global ID instead.
+  const idsByType = new Map<string, Map<string, unknown>>();
+  const results = new Map<string, MaybePromise<unknown>>();
 
   for (const globalID of globalIDs) {
     if (globalID == null) {
@@ -28,26 +39,27 @@ export async function resolveNodes<Types extends SchemaTypes>(
     }
 
     const { id, typename } = globalID;
-    const cacheKey = `${typename}:${id}`;
+    const cacheKey = nodeCacheKey(typename, globalID);
 
     if (requestCache.has(cacheKey)) {
-      results[cacheKey] = requestCache.get(cacheKey)!;
+      results.set(cacheKey, requestCache.get(cacheKey)!);
       continue;
     }
 
     let idsForType = idsByType.get(typename);
 
     if (!idsForType) {
-      idsForType = new Set();
+      idsForType = new Map();
       idsByType.set(typename, idsForType);
     }
 
-    idsForType.add(id);
+    idsForType.set(cacheKey, id);
   }
 
   await Promise.all(
     [...idsByType].map(async ([typename, idsForType]) => {
-      const ids = [...idsForType];
+      const ids = [...idsForType.values()];
+      const keys = [...idsForType.keys()];
 
       const config = builder.configStore.getTypeConfig(typename, 'Object');
       const options = config.pothosOptions as NodeObjectOptions<Types, ObjectParam<Types>, []>;
@@ -60,6 +72,7 @@ export async function resolveNodes<Types extends SchemaTypes>(
         info,
         ids,
         typename,
+        keys,
       );
 
       resultsForType.forEach((val, i) => {
@@ -67,13 +80,13 @@ export async function resolveNodes<Types extends SchemaTypes>(
           brandWithType(val, typename as OutputType<Types>);
         }
 
-        results[`${typename}:${ids[i]}`] = val;
+        results.set(keys[i], val);
       });
     }),
   );
 
   return globalIDs.map((globalID) =>
-    globalID == null ? null : (results[`${globalID.typename}:${globalID.id}`] ?? null),
+    globalID == null ? null : (results.get(nodeCacheKey(globalID.typename, globalID)) ?? null),
   );
 }
 
@@ -84,25 +97,33 @@ export async function resolveUncachedNodesForType<Types extends SchemaTypes>(
   info: GraphQLResolveInfo,
   ids: readonly unknown[],
   type: OutputType<Types> | string,
+  /**
+   * Request cache keys for each entry of `ids`, in the same order. Defaults to
+   * `${typename}:${id}`, which is only a correct identity when `id` has not been
+   * transformed by `id.parse`.
+   */
+  keys?: readonly string[],
 ): Promise<unknown[]> {
   const requestCache = getRequestCache(context);
   const config = builder.configStore.getTypeConfig(type, 'Object');
   const options = config.pothosOptions as NodeObjectOptions<Types, ObjectParam<Types>, [], unknown>;
+  const cacheKey = (id: unknown, i: number) => keys?.[i] ?? `${config.name}:${id}`;
 
   if (options.loadMany) {
     const loadManyPromise = Promise.resolve(options.loadMany(ids as unknown[], context));
 
     return Promise.all(
       ids.map((id, i) => {
+        const key = cacheKey(id, i);
         const entryPromise = loadManyPromise
           .then((results: readonly unknown[]) => results[i])
           .then((result: unknown) => {
-            requestCache.set(`${config.name}:${id}`, result);
+            requestCache.set(key, result);
 
             return result;
           });
 
-        requestCache.set(`${config.name}:${id}`, entryPromise);
+        requestCache.set(key, entryPromise);
 
         return entryPromise;
       }),
@@ -111,16 +132,17 @@ export async function resolveUncachedNodesForType<Types extends SchemaTypes>(
 
   if (options.loadOne) {
     return Promise.all(
-      ids.map((id) => {
+      ids.map((id, i) => {
+        const key = cacheKey(id, i);
         const entryPromise = Promise.resolve(options.loadOne!(id, context)).then(
           (result: unknown) => {
-            requestCache.set(`${config.name}:${id}`, result);
+            requestCache.set(key, result);
 
             return result;
           },
         );
 
-        requestCache.set(`${config.name}:${id}`, entryPromise);
+        requestCache.set(key, entryPromise);
 
         return entryPromise;
       }),

--- a/packages/plugin-relay/src/utils/resolve-nodes.ts
+++ b/packages/plugin-relay/src/utils/resolve-nodes.ts
@@ -12,9 +12,6 @@ import type { NodeObjectOptions } from '../types.js';
 
 const getRequestCache = createContextCache(() => new Map<string, MaybePromise<unknown>>());
 
-// A node's identity is the global ID the client sent, not whatever `id.parse` turned it into.
-// `rawId` is only absent for callers that build global IDs themselves (or never parse), where
-// `id` is already the raw value, so this produces the same key strings as before.
 function nodeCacheKey(typename: string, globalID: { id: unknown; rawId?: string }) {
   return `${typename}:${globalID.rawId ?? globalID.id}`;
 }
@@ -26,10 +23,6 @@ export async function resolveNodes<Types extends SchemaTypes>(
   globalIDs: ({ id: unknown; rawId?: string; typename: string } | null | undefined)[],
 ): Promise<MaybePromise<unknown>[]> {
   const requestCache = getRequestCache(context);
-  // The inner Map goes from a node's identity key to its (possibly parsed) id. `id.parse`
-  // may return any shape, so the parsed value is never a usable identity: `{ key: 1 }` and
-  // `{ key: 2 }` both stringify to `[object Object]`. The key is always derived from the
-  // raw, pre-parse global ID instead.
   const idsByType = new Map<string, Map<string, unknown>>();
   const results = new Map<string, MaybePromise<unknown>>();
 
@@ -99,8 +92,7 @@ export async function resolveUncachedNodesForType<Types extends SchemaTypes>(
   type: OutputType<Types> | string,
   /**
    * Request cache keys for each entry of `ids`, in the same order. Defaults to
-   * `${typename}:${id}`, which is only a correct identity when `id` has not been
-   * transformed by `id.parse`.
+   * `${typename}:${id}`.
    */
   keys?: readonly string[],
 ): Promise<unknown[]> {

--- a/packages/plugin-relay/tests/node-identity.test.ts
+++ b/packages/plugin-relay/tests/node-identity.test.ts
@@ -225,4 +225,73 @@ describe('node identity for parsed ids', () => {
     expect(result.data).toEqual({ nodes: [{ key: 1 }, { key: 1 }, { key: 2 }] });
     expect(batches).toEqual([[{ key: 1 }, { key: 2 }]]);
   });
+
+  describe('a GlobalIDShape and a global ID string for the same node', () => {
+    // `GlobalIDShape.id` is an `ID` scalar, not an already-parsed `IDShape`, so both paths
+    // must apply `id.parse` and hand loaders the shape they are typed to receive. Keying on
+    // the raw id makes both paths share one cache entry, so a shape-supplied field appearing
+    // first must not be able to poison a string-supplied one (or vice versa).
+    function build() {
+      const builder = new SchemaBuilder<{}>({ plugins: [RelayPlugin] });
+
+      const calls: unknown[] = [];
+
+      const User = builder.objectRef<{ id: number }>('User');
+
+      builder.node(User, {
+        isTypeOf: () => true,
+        id: { resolve: (user) => user.id, parse: (id) => ({ key: Number(id) }) },
+        loadOne: (id) => {
+          calls.push(id);
+
+          return { id: id.key };
+        },
+        fields: (t) => ({ key: t.int({ nullable: true, resolve: (user) => user.id }) }),
+      });
+
+      builder.queryType({
+        fields: (t) => ({
+          shape: t.node({ id: () => ({ id: '1', type: User }) }),
+          str: t.node({ id: () => encodeGlobalID('User', '1') }),
+        }),
+      });
+
+      return { schema: builder.toSchema(), calls };
+    }
+
+    it.each([
+      ['shape first', '{ a: shape { ...F } b: str { ...F } }'],
+      ['string first', '{ a: str { ...F } b: shape { ...F } }'],
+    ])('resolves both to the parsed id with %s', async (_name, selection) => {
+      const { schema, calls } = build();
+
+      const result = await graphql({
+        schema,
+        source: `${selection} fragment F on User { key }`,
+        contextValue: {},
+      });
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data).toEqual({ a: { key: 1 }, b: { key: 1 } });
+      expect(calls).toEqual([{ key: 1 }]);
+    });
+
+    it('resolves a root node field alongside a shape-supplied field', async () => {
+      const { schema, calls } = build();
+
+      const result = await graphql({
+        schema,
+        source: `query($id: ID!) {
+          a: shape { ... on User { key } }
+          b: node(id: $id) { ... on User { key } }
+        }`,
+        variableValues: { id: encodeGlobalID('User', '1') },
+        contextValue: {},
+      });
+
+      expect(result.errors).toBeUndefined();
+      expect(result.data).toEqual({ a: { key: 1 }, b: { key: 1 } });
+      expect(calls).toEqual([{ key: 1 }]);
+    });
+  });
 });

--- a/packages/plugin-relay/tests/node-identity.test.ts
+++ b/packages/plugin-relay/tests/node-identity.test.ts
@@ -1,0 +1,228 @@
+import SchemaBuilder from '@pothos/core';
+import { type GraphQLResolveInfo, graphql } from 'graphql';
+import RelayPlugin, { encodeGlobalID, resolveUncachedNodesForType } from '../src';
+
+describe('node identity for parsed ids', () => {
+  it('keeps parsed object ids distinct', async () => {
+    const builder = new SchemaBuilder<{}>({ plugins: [RelayPlugin] });
+
+    const User = builder.objectRef<{ id: number; name: string }>('User');
+
+    builder.node(User, {
+      id: { resolve: (user) => user.id, parse: (id) => ({ key: Number(id) }) },
+      loadOne: (id) => ({ id: id.key, name: `User ${id.key}` }),
+      fields: (t) => ({ name: t.exposeString('name') }),
+    });
+
+    builder.queryType({});
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: 'query($ids: [ID!]!) { nodes(ids: $ids) { ... on User { name } } }',
+      variableValues: { ids: [encodeGlobalID('User', '1'), encodeGlobalID('User', '2')] },
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ nodes: [{ name: 'User 1' }, { name: 'User 2' }] });
+  });
+
+  it('keeps parsed Date ids within the same second distinct', async () => {
+    const builder = new SchemaBuilder<{}>({ plugins: [RelayPlugin] });
+
+    const Event = builder.objectRef<{ at: Date }>('Event');
+
+    builder.node(Event, {
+      id: {
+        parse: (id) => new Date(id),
+        resolve: (value) => value.at.toISOString(),
+      },
+      loadOne: (at) => ({ at }),
+      fields: (t) => ({ at: t.string({ resolve: (value) => value.at.toISOString() }) }),
+    });
+
+    builder.queryType({});
+
+    const dates = ['2026-01-01T00:00:00.001Z', '2026-01-01T00:00:00.002Z'];
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: 'query($ids: [ID!]!) { nodes(ids: $ids) { ... on Event { at } } }',
+      variableValues: { ids: dates.map((id) => encodeGlobalID('Event', id)) },
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ nodes: [{ at: dates[0] }, { at: dates[1] }] });
+  });
+
+  it('keeps parsed bigint and class instance ids distinct', async () => {
+    class Key {
+      constructor(readonly value: string) {}
+    }
+
+    const builder = new SchemaBuilder<{}>({ plugins: [RelayPlugin] });
+
+    const Big = builder.objectRef<{ id: bigint }>('Big');
+    builder.node(Big, {
+      id: { resolve: (value) => String(value.id), parse: (id) => BigInt(id) },
+      loadOne: (id) => ({ id }),
+      fields: (t) => ({ value: t.string({ resolve: (value) => String(value.id) }) }),
+    });
+
+    const Keyed = builder.objectRef<{ key: Key }>('Keyed');
+    builder.node(Keyed, {
+      id: { resolve: (value) => value.key.value, parse: (id) => new Key(id) },
+      loadOne: (key) => ({ key }),
+      fields: (t) => ({ value: t.string({ resolve: (value) => value.key.value }) }),
+    });
+
+    builder.queryType({});
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: `query($ids: [ID!]!) {
+        nodes(ids: $ids) { ... on Big { value } ... on Keyed { value } }
+      }`,
+      variableValues: {
+        ids: [
+          encodeGlobalID('Big', '1'),
+          encodeGlobalID('Big', '2'),
+          encodeGlobalID('Keyed', 'a'),
+          encodeGlobalID('Keyed', 'b'),
+        ],
+      },
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      nodes: [{ value: '1' }, { value: '2' }, { value: 'a' }, { value: 'b' }],
+    });
+  });
+
+  it('still caches a parsed id across node and nodes in one request', async () => {
+    const builder = new SchemaBuilder<{}>({ plugins: [RelayPlugin] });
+
+    const calls: unknown[] = [];
+
+    const User = builder.objectRef<{ id: number }>('User');
+
+    builder.node(User, {
+      // The request cache can hand a node back before `resolveNodes` has branded it,
+      // so resolve the type explicitly to keep this test about cache hits.
+      isTypeOf: () => true,
+      id: { resolve: (user) => user.id, parse: (id) => ({ key: Number(id) }) },
+      loadOne: (id) => {
+        calls.push(id);
+
+        return { id: id.key };
+      },
+      fields: (t) => ({ key: t.int({ resolve: (user) => user.id }) }),
+    });
+
+    builder.queryType({});
+
+    const id = encodeGlobalID('User', '1');
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: `query($id: ID!, $ids: [ID!]!) {
+        first: node(id: $id) { ... on User { key } }
+        second: node(id: $id) { ... on User { key } }
+        many: nodes(ids: $ids) { ... on User { key } }
+      }`,
+      variableValues: { id, ids: [id, id] },
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      first: { key: 1 },
+      second: { key: 1 },
+      many: [{ key: 1 }, { key: 1 }],
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  it('produces byte-identical cache keys for the default (no `parse`) path', async () => {
+    // `resolveUncachedNodesForType` is publicly exported and knows nothing about raw global
+    // IDs, so it can only ever write the legacy `${typename}:${id}` key. If `resolveNodes`
+    // reads a different string for the same node, this cache entry is missed and the loader
+    // runs a second time. A hit here is proof the two key strings are identical.
+    const builder = new SchemaBuilder<{}>({ plugins: [RelayPlugin] });
+
+    const calls: unknown[] = [];
+
+    const User = builder.objectRef<{ id: string }>('User');
+
+    builder.node(User, {
+      isTypeOf: () => true,
+      id: { resolve: (user) => user.id },
+      loadOne: (id) => {
+        calls.push(id);
+
+        return { id: String(id) };
+      },
+      fields: (t) => ({ key: t.exposeString('id') }),
+    });
+
+    builder.queryType({});
+
+    const schema = builder.toSchema();
+    const context = {};
+
+    // Legacy 5-argument call: the exported signature, unchanged.
+    await resolveUncachedNodesForType(builder, context, {} as GraphQLResolveInfo, ['1'], 'User');
+
+    expect(calls).toEqual(['1']);
+
+    const result = await graphql({
+      schema,
+      source: 'query($id: ID!) { node(id: $id) { ... on User { key } } }',
+      variableValues: { id: encodeGlobalID('User', '1') },
+      contextValue: context,
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ node: { key: '1' } });
+    expect(calls).toEqual(['1']);
+  });
+
+  it('dedupes repeated ids in a single nodes query with a parsed id', async () => {
+    const builder = new SchemaBuilder<{}>({ plugins: [RelayPlugin] });
+
+    const batches: unknown[][] = [];
+
+    const User = builder.objectRef<{ id: number }>('User');
+
+    builder.node(User, {
+      id: { resolve: (user) => user.id, parse: (id) => ({ key: Number(id) }) },
+      loadMany: (ids) => {
+        batches.push(ids);
+
+        return ids.map((id) => ({ id: id.key }));
+      },
+      fields: (t) => ({ key: t.int({ resolve: (user) => user.id }) }),
+    });
+
+    builder.queryType({});
+
+    const result = await graphql({
+      schema: builder.toSchema(),
+      source: 'query($ids: [ID!]!) { nodes(ids: $ids) { ... on User { key } } }',
+      variableValues: {
+        ids: [
+          encodeGlobalID('User', '1'),
+          encodeGlobalID('User', '1'),
+          encodeGlobalID('User', '2'),
+        ],
+      },
+      contextValue: {},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({ nodes: [{ key: 1 }, { key: 1 }, { key: 2 }] });
+    expect(batches).toEqual([[{ key: 1 }, { key: 2 }]]);
+  });
+});

--- a/packages/plugin-relay/tests/node-identity.test.ts
+++ b/packages/plugin-relay/tests/node-identity.test.ts
@@ -109,8 +109,6 @@ describe('node identity for parsed ids', () => {
     const User = builder.objectRef<{ id: number }>('User');
 
     builder.node(User, {
-      // The request cache can hand a node back before `resolveNodes` has branded it,
-      // so resolve the type explicitly to keep this test about cache hits.
       isTypeOf: () => true,
       id: { resolve: (user) => user.id, parse: (id) => ({ key: Number(id) }) },
       loadOne: (id) => {
@@ -146,10 +144,6 @@ describe('node identity for parsed ids', () => {
   });
 
   it('produces byte-identical cache keys for the default (no `parse`) path', async () => {
-    // `resolveUncachedNodesForType` is publicly exported and knows nothing about raw global
-    // IDs, so it can only ever write the legacy `${typename}:${id}` key. If `resolveNodes`
-    // reads a different string for the same node, this cache entry is missed and the loader
-    // runs a second time. A hit here is proof the two key strings are identical.
     const builder = new SchemaBuilder<{}>({ plugins: [RelayPlugin] });
 
     const calls: unknown[] = [];
@@ -172,7 +166,6 @@ describe('node identity for parsed ids', () => {
     const schema = builder.toSchema();
     const context = {};
 
-    // Legacy 5-argument call: the exported signature, unchanged.
     await resolveUncachedNodesForType(builder, context, {} as GraphQLResolveInfo, ['1'], 'User');
 
     expect(calls).toEqual(['1']);
@@ -227,10 +220,6 @@ describe('node identity for parsed ids', () => {
   });
 
   describe('a GlobalIDShape and a global ID string for the same node', () => {
-    // `GlobalIDShape.id` is an `ID` scalar, not an already-parsed `IDShape`, so both paths
-    // must apply `id.parse` and hand loaders the shape they are typed to receive. Keying on
-    // the raw id makes both paths share one cache entry, so a shape-supplied field appearing
-    // first must not be able to poison a string-supplied one (or vice versa).
     function build() {
       const builder = new SchemaBuilder<{}>({ plugins: [RelayPlugin] });
 


### PR DESCRIPTION
Stacked on #1752 (`fix/review-relay`) — this PR's diff is two commits on top of it.

## The bug

`resolveNodes` derives a node's identity by interpolating the **parsed** id into `${typename}:${id}`. `id.parse` is documented and typed to return an arbitrary `IDShape`, so any two parse results that stringify alike become the same node:

- `parse: (id) => ({ key: Number(id) })` — `{ key: 1 }` and `{ key: 2 }` are both `User:[object Object]`
- `parse: (id) => new Date(id)` — two `Date`s in the same second are both `Event:…GMT+0000 (Coordinated Universal Time)`

A public `nodes` query then returns the same entity twice, even though every loader call returned the correct row:

```graphql
nodes(ids: [encodeGlobalID("User", "1"), encodeGlobalID("User", "2")])
# was: [{ name: "User 2" }, { name: "User 2" }]
# now: [{ name: "User 1" }, { name: "User 2" }]
```

The identity is used at three sites, and disabling the request cache does **not** fix it — the function-local `results` mapping collides independently, and `loadManyWithoutCache` / `loadWithoutCache` flow through the same write.

One clarification on the original review note: the type-grouping site was *not* a collision. It collected ids in a `Set<unknown>`, which compares by SameValueZero, so structurally equal parsed objects stayed distinct members — grouping **over-fetched** (`nodes(ids: [A, A])` with an object `parse` called the loader twice) rather than collapsing. It still needed the identity change, for the opposite reason.

## The fix

### 1. Key identity on the raw global ID

Key node identity on the original **decoded, pre-parse global ID string**, never on the parsed value. `internalDecodeGlobalID` already holds that string immediately before overwriting it with the parse result; it is now carried through as `rawId`.

- the inner `idsByType` collection goes from `Set<unknown>` to `Map<string, unknown>` (identity key → parsed id), so grouping, batch ordering and result mapping all come from one structure
- `results` becomes a `Map` keyed the same way. (This was not a prototype-pollution fix — every key contains `:`, which `Object.prototype` has none of. It is purely about identity.)
- the outer `Map` and its comment from #1752 are untouched

The parsed value is a *projection* of the identity, not the identity. Using the global ID the client actually sent is correct for every `IDShape` by construction — objects, `Date`s, bigints and class instances alike — with no serialization and no new user-facing option.

### 2. Apply `id.parse` to `GlobalIDShape` node ids

Keying on the raw id has a consequence the first commit alone got wrong. A node type with an `id.parse` reaches `resolveNodes` two ways, and they did not agree on the value shape:

| supplied as | applies `parse`? | `loadOne` receives |
| --- | --- | --- |
| global ID string (`node(id:)`, `t.node` returning a string) | yes | the parsed `IDShape` |
| `GlobalIDShape` (`t.node({ id: () => ({ id: '1', type: User }) })`) | **no** | the raw id |

Before, those produced different keys (`User:[object Object]` vs `User:1`) and so loaded separately. Keying on the raw id makes both `User:1`, merging a sound and an unsound load into one cache entry — whichever field resolved first decided the value for both. A shape-supplied field appearing earlier in a document could make a correct string-supplied field return the wrong value.

The `GlobalIDShape` side was **already broken** before this PR: `GlobalIDShape.id` is typed `OutputShape<Types, 'ID'>` — an `ID` scalar, never an already-parsed `IDShape` — while `loadOne`/`loadMany` are typed `(id: IDShape) => …`. That path was handing loaders a value their own signatures said they would not get, silently.

So rather than partition the two into separate cache namespaces (which would keep the key design but leave that path still lying about its types), the second commit applies `id.parse` on the shape path too, through a helper shared with the string path. Both paths now produce the same parsed value *and* the same raw key, so sharing one cache entry is correct rather than accidental, and `loadOne`'s type is honest. Double-parsing is not reachable: the shape's `id` is an ID scalar by type, so a caller cannot legally hand it an already-parsed value. Nodes without an `id.parse` keep their id untouched.

### Public API

`resolveUncachedNodesForType` is publicly exported (`src/index.ts` re-exports `utils/index.js`), so the keys reach it through a **new optional trailing parameter**. The existing 5-argument signature is unchanged and, when `keys` is omitted, falls back to exactly the previous `${config.name}:${id}` expression. Same for `resolveNodes`: `rawId` is optional, and direct callers that pass `{ id, typename }` behave as before.

### Blast radius

For nodes **without** an `id.parse` — the default and the overwhelming majority — `rawId` is absent, the shape path is a no-op, and keys are byte-identical to today, so cache behaviour is unchanged. `produces byte-identical cache keys for the default (no parse) path` pins this: it writes a cache entry through the legacy 5-argument `resolveUncachedNodesForType` call (which cannot know about raw global IDs, so it can only produce the old key string) and then asserts a `node` query hits it without re-loading. Verified non-vacuous by mutation — perturbing the key string fails that test and only that test.

The one intentional behaviour change beyond the fixes: a non-injective `parse` (e.g. `Number`, mapping `"1"` and `"01"` to the same value) no longer shares a cache entry between those two global IDs and loads twice. Results stay correct; only a coincidental cache hit is lost. Nothing in the docs or the test suite asserted that behaviour.

`@pothos/plugin-dataloader` is unaffected — `loadableNode` already constrains `IDShape extends bigint | number | string`.

## Tests

`packages/plugin-relay/tests/node-identity.test.ts`, nine tests. Five are repros that **fail on the base and pass here**; four are guards that correctly pass on the base too:

Repros:
- parsed **object** ids stay distinct (the original repro)
- parsed **`Date`** ids one millisecond apart stay distinct (the second repro)
- parsed **bigint** and **class instance** ids stay distinct — the class case is precisely where a canonical-serialization approach would have failed silently
- **dedupe**: `nodes(ids: [A, A, B])` with an object `parse` now sends the loader one deduped batch and maps each requested position to its own row. This over-fetched before
- **shape/string agreement, shape first**: a `GlobalIDShape`-supplied field followed by a string-supplied one. On the base this returns `{ key: null }` then `{ key: 1 }`; it now returns `{ key: 1 }` twice from a single `loadOne({ key: 1 })`

Guards (pass on the base, and must keep passing):
- **cache-hit regression**: one query selecting the same global ID through `node` twice and `nodes` calls the loader exactly once. No call-count coverage existed before; this is the guard against over-correcting into a cache that never hits
- **byte-identical keys** for the default no-parse path (above)
- **shape/string agreement, string first** and **root `node` field after a shape field**. These two pass on the base only by a resolver-ordering accident — the root `node` field reaches `resolveNodes` synchronously while `t.node` always awaits its `id` callback, so the correct load happens to win. They are pinned here so the result no longer depends on that ordering

Suite goes from 45 to 54 tests. `pnpm --filter @pothos/plugin-relay run test`, `run type`, `pnpm biome check packages/plugin-relay`, and `pnpm turbo run type --filter='...@pothos/plugin-relay'` (49 tasks) all pass.

## Known follow-ups, deliberately not in this PR

- **`types.ts:110`** types the custom-resolve escape hatch as `resolveNodes: (ids: { id: string; typename: string }[])` even though `id` is the *parsed* value and may not be a string. Pre-existing type inaccuracy on the same contract; left alone to keep this diff to the correctness fix.
- A **cache hit can return a node before `resolveNodes` has branded it**, so a concurrent `nodes` field in the same query can fail `resolveType` on an unbranded object. This reproduces on the base branch with no `parse` at all, so it is unrelated to this change; the tests here set `isTypeOf` to stay on topic.
- An **opt-in identity hook** (`id.key?: (parsed) => string`) remains available as a follow-up if the narrowed dedupe above ever proves to matter. The `rawId ?? id` fallback leaves room for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
