### PR TITLE
fix(prisma-next): infer the node shape from resolveNode

### DIFF
--- a/.changeset/prisma-next-resolve-node-shape.md
+++ b/.changeset/prisma-next-resolve-node-shape.md
@@ -15,5 +15,12 @@ as `string` while the runtime value was `undefined`, and strict `tsc` accepted i
 `resolveNode` are unaffected: `Node` stays at its `never` default and `wrap` keeps
 inferring the node from its own argument, including rows narrowed before materializing.
 
+Because `resolveNode` is supplied when the helper is built, its parameter can only be
+annotated with the model's full row. `wrap` now requires the full row whenever a
+`resolveNode` is configured, so a callback that mentions its parameter — `(row) => row`, or
+`(row) => ({ ...row, extra: 1 })` — can no longer launder that annotation into the node
+type and promise columns the caller never loaded. Passing narrowed rows to such a helper is
+now rejected at the `wrap` call, naming the missing columns.
+
 Runtime behaviour is unchanged — the transform still runs after `buildConnectionPage`, so
 each edge's cursor is still encoded from the original row.

--- a/.changeset/prisma-next-resolve-node-shape.md
+++ b/.changeset/prisma-next-resolve-node-shape.md
@@ -1,0 +1,19 @@
+---
+'@pothos/plugin-prisma-next': patch
+---
+
+Infer the connection node shape from `prismaConnectionHelpers`' `resolveNode`
+
+`resolveNode` replaces every `edge.node`, but `wrap` still declared its result as
+`ConnectionPage<WrapRow>` — the row that was passed in. A helper configured with
+`resolveNode: (row) => ({ post: row, decoratedAt: new Date() })` typed `edges[0].node.id`
+as `string` while the runtime value was `undefined`, and strict `tsc` accepted it.
+
+`resolveNode`'s return type is now inferred as a `Node` generic and resolved at `wrap`.
+`PrismaConnectionHelpers` gains a defaulted fourth type parameter, so existing
+`PrismaConnectionHelpers<Types, M, Args>` references keep compiling. Helpers without a
+`resolveNode` are unaffected: `Node` stays at its `never` default and `wrap` keeps
+inferring the node from its own argument, including rows narrowed before materializing.
+
+Runtime behaviour is unchanged — the transform still runs after `buildConnectionPage`, so
+each edge's cursor is still encoded from the original row.

--- a/.changeset/prisma-next-resolve-node-shape.md
+++ b/.changeset/prisma-next-resolve-node-shape.md
@@ -22,5 +22,10 @@ annotated with the model's full row. `wrap` now requires the full row whenever a
 type and promise columns the caller never loaded. Passing narrowed rows to such a helper is
 now rejected at the `wrap` call, naming the missing columns.
 
+A `resolveNode` supplied conditionally (`enabled ? fn : undefined`) may never run, and `wrap`
+leaves the row untouched when it is absent. Such a helper's node is therefore typed as the
+callback's result *or* the original row, so the caller has to narrow, rather than promising a
+transform that did not happen.
+
 Runtime behaviour is unchanged — the transform still runs after `buildConnectionPage`, so
 each edge's cursor is still encoded from the original row.

--- a/packages/plugin-prisma-next/src/connection-helpers.ts
+++ b/packages/plugin-prisma-next/src/connection-helpers.ts
@@ -36,15 +36,8 @@ import { getRefFromContractModel } from './utils/refs.js';
 import { aggregateCount, wrapConnectionOptionsWithTotalCount } from './utils/total-count.js';
 
 /**
- * The shape `wrap` hands back on each edge:
- *
- *   - No `resolveNode` (`Node` stays `never`) → the rows the caller passed to `wrap`.
- *   - A `resolveNode` that is always there → its return type.
- *   - One that may be absent (`enabled ? fn : undefined`) → either, since the transform
- *     only sometimes runs.
- *
- * `[Node] extends [never]` is the naked-`never` guard: a bare `Node extends never`
- * distributes and would collapse to `never`.
+ * `[Node]`, not bare `Node`: a naked type parameter distributes over a conditional, and
+ * `never` distributes to `never`.
  */
 export type ConnectionNodeShape<Node, WrapRow, MaybeAbsent extends boolean> = [Node] extends [never]
   ? WrapRow
@@ -52,12 +45,6 @@ export type ConnectionNodeShape<Node, WrapRow, MaybeAbsent extends boolean> = [N
     ? Node | WrapRow
     : Node;
 
-/**
- * What `wrap` accepts as rows: the full model row whenever a `resolveNode` might run, since
- * that callback's parameter is annotated with the full row and a callback that mentions it
- * would otherwise carry that annotation into the node type. With no callback the rows are
- * unconstrained, so a caller may narrow the selection freely.
- */
 export type ConnectionWrapRows<Types extends SchemaTypes, M extends ModelName<Types>, Node> = [
   Node,
 ] extends [never]
@@ -69,7 +56,6 @@ export interface PrismaConnectionHelpers<
   M extends ModelName<Types>,
   Args extends InputFieldMap = {},
   Node = never,
-  /** Whether the configured `resolveNode` might not be there at all. */
   MaybeAbsent extends boolean = false,
 > {
   ref: PrismaNextObjectRef<Types, M>;
@@ -98,10 +84,6 @@ export interface PrismaConnectionHelpers<
   connectionOptions<T extends object>(connectionOptions: T): T;
 }
 
-/**
- * Everything about a helper except `resolveNode`, which the overloads below vary so that a
- * definitely-present callback can be told apart from one that may be absent.
- */
 export interface PrismaConnectionHelperOptions<
   Types extends SchemaTypes,
   M extends ModelName<Types>,
@@ -147,10 +129,6 @@ export interface PrismaConnectionHelperOptions<
       ) => unknown);
 }
 
-/**
- * A `resolveNode` that is always present: every edge is transformed, so the node is exactly
- * the callback's return type.
- */
 export function prismaConnectionHelpers<
   Types extends SchemaTypes,
   M extends ModelName<Types>,
@@ -165,11 +143,6 @@ export function prismaConnectionHelpers<
   },
 ): PrismaConnectionHelpers<Types, M, Args, Node, false>;
 
-/**
- * No `resolveNode`, or one that may be absent (`enabled ? fn : undefined`): the node is the
- * callback's result or the untouched row. With no callback at all `Node` stays `never` and
- * the node falls back to `wrap`'s own row inference.
- */
 export function prismaConnectionHelpers<
   Types extends SchemaTypes,
   M extends ModelName<Types>,
@@ -309,8 +282,8 @@ export function prismaConnectionHelpers<
           if (totalCount !== undefined) {
             (page as { totalCount?: number }).totalCount = totalCount;
           }
-          // `page` is typed from `rows`, and the conditional can't be resolved against an
-          // unbound `Node` here; the loop above is what makes the declared shape true.
+          // A conditional type over an unbound type parameter stays deferred, and nothing
+          // checks as assignable to a deferred conditional.
           return page as unknown as ConnectionPage<ConnectionNodeShape<Node, WrapRow, boolean>>;
         },
       });

--- a/packages/plugin-prisma-next/src/connection-helpers.ts
+++ b/packages/plugin-prisma-next/src/connection-helpers.ts
@@ -36,17 +36,12 @@ import { getRefFromContractModel } from './utils/refs.js';
 import { aggregateCount, wrapConnectionOptionsWithTotalCount } from './utils/total-count.js';
 
 /**
- * The shape `wrap` hands back on each edge. Three cases, and the middle one is easy to miss:
+ * The shape `wrap` hands back on each edge:
  *
- * - **No `resolveNode`** — `Node` finds no inference candidate and stays `never`, so the node
- *   is whatever the caller passed to `wrap`. `Node` defaults to `never` rather than to
- *   `Row<Types, M>` precisely so this holds: a caller who narrows the collection's selection
- *   before materializing it must not be handed the full model row.
- * - **A `resolveNode` that may be absent** (`MaybeAbsent`, from `enabled ? fn : undefined`) —
- *   the transform runs only sometimes, so the node is the callback's result *or* the
- *   untouched row, and the caller has to narrow. Taking only the callback's return type here
- *   would promise a transform that never ran.
- * - **A `resolveNode` that is always there** — the node is its return type.
+ *   - No `resolveNode` (`Node` stays `never`) → the rows the caller passed to `wrap`.
+ *   - A `resolveNode` that is always there → its return type.
+ *   - One that may be absent (`enabled ? fn : undefined`) → either, since the transform
+ *     only sometimes runs.
  *
  * `[Node] extends [never]` is the naked-`never` guard: a bare `Node extends never`
  * distributes and would collapse to `never`.
@@ -58,18 +53,10 @@ export type ConnectionNodeShape<Node, WrapRow, MaybeAbsent extends boolean> = [N
     : Node;
 
 /**
- * What `wrap` accepts as rows.
- *
- * `resolveNode` is supplied when the helper is built, so its parameter can only be annotated
- * with the model's full row — the shape of the rows actually handed to `wrap` is not known
- * until much later. Reading the node off that callback therefore only tells the truth if the
- * rows really are full rows: a callback that mentions its parameter
- * (`(row) => ({ ...row, extra: 1 })`, or plain `(row) => row`) would otherwise propagate the
- * full-row annotation into the node type and promise columns the caller never loaded.
- *
- * So whenever a callback might run, `wrap` requires the full row — which is what that
- * callback already claims to receive. With no callback at all, rows are unconstrained and a
- * caller may narrow the selection freely.
+ * What `wrap` accepts as rows: the full model row whenever a `resolveNode` might run, since
+ * that callback's parameter is annotated with the full row and a callback that mentions it
+ * would otherwise carry that annotation into the node type. With no callback the rows are
+ * unconstrained, so a caller may narrow the selection freely.
  */
 export type ConnectionWrapRows<Types extends SchemaTypes, M extends ModelName<Types>, Node> = [
   Node,
@@ -179,11 +166,9 @@ export function prismaConnectionHelpers<
 ): PrismaConnectionHelpers<Types, M, Args, Node, false>;
 
 /**
- * No `resolveNode`, or one that may be absent (`enabled ? fn : undefined`). When it may be
- * absent the node is the callback's result *or* the untouched row, because that is what
- * `wrap` actually produces, and the caller has to narrow. When it is absent entirely `Node`
- * has no inference candidate and stays `never`, which collapses the node back to `wrap`'s
- * own row inference.
+ * No `resolveNode`, or one that may be absent (`enabled ? fn : undefined`): the node is the
+ * callback's result or the untouched row. With no callback at all `Node` stays `never` and
+ * the node falls back to `wrap`'s own row inference.
  */
 export function prismaConnectionHelpers<
   Types extends SchemaTypes,
@@ -324,9 +309,8 @@ export function prismaConnectionHelpers<
           if (totalCount !== undefined) {
             (page as { totalCount?: number }).totalCount = totalCount;
           }
-          // The loop above is what makes the declared node shape true; `page` is still
-          // typed from `rows`, and the conditional can't be resolved against an
-          // unbound `Node` here.
+          // `page` is typed from `rows`, and the conditional can't be resolved against an
+          // unbound `Node` here; the loop above is what makes the declared shape true.
           return page as unknown as ConnectionPage<ConnectionNodeShape<Node, WrapRow, boolean>>;
         },
       });

--- a/packages/plugin-prisma-next/src/connection-helpers.ts
+++ b/packages/plugin-prisma-next/src/connection-helpers.ts
@@ -35,10 +35,24 @@ import {
 import { getRefFromContractModel } from './utils/refs.js';
 import { aggregateCount, wrapConnectionOptionsWithTotalCount } from './utils/total-count.js';
 
+/**
+ * The shape `wrap` hands back on each edge. `resolveNode` replaces every `edge.node`, so
+ * when one is configured the node is the callback's return type; otherwise the node stays
+ * the row the caller passed to `wrap`.
+ *
+ * `Node` defaults to `never` rather than to `Row<Types, M>` so that helpers without a
+ * `resolveNode` keep inferring the node from `wrap`'s argument — a caller who narrows the
+ * collection's selection before materializing it must not be handed the full model row.
+ * `[Node] extends [never]` is the naked-`never` guard: a bare `Node extends never`
+ * distributes and would collapse to `never`.
+ */
+export type ConnectionNodeShape<Node, WrapRow> = [Node] extends [never] ? WrapRow : Node;
+
 export interface PrismaConnectionHelpers<
   Types extends SchemaTypes,
   M extends ModelName<Types>,
   Args extends InputFieldMap = {},
+  Node = never,
 > {
   ref: PrismaNextObjectRef<Types, M>;
   /**
@@ -60,7 +74,7 @@ export interface PrismaConnectionHelpers<
     wrap<WrapRow extends Record<string, unknown>>(
       rows: readonly WrapRow[],
       totalCount?: number,
-    ): ConnectionPage<WrapRow>;
+    ): ConnectionPage<ConnectionNodeShape<Node, WrapRow>>;
   }>;
   getArgs(): Args;
   connectionOptions<T extends object>(connectionOptions: T): T;
@@ -71,6 +85,7 @@ export function prismaConnectionHelpers<
   M extends ModelName<Types>,
   Cursor extends CursorSpec<Types, M>,
   Args extends InputFieldMap = {},
+  Node = never,
 >(
   builder: PothosSchemaTypes.SchemaBuilder<Types>,
   modelName: M,
@@ -112,9 +127,14 @@ export function prismaConnectionHelpers<
             import('@pothos/plugin-relay').DefaultConnectionArguments,
           ctx: Types['Context'],
         ) => unknown);
-    resolveNode?: (edge: Row<Types, M>) => unknown;
+    /**
+     * `Node` is inferred from this callback's return type and becomes the node on every
+     * edge `wrap` returns. Omitting `resolveNode` leaves `Node` at its `never` default,
+     * which hands the node position back to `wrap`'s own row inference.
+     */
+    resolveNode?: (edge: Row<Types, M>) => Node;
   },
-): PrismaConnectionHelpers<Types, M, Args> {
+): PrismaConnectionHelpers<Types, M, Args, Node> {
   const ref = getRefFromContractModel<Types, M>(modelName, builder);
 
   // `options.args` may be a literal or a thunk `(t) => argMap`; resolve
@@ -214,7 +234,7 @@ export function prismaConnectionHelpers<
         wrap<WrapRow extends Record<string, unknown>>(
           rows: readonly WrapRow[],
           totalCount?: number,
-        ): ConnectionPage<WrapRow> {
+        ): ConnectionPage<ConnectionNodeShape<Node, WrapRow>> {
           const page = buildConnectionPage(rows, pagination);
           // Apply resolveNode after buildConnectionPage so the cursor
           // encoder still sees the original row columns.
@@ -227,7 +247,10 @@ export function prismaConnectionHelpers<
           if (totalCount !== undefined) {
             (page as { totalCount?: number }).totalCount = totalCount;
           }
-          return page;
+          // The loop above is what makes the declared node shape true; `page` is still
+          // typed from `rows`, and the conditional can't be resolved against an
+          // unbound `Node` here.
+          return page as unknown as ConnectionPage<ConnectionNodeShape<Node, WrapRow>>;
         },
       });
 

--- a/packages/plugin-prisma-next/src/connection-helpers.ts
+++ b/packages/plugin-prisma-next/src/connection-helpers.ts
@@ -36,31 +36,39 @@ import { getRefFromContractModel } from './utils/refs.js';
 import { aggregateCount, wrapConnectionOptionsWithTotalCount } from './utils/total-count.js';
 
 /**
- * The shape `wrap` hands back on each edge. `resolveNode` replaces every `edge.node`, so
- * when one is configured the node is the callback's return type; otherwise the node stays
- * the row the caller passed to `wrap`.
+ * The shape `wrap` hands back on each edge. Three cases, and the middle one is easy to miss:
  *
- * `Node` defaults to `never` rather than to `Row<Types, M>` so that helpers without a
- * `resolveNode` keep inferring the node from `wrap`'s argument — a caller who narrows the
- * collection's selection before materializing it must not be handed the full model row.
+ * - **No `resolveNode`** — `Node` finds no inference candidate and stays `never`, so the node
+ *   is whatever the caller passed to `wrap`. `Node` defaults to `never` rather than to
+ *   `Row<Types, M>` precisely so this holds: a caller who narrows the collection's selection
+ *   before materializing it must not be handed the full model row.
+ * - **A `resolveNode` that may be absent** (`MaybeAbsent`, from `enabled ? fn : undefined`) —
+ *   the transform runs only sometimes, so the node is the callback's result *or* the
+ *   untouched row, and the caller has to narrow. Taking only the callback's return type here
+ *   would promise a transform that never ran.
+ * - **A `resolveNode` that is always there** — the node is its return type.
+ *
  * `[Node] extends [never]` is the naked-`never` guard: a bare `Node extends never`
  * distributes and would collapse to `never`.
  */
-export type ConnectionNodeShape<Node, WrapRow> = [Node] extends [never] ? WrapRow : Node;
+export type ConnectionNodeShape<Node, WrapRow, MaybeAbsent extends boolean> = [Node] extends [never]
+  ? WrapRow
+  : MaybeAbsent extends true
+    ? Node | WrapRow
+    : Node;
 
 /**
  * What `wrap` accepts as rows.
  *
- * `resolveNode` is supplied when the helper is built, so its parameter can only be
- * annotated with the model's full row — the shape of the rows actually handed to `wrap` is
- * not known until much later. Inferring `Node` from that callback's return type therefore
- * only tells the truth if the rows really are full rows: a callback that mentions its
- * parameter (`(row) => ({ ...row, extra: 1 })`, or plain `(row) => row`) would otherwise
- * propagate the full-row annotation into the node type and promise columns the caller
- * never loaded.
+ * `resolveNode` is supplied when the helper is built, so its parameter can only be annotated
+ * with the model's full row — the shape of the rows actually handed to `wrap` is not known
+ * until much later. Reading the node off that callback therefore only tells the truth if the
+ * rows really are full rows: a callback that mentions its parameter
+ * (`(row) => ({ ...row, extra: 1 })`, or plain `(row) => row`) would otherwise propagate the
+ * full-row annotation into the node type and promise columns the caller never loaded.
  *
- * So when a `resolveNode` is configured, `wrap` requires the full row, which is what the
- * callback already claims to receive. Without one, rows are unconstrained as before and a
+ * So whenever a callback might run, `wrap` requires the full row — which is what that
+ * callback already claims to receive. With no callback at all, rows are unconstrained and a
  * caller may narrow the selection freely.
  */
 export type ConnectionWrapRows<Types extends SchemaTypes, M extends ModelName<Types>, Node> = [
@@ -74,6 +82,8 @@ export interface PrismaConnectionHelpers<
   M extends ModelName<Types>,
   Args extends InputFieldMap = {},
   Node = never,
+  /** Whether the configured `resolveNode` might not be there at all. */
+  MaybeAbsent extends boolean = false,
 > {
   ref: PrismaNextObjectRef<Types, M>;
   /**
@@ -95,11 +105,99 @@ export interface PrismaConnectionHelpers<
     wrap<WrapRow extends ConnectionWrapRows<Types, M, Node>>(
       rows: readonly WrapRow[],
       totalCount?: number,
-    ): ConnectionPage<ConnectionNodeShape<Node, WrapRow>>;
+    ): ConnectionPage<ConnectionNodeShape<Node, WrapRow, MaybeAbsent>>;
   }>;
   getArgs(): Args;
   connectionOptions<T extends object>(connectionOptions: T): T;
 }
+
+/**
+ * Everything about a helper except `resolveNode`, which the overloads below vary so that a
+ * definitely-present callback can be told apart from one that may be absent.
+ */
+export interface PrismaConnectionHelperOptions<
+  Types extends SchemaTypes,
+  M extends ModelName<Types>,
+  Cursor extends CursorSpec<Types, M>,
+  Args extends InputFieldMap,
+> {
+  cursor: Cursor;
+  args?: Args | ((t: PothosSchemaTypes.InputFieldBuilder<Types, 'Arg'>) => Args);
+  defaultSize?:
+    | number
+    | ((
+        args: import('@pothos/plugin-relay').DefaultConnectionArguments,
+        ctx: Types['Context'],
+      ) => number);
+  maxSize?:
+    | number
+    | ((
+        args: import('@pothos/plugin-relay').DefaultConnectionArguments,
+        ctx: Types['Context'],
+      ) => number);
+  totalCount?:
+    | boolean
+    | ((
+        args: InputShapeFromFields<Args> &
+          import('@pothos/plugin-relay').DefaultConnectionArguments,
+        ctx: Types['Context'],
+        info: GraphQLResolveInfo | undefined,
+      ) => MaybePromise<number>);
+  where?:
+    | import('@prisma/orm-family-sql/orm-client').ShorthandWhereFilter<
+        Types['PrismaNextContract'],
+        NamespaceOf<Types, M>,
+        M
+      >
+    | ((
+        accessor: import('@prisma/orm-family-sql/orm-client').ModelAccessor<
+          Types['PrismaNextContract'],
+          M
+        >,
+        args: InputShapeFromFields<Args> &
+          import('@pothos/plugin-relay').DefaultConnectionArguments,
+        ctx: Types['Context'],
+      ) => unknown);
+}
+
+/**
+ * A `resolveNode` that is always present: every edge is transformed, so the node is exactly
+ * the callback's return type.
+ */
+export function prismaConnectionHelpers<
+  Types extends SchemaTypes,
+  M extends ModelName<Types>,
+  Cursor extends CursorSpec<Types, M>,
+  Args extends InputFieldMap = {},
+  Node = never,
+>(
+  builder: PothosSchemaTypes.SchemaBuilder<Types>,
+  modelName: M,
+  options: PrismaConnectionHelperOptions<Types, M, Cursor, Args> & {
+    resolveNode: (edge: Row<Types, M>) => Node;
+  },
+): PrismaConnectionHelpers<Types, M, Args, Node, false>;
+
+/**
+ * No `resolveNode`, or one that may be absent (`enabled ? fn : undefined`). When it may be
+ * absent the node is the callback's result *or* the untouched row, because that is what
+ * `wrap` actually produces, and the caller has to narrow. When it is absent entirely `Node`
+ * has no inference candidate and stays `never`, which collapses the node back to `wrap`'s
+ * own row inference.
+ */
+export function prismaConnectionHelpers<
+  Types extends SchemaTypes,
+  M extends ModelName<Types>,
+  Cursor extends CursorSpec<Types, M>,
+  Args extends InputFieldMap = {},
+  Node = never,
+>(
+  builder: PothosSchemaTypes.SchemaBuilder<Types>,
+  modelName: M,
+  options: PrismaConnectionHelperOptions<Types, M, Cursor, Args> & {
+    resolveNode?: ((edge: Row<Types, M>) => Node) | undefined;
+  },
+): PrismaConnectionHelpers<Types, M, Args, Node, true>;
 
 export function prismaConnectionHelpers<
   Types extends SchemaTypes,
@@ -110,52 +208,10 @@ export function prismaConnectionHelpers<
 >(
   builder: PothosSchemaTypes.SchemaBuilder<Types>,
   modelName: M,
-  options: {
-    cursor: Cursor;
-    args?: Args | ((t: PothosSchemaTypes.InputFieldBuilder<Types, 'Arg'>) => Args);
-    defaultSize?:
-      | number
-      | ((
-          args: import('@pothos/plugin-relay').DefaultConnectionArguments,
-          ctx: Types['Context'],
-        ) => number);
-    maxSize?:
-      | number
-      | ((
-          args: import('@pothos/plugin-relay').DefaultConnectionArguments,
-          ctx: Types['Context'],
-        ) => number);
-    totalCount?:
-      | boolean
-      | ((
-          args: InputShapeFromFields<Args> &
-            import('@pothos/plugin-relay').DefaultConnectionArguments,
-          ctx: Types['Context'],
-          info: GraphQLResolveInfo | undefined,
-        ) => MaybePromise<number>);
-    where?:
-      | import('@prisma/orm-family-sql/orm-client').ShorthandWhereFilter<
-          Types['PrismaNextContract'],
-          NamespaceOf<Types, M>,
-          M
-        >
-      | ((
-          accessor: import('@prisma/orm-family-sql/orm-client').ModelAccessor<
-            Types['PrismaNextContract'],
-            M
-          >,
-          args: InputShapeFromFields<Args> &
-            import('@pothos/plugin-relay').DefaultConnectionArguments,
-          ctx: Types['Context'],
-        ) => unknown);
-    /**
-     * `Node` is inferred from this callback's return type and becomes the node on every
-     * edge `wrap` returns. Omitting `resolveNode` leaves `Node` at its `never` default,
-     * which hands the node position back to `wrap`'s own row inference.
-     */
-    resolveNode?: (edge: Row<Types, M>) => Node;
+  options: PrismaConnectionHelperOptions<Types, M, Cursor, Args> & {
+    resolveNode?: ((edge: Row<Types, M>) => Node) | undefined;
   },
-): PrismaConnectionHelpers<Types, M, Args, Node> {
+): PrismaConnectionHelpers<Types, M, Args, Node, boolean> {
   const ref = getRefFromContractModel<Types, M>(modelName, builder);
 
   // `options.args` may be a literal or a thunk `(t) => argMap`; resolve
@@ -255,7 +311,7 @@ export function prismaConnectionHelpers<
         wrap<WrapRow extends ConnectionWrapRows<Types, M, Node>>(
           rows: readonly WrapRow[],
           totalCount?: number,
-        ): ConnectionPage<ConnectionNodeShape<Node, WrapRow>> {
+        ): ConnectionPage<ConnectionNodeShape<Node, WrapRow, boolean>> {
           const page = buildConnectionPage(rows, pagination);
           // Apply resolveNode after buildConnectionPage so the cursor
           // encoder still sees the original row columns.
@@ -271,7 +327,7 @@ export function prismaConnectionHelpers<
           // The loop above is what makes the declared node shape true; `page` is still
           // typed from `rows`, and the conditional can't be resolved against an
           // unbound `Node` here.
-          return page as unknown as ConnectionPage<ConnectionNodeShape<Node, WrapRow>>;
+          return page as unknown as ConnectionPage<ConnectionNodeShape<Node, WrapRow, boolean>>;
         },
       });
 

--- a/packages/plugin-prisma-next/src/connection-helpers.ts
+++ b/packages/plugin-prisma-next/src/connection-helpers.ts
@@ -35,10 +35,6 @@ import {
 import { getRefFromContractModel } from './utils/refs.js';
 import { aggregateCount, wrapConnectionOptionsWithTotalCount } from './utils/total-count.js';
 
-/**
- * `[Node]`, not bare `Node`: a naked type parameter distributes over a conditional, and
- * `never` distributes to `never`.
- */
 export type ConnectionNodeShape<Node, WrapRow, MaybeAbsent extends boolean> = [Node] extends [never]
   ? WrapRow
   : MaybeAbsent extends true
@@ -282,8 +278,6 @@ export function prismaConnectionHelpers<
           if (totalCount !== undefined) {
             (page as { totalCount?: number }).totalCount = totalCount;
           }
-          // A conditional type over an unbound type parameter stays deferred, and nothing
-          // checks as assignable to a deferred conditional.
           return page as unknown as ConnectionPage<ConnectionNodeShape<Node, WrapRow, boolean>>;
         },
       });

--- a/packages/plugin-prisma-next/src/connection-helpers.ts
+++ b/packages/plugin-prisma-next/src/connection-helpers.ts
@@ -48,6 +48,27 @@ import { aggregateCount, wrapConnectionOptionsWithTotalCount } from './utils/tot
  */
 export type ConnectionNodeShape<Node, WrapRow> = [Node] extends [never] ? WrapRow : Node;
 
+/**
+ * What `wrap` accepts as rows.
+ *
+ * `resolveNode` is supplied when the helper is built, so its parameter can only be
+ * annotated with the model's full row — the shape of the rows actually handed to `wrap` is
+ * not known until much later. Inferring `Node` from that callback's return type therefore
+ * only tells the truth if the rows really are full rows: a callback that mentions its
+ * parameter (`(row) => ({ ...row, extra: 1 })`, or plain `(row) => row`) would otherwise
+ * propagate the full-row annotation into the node type and promise columns the caller
+ * never loaded.
+ *
+ * So when a `resolveNode` is configured, `wrap` requires the full row, which is what the
+ * callback already claims to receive. Without one, rows are unconstrained as before and a
+ * caller may narrow the selection freely.
+ */
+export type ConnectionWrapRows<Types extends SchemaTypes, M extends ModelName<Types>, Node> = [
+  Node,
+] extends [never]
+  ? Record<string, unknown>
+  : Row<Types, M>;
+
 export interface PrismaConnectionHelpers<
   Types extends SchemaTypes,
   M extends ModelName<Types>,
@@ -71,7 +92,7 @@ export interface PrismaConnectionHelpers<
   ): MaybePromise<{
     collection: CollectionFor<Types, M>;
     totalCountPromise: Promise<number> | undefined;
-    wrap<WrapRow extends Record<string, unknown>>(
+    wrap<WrapRow extends ConnectionWrapRows<Types, M, Node>>(
       rows: readonly WrapRow[],
       totalCount?: number,
     ): ConnectionPage<ConnectionNodeShape<Node, WrapRow>>;
@@ -231,7 +252,7 @@ export function prismaConnectionHelpers<
         get totalCountPromise() {
           return getTotalCountPromise();
         },
-        wrap<WrapRow extends Record<string, unknown>>(
+        wrap<WrapRow extends ConnectionWrapRows<Types, M, Node>>(
           rows: readonly WrapRow[],
           totalCount?: number,
         ): ConnectionPage<ConnectionNodeShape<Node, WrapRow>> {

--- a/packages/plugin-prisma-next/src/index.ts
+++ b/packages/plugin-prisma-next/src/index.ts
@@ -50,6 +50,7 @@ export { all, and, not, or } from '@prisma/orm-family-sql/orm-client';
 export type {
   ConnectionNodeShape,
   ConnectionWrapRows,
+  PrismaConnectionHelperOptions,
   PrismaConnectionHelpers,
 } from './connection-helpers.js';
 export { prismaConnectionHelpers } from './connection-helpers.js';

--- a/packages/plugin-prisma-next/src/index.ts
+++ b/packages/plugin-prisma-next/src/index.ts
@@ -47,7 +47,11 @@ export type {
 // so the plugin owns reconstructed copies. `IncludeRefinementResult` was
 // dropped (see the note in ./types).
 export { all, and, not, or } from '@prisma/orm-family-sql/orm-client';
-export type { ConnectionNodeShape, PrismaConnectionHelpers } from './connection-helpers.js';
+export type {
+  ConnectionNodeShape,
+  ConnectionWrapRows,
+  PrismaConnectionHelpers,
+} from './connection-helpers.js';
 export { prismaConnectionHelpers } from './connection-helpers.js';
 export { PRISMA_NEXT_MODEL, PRISMA_NEXT_PREPARED, PRISMA_NEXT_SELECT } from './constants.js';
 export type { PreparedFieldExtension, RefineCallback } from './extensions.js';

--- a/packages/plugin-prisma-next/src/index.ts
+++ b/packages/plugin-prisma-next/src/index.ts
@@ -47,7 +47,7 @@ export type {
 // so the plugin owns reconstructed copies. `IncludeRefinementResult` was
 // dropped (see the note in ./types).
 export { all, and, not, or } from '@prisma/orm-family-sql/orm-client';
-export type { PrismaConnectionHelpers } from './connection-helpers.js';
+export type { ConnectionNodeShape, PrismaConnectionHelpers } from './connection-helpers.js';
 export { prismaConnectionHelpers } from './connection-helpers.js';
 export { PRISMA_NEXT_MODEL, PRISMA_NEXT_PREPARED, PRISMA_NEXT_SELECT } from './constants.js';
 export type { PreparedFieldExtension, RefineCallback } from './extensions.js';

--- a/packages/plugin-prisma-next/tests/connection-types.test-d.ts
+++ b/packages/plugin-prisma-next/tests/connection-types.test-d.ts
@@ -40,10 +40,6 @@ builder.queryType({
   }),
 });
 
-// `resolveNode` replaces every `edge.node` in place, so `wrap`'s return type has to
-// describe the callback's shape rather than the rows that were passed in. Before the
-// node shape was inferred, `node.id` typed as `string` while the runtime value was
-// `undefined`.
 const wrappedNodes = prismaConnectionHelpers(builder, 'User', {
   cursor: 'id',
   resolveNode: (row) => ({ user: row }),
@@ -60,8 +56,6 @@ export async function wrappedNodeShape() {
   expectTypeOf(result.edges[0]!.cursor).toEqualTypeOf<string>();
 }
 
-// A `resolveNode` returning a union keeps both members on the node, and never collapses
-// back to the row.
 const unionNodes = prismaConnectionHelpers(builder, 'User', {
   cursor: 'id',
   resolveNode: (row): { kind: 'user'; user: typeof row } | { kind: 'empty' } =>
@@ -75,15 +69,11 @@ export async function unionNodeShape() {
   expectTypeOf(result.edges[0]!.node.kind).toEqualTypeOf<'user' | 'empty'>();
 }
 
-// Without `resolveNode` the node is still inferred from the rows handed to `wrap`,
-// including rows the caller narrowed before materializing them.
 const plainNodes = prismaConnectionHelpers(builder, 'User', { cursor: 'id' });
 
 export async function plainNodeShape() {
   const page = await plainNodes.applyPagination(ctx.ormClient.User, { first: 1 }, undefined, {});
 
-  // Exact whole-type equality, not just the node member: the `Node = never` default has
-  // to leave this inference byte-for-byte what it was before the node shape existed.
   const narrowed = page.wrap([{ id: 'a', firstName: 'Alice' }]);
   expectTypeOf(narrowed).toEqualTypeOf<ConnectionPage<{ id: string; firstName: string }>>();
   expectTypeOf(narrowed.edges[0]!.node).toEqualTypeOf<{ id: string; firstName: string }>();
@@ -93,14 +83,6 @@ export async function plainNodeShape() {
   expectTypeOf(rows.edges[0]!.cursor).toEqualTypeOf<string>();
 }
 
-// `resolveNode`'s parameter can only be annotated with the model's full row — the helper
-// is built long before anyone calls `wrap`. So a callback that mentions its parameter
-// would otherwise launder that annotation into the node type and promise columns the
-// caller never loaded. `wrap` therefore demands the full row whenever a `resolveNode` is
-// configured, which is exactly what the callback already claims to receive.
-//
-// Each case below is rejected at the `wrap` call, naming the missing columns, rather than
-// silently producing a node type with `email`/`lastName` on it.
 const narrowRows = [{ id: 'a', firstName: 'Alice' }];
 
 const spreadingNode = prismaConnectionHelpers(builder, 'User', {
@@ -141,17 +123,12 @@ export async function narrowedRowsRejected() {
   // @ts-expect-error the documented wrapper form would put the full row under `.user`.
   wrapper.wrap(narrowRows);
 
-  // The full row satisfies the constraint, so the ordinary path is untouched — the node
-  // type is then true, because the callback really did receive what it was annotated with.
   const full = await spreadingNode.applyPagination(ctx.ormClient.User, { first: 1 }, undefined, {});
   const result = full.wrap(await full.collection.all());
   expectTypeOf(result.edges[0]!.node.extra).toEqualTypeOf<number>();
   expectTypeOf(result.edges[0]!.node.email).toEqualTypeOf<string>();
 }
 
-// A `resolveNode` supplied conditionally may never run. Taking only its return type would
-// promise a transform that didn't happen: at runtime `wrap` leaves the row untouched when
-// the callback is absent, so the node is the callback's result *or* the original row.
 declare const enabled: boolean;
 
 const conditionalNodes = prismaConnectionHelpers(builder, 'User', {
@@ -171,7 +148,6 @@ export async function conditionalNodeShape() {
   // @ts-expect-error the transform may not have run, so the node may still be the raw row.
   node.user;
 
-  // Narrowing is the caller's job, and both branches are reachable.
   if ('user' in node) {
     expectTypeOf(node.user.id).toEqualTypeOf<string>();
   } else {
@@ -179,7 +155,6 @@ export async function conditionalNodeShape() {
   }
 }
 
-// Non-object returns survive inference unchanged.
 const primitiveNode = prismaConnectionHelpers(builder, 'User', {
   cursor: 'id',
   resolveNode: (row) => row.firstName,

--- a/packages/plugin-prisma-next/tests/connection-types.test-d.ts
+++ b/packages/plugin-prisma-next/tests/connection-types.test-d.ts
@@ -1,7 +1,8 @@
 import SchemaBuilder from '@pothos/core';
 import RelayPlugin from '@pothos/plugin-relay';
 import { expectTypeOf } from 'vitest';
-import prismaNextPlugin from '../src';
+import prismaNextPlugin, { prismaConnectionHelpers } from '../src';
+import type { ConnectionPage } from '../src/utils/cursors';
 import type { SampleContract, TestRuntimeContext } from './fixtures/runtime';
 
 declare const ctx: TestRuntimeContext;
@@ -38,3 +39,56 @@ builder.queryType({
     }),
   }),
 });
+
+// `resolveNode` replaces every `edge.node` in place, so `wrap`'s return type has to
+// describe the callback's shape rather than the rows that were passed in. Before the
+// node shape was inferred, `node.id` typed as `string` while the runtime value was
+// `undefined`.
+const wrappedNodes = prismaConnectionHelpers(builder, 'User', {
+  cursor: 'id',
+  resolveNode: (row) => ({ user: row }),
+});
+
+export async function wrappedNodeShape() {
+  const page = await wrappedNodes.applyPagination(ctx.ormClient.User, { first: 1 }, undefined, {});
+  const result = page.wrap(await page.collection.all());
+
+  // @ts-expect-error `node` is the `{ user: Row }` wrapper, not the row itself.
+  result.edges[0]!.node.id;
+
+  expectTypeOf(result.edges[0]!.node.user.id).toEqualTypeOf<string>();
+  expectTypeOf(result.edges[0]!.cursor).toEqualTypeOf<string>();
+}
+
+// A `resolveNode` returning a union keeps both members on the node, and never collapses
+// back to the row.
+const unionNodes = prismaConnectionHelpers(builder, 'User', {
+  cursor: 'id',
+  resolveNode: (row): { kind: 'user'; user: typeof row } | { kind: 'empty' } =>
+    row.firstName ? { kind: 'user', user: row } : { kind: 'empty' },
+});
+
+export async function unionNodeShape() {
+  const page = await unionNodes.applyPagination(ctx.ormClient.User, { first: 1 }, undefined, {});
+  const result = page.wrap(await page.collection.all());
+
+  expectTypeOf(result.edges[0]!.node.kind).toEqualTypeOf<'user' | 'empty'>();
+}
+
+// Without `resolveNode` the node is still inferred from the rows handed to `wrap`,
+// including rows the caller narrowed before materializing them.
+const plainNodes = prismaConnectionHelpers(builder, 'User', { cursor: 'id' });
+
+export async function plainNodeShape() {
+  const page = await plainNodes.applyPagination(ctx.ormClient.User, { first: 1 }, undefined, {});
+
+  // Exact whole-type equality, not just the node member: the `Node = never` default has
+  // to leave this inference byte-for-byte what it was before the node shape existed.
+  const narrowed = page.wrap([{ id: 'a', firstName: 'Alice' }]);
+  expectTypeOf(narrowed).toEqualTypeOf<ConnectionPage<{ id: string; firstName: string }>>();
+  expectTypeOf(narrowed.edges[0]!.node).toEqualTypeOf<{ id: string; firstName: string }>();
+
+  const rows = page.wrap(await page.collection.all());
+  expectTypeOf(rows.edges[0]!.node.id).toEqualTypeOf<string>();
+  expectTypeOf(rows.edges[0]!.cursor).toEqualTypeOf<string>();
+}

--- a/packages/plugin-prisma-next/tests/connection-types.test-d.ts
+++ b/packages/plugin-prisma-next/tests/connection-types.test-d.ts
@@ -148,3 +148,73 @@ export async function narrowedRowsRejected() {
   expectTypeOf(result.edges[0]!.node.extra).toEqualTypeOf<number>();
   expectTypeOf(result.edges[0]!.node.email).toEqualTypeOf<string>();
 }
+
+// A `resolveNode` supplied conditionally may never run. Taking only its return type would
+// promise a transform that didn't happen: at runtime `wrap` leaves the row untouched when
+// the callback is absent, so the node is the callback's result *or* the original row.
+declare const enabled: boolean;
+
+const conditionalNodes = prismaConnectionHelpers(builder, 'User', {
+  cursor: 'id',
+  resolveNode: enabled ? (row) => ({ user: row }) : undefined,
+});
+
+export async function conditionalNodeShape() {
+  const page = await conditionalNodes.applyPagination(
+    ctx.ormClient.User,
+    { first: 1 },
+    undefined,
+    {},
+  );
+  const node = page.wrap(await page.collection.all()).edges[0]!.node;
+
+  // @ts-expect-error the transform may not have run, so the node may still be the raw row.
+  node.user;
+
+  // Narrowing is the caller's job, and both branches are reachable.
+  if ('user' in node) {
+    expectTypeOf(node.user.id).toEqualTypeOf<string>();
+  } else {
+    expectTypeOf(node.id).toEqualTypeOf<string>();
+  }
+}
+
+// Non-object returns survive inference unchanged.
+const primitiveNode = prismaConnectionHelpers(builder, 'User', {
+  cursor: 'id',
+  resolveNode: (row) => row.firstName,
+});
+
+const nullNode = prismaConnectionHelpers(builder, 'User', {
+  cursor: 'id',
+  resolveNode: () => null,
+});
+
+const promiseNode = prismaConnectionHelpers(builder, 'User', {
+  cursor: 'id',
+  resolveNode: (row) => Promise.resolve({ user: row }),
+});
+
+export async function otherReturnShapes() {
+  const primitive = await primitiveNode.applyPagination(
+    ctx.ormClient.User,
+    { first: 1 },
+    undefined,
+    {},
+  );
+  expectTypeOf(
+    primitive.wrap(await primitive.collection.all()).edges[0]!.node,
+  ).toEqualTypeOf<string>();
+
+  const nulled = await nullNode.applyPagination(ctx.ormClient.User, { first: 1 }, undefined, {});
+  expectTypeOf(nulled.wrap(await nulled.collection.all()).edges[0]!.node).toEqualTypeOf<null>();
+
+  const promised = await promiseNode.applyPagination(
+    ctx.ormClient.User,
+    { first: 1 },
+    undefined,
+    {},
+  );
+  const node = promised.wrap(await promised.collection.all()).edges[0]!.node;
+  expectTypeOf((await node).user.id).toEqualTypeOf<string>();
+}

--- a/packages/plugin-prisma-next/tests/connection-types.test-d.ts
+++ b/packages/plugin-prisma-next/tests/connection-types.test-d.ts
@@ -92,3 +92,59 @@ export async function plainNodeShape() {
   expectTypeOf(rows.edges[0]!.node.id).toEqualTypeOf<string>();
   expectTypeOf(rows.edges[0]!.cursor).toEqualTypeOf<string>();
 }
+
+// `resolveNode`'s parameter can only be annotated with the model's full row — the helper
+// is built long before anyone calls `wrap`. So a callback that mentions its parameter
+// would otherwise launder that annotation into the node type and promise columns the
+// caller never loaded. `wrap` therefore demands the full row whenever a `resolveNode` is
+// configured, which is exactly what the callback already claims to receive.
+//
+// Each case below is rejected at the `wrap` call, naming the missing columns, rather than
+// silently producing a node type with `email`/`lastName` on it.
+const narrowRows = [{ id: 'a', firstName: 'Alice' }];
+
+const spreadingNode = prismaConnectionHelpers(builder, 'User', {
+  cursor: 'id',
+  resolveNode: (row) => ({ ...row, extra: 1 }),
+});
+
+const identityNode = prismaConnectionHelpers(builder, 'User', {
+  cursor: 'id',
+  resolveNode: (row) => row,
+});
+
+export async function narrowedRowsRejected() {
+  const spreading = await spreadingNode.applyPagination(
+    ctx.ormClient.User,
+    { first: 1 },
+    undefined,
+    {},
+  );
+  // @ts-expect-error a spreading callback would claim `email`/`lastName` these rows lack.
+  spreading.wrap(narrowRows);
+
+  const identity = await identityNode.applyPagination(
+    ctx.ormClient.User,
+    { first: 1 },
+    undefined,
+    {},
+  );
+  // @ts-expect-error an identity callback would re-declare the node as the full row.
+  identity.wrap(narrowRows);
+
+  const wrapper = await wrappedNodes.applyPagination(
+    ctx.ormClient.User,
+    { first: 1 },
+    undefined,
+    {},
+  );
+  // @ts-expect-error the documented wrapper form would put the full row under `.user`.
+  wrapper.wrap(narrowRows);
+
+  // The full row satisfies the constraint, so the ordinary path is untouched — the node
+  // type is then true, because the callback really did receive what it was annotated with.
+  const full = await spreadingNode.applyPagination(ctx.ormClient.User, { first: 1 }, undefined, {});
+  const result = full.wrap(await full.collection.all());
+  expectTypeOf(result.edges[0]!.node.extra).toEqualTypeOf<number>();
+  expectTypeOf(result.edges[0]!.node.email).toEqualTypeOf<string>();
+}

--- a/packages/plugin-prisma-next/tests/connection.test.ts
+++ b/packages/plugin-prisma-next/tests/connection.test.ts
@@ -252,8 +252,6 @@ function buildSchema() {
         type: DecoratedUser,
         args: decoratedUsers.getArgs(),
         resolve: async (_p, args, _ctx) => {
-          // `info` withheld: the auto-include mapper descends into `edges.node` and
-          // requires that type to be prisma-backed.
           const { collection, wrap } = await decoratedUsers.applyPagination(
             ctx.ormClient.User,
             args,

--- a/packages/plugin-prisma-next/tests/connection.test.ts
+++ b/packages/plugin-prisma-next/tests/connection.test.ts
@@ -149,11 +149,8 @@ function buildSchema() {
     resolveNode: (edge) => ({ id: edge.id, name: edge.firstName }),
   });
 
-  // Helper with a *wrapper*-shaped `resolveNode` — the documented shape
-  // (docs/connections.mdx) where the node is an object holding the row plus
-  // metadata, so none of the row's own columns are reachable on the node.
-  // `namesOnly` above cannot catch a lost node shape because its result happens
-  // to keep an `id` of its own.
+  // Wrapper-shaped `resolveNode` — the node is an object holding the row plus
+  // metadata, so none of the row's own columns are reachable on it.
   const decoratedUsers = prismaConnectionHelpers(builder, 'User', {
     cursor: 'id',
     defaultSize: 10,
@@ -164,8 +161,6 @@ function buildSchema() {
     .objectRef<{ user: { id: string; firstName: string }; decoratedAt: string }>('DecoratedUser')
     .implement({
       fields: (t) => ({
-        // Read *through* the wrapper. If `wrap` handed back the untransformed
-        // row, `parent.user` would be undefined and these would throw.
         userId: t.string({ resolve: (parent) => parent.user.id }),
         firstName: t.string({ resolve: (parent) => parent.user.firstName }),
         decoratedAt: t.exposeString('decoratedAt'),
@@ -255,23 +250,15 @@ function buildSchema() {
           return wrap(rows) as never;
         },
       }),
-      // Wrapper-shaped `resolveNode` end-to-end: the GraphQL node type reads
-      // through the wrapper, so this field only resolves if `wrap` really did
-      // replace each `edge.node`.
-      //
-      // Note the missing `as never` on the `wrap` call below — the only helper
-      // call site in this file without one. Now that the node shape is inferred
-      // from `resolveNode`, `wrap`'s result checks structurally against the
-      // `DecoratedUser` node this connection declares. Before, it was typed as
-      // the User row and could only be forced through with a cast.
+      // Wrapper-shaped `resolveNode` end-to-end — the GraphQL node type reads
+      // through the wrapper.
       decoratedUsers: t.connection({
         type: DecoratedUser,
         args: decoratedUsers.getArgs(),
         resolve: async (_p, args, _ctx) => {
           // `info` is deliberately withheld: the auto-include mapper descends into
           // `edges.node` and requires that type to be prisma-backed, which a
-          // wrapper node is not. Without it the collection materializes the full
-          // row, which is what the wrapper holds anyway.
+          // wrapper node is not.
           const { collection, wrap } = await decoratedUsers.applyPagination(
             ctx.ormClient.User,
             args,
@@ -983,9 +970,6 @@ describe('prismaConnection: end-to-end against real sqlite', () => {
   });
 
   it('prismaConnectionHelpers resolveNode: a wrapper node resolves through the wrapper', async () => {
-    // `resolveNode: (row) => ({ user: row, decoratedAt })` — none of the row's own
-    // columns survive on the node, so every field here has to reach through
-    // `parent.user`. This is the shape `namesOnly` cannot exercise.
     const result = await runQuery(
       '{ decoratedUsers(first: 10) { edges { cursor node { userId firstName decoratedAt } } } }',
     );
@@ -1002,8 +986,6 @@ describe('prismaConnection: end-to-end against real sqlite', () => {
     expect(data.decoratedUsers.edges).toHaveLength(2);
     expect(data.decoratedUsers.edges.map((edge) => edge.node.userId)).toEqual(['u-alice', 'u-bob']);
     for (const edge of data.decoratedUsers.edges) {
-      // The defect this guards: before the node shape was inferred, a caller could
-      // read `node.id` as a `string` and get `undefined`.
       expect(edge.node.userId).toBeTruthy();
       expect(edge.node.firstName).toBeTruthy();
       expect(edge.node.decoratedAt).toBe('decorated');
@@ -1011,10 +993,6 @@ describe('prismaConnection: end-to-end against real sqlite', () => {
   });
 
   it('prismaConnectionHelpers resolveNode: cursors still encode the original rows', async () => {
-    // `resolveNode` mutates `edge.node` after `buildConnectionPage` has built the
-    // cursor getters, which close over the pre-transform row (utils/cursors.ts).
-    // Paginating with the returned `endCursor` proves the mutation left the cursor
-    // encoding intact.
     const page1 = await runQuery(
       '{ decoratedUsers(first: 1) { pageInfo { endCursor hasNextPage } edges { cursor node { userId } } } }',
     );
@@ -1044,10 +1022,6 @@ describe('prismaConnection: end-to-end against real sqlite', () => {
   });
 
   it('prismaConnectionHelpers resolveNode: an absent transform leaves the original row', async () => {
-    // The runtime half of the conditional-transform case. `wrap` only rewrites nodes when
-    // a callback is actually there, so a helper built with `enabled ? fn : undefined` and
-    // `enabled === false` hands back untouched rows. The declared node type is the union of
-    // both outcomes for exactly this reason.
     const builder = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
       plugins: [RelayPlugin, prismaNextPlugin],
       relay: {},

--- a/packages/plugin-prisma-next/tests/connection.test.ts
+++ b/packages/plugin-prisma-next/tests/connection.test.ts
@@ -1043,6 +1043,32 @@ describe('prismaConnection: end-to-end against real sqlite', () => {
     expect(second.decoratedUsers.edges[0]!.node.userId).toBe('u-bob');
   });
 
+  it('prismaConnectionHelpers resolveNode: an absent transform leaves the original row', async () => {
+    // The runtime half of the conditional-transform case. `wrap` only rewrites nodes when
+    // a callback is actually there, so a helper built with `enabled ? fn : undefined` and
+    // `enabled === false` hands back untouched rows. The declared node type is the union of
+    // both outcomes for exactly this reason.
+    const builder = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
+      plugins: [RelayPlugin, prismaNextPlugin],
+      relay: {},
+      prismaNext: { contract: ctx.contract },
+    });
+
+    const off: boolean = false;
+    const helper = prismaConnectionHelpers(builder, 'User', {
+      cursor: 'id',
+      resolveNode: off ? (row) => ({ user: row }) : undefined,
+    });
+
+    const page = await helper.applyPagination(ctx.ormClient.User, { first: 1 }, undefined, {});
+    const node = page.wrap(await page.collection.all()).edges[0]!.node;
+
+    expect('user' in node).toBe(false);
+    if (!('user' in node)) {
+      expect(node.id).toBe('u-alice');
+    }
+  });
+
   it('totalCount rejection does NOT crash queries that did not select totalCount', async () => {
     // Round-3 fix: the count promise is only built when `totalCount`
     // is in the selection set. Without this gate, a `totalCount` that

--- a/packages/plugin-prisma-next/tests/connection.test.ts
+++ b/packages/plugin-prisma-next/tests/connection.test.ts
@@ -149,6 +149,29 @@ function buildSchema() {
     resolveNode: (edge) => ({ id: edge.id, name: edge.firstName }),
   });
 
+  // Helper with a *wrapper*-shaped `resolveNode` — the documented shape
+  // (docs/connections.mdx) where the node is an object holding the row plus
+  // metadata, so none of the row's own columns are reachable on the node.
+  // `namesOnly` above cannot catch a lost node shape because its result happens
+  // to keep an `id` of its own.
+  const decoratedUsers = prismaConnectionHelpers(builder, 'User', {
+    cursor: 'id',
+    defaultSize: 10,
+    resolveNode: (row) => ({ user: row, decoratedAt: 'decorated' }),
+  });
+
+  const DecoratedUser = builder
+    .objectRef<{ user: { id: string; firstName: string }; decoratedAt: string }>('DecoratedUser')
+    .implement({
+      fields: (t) => ({
+        // Read *through* the wrapper. If `wrap` handed back the untransformed
+        // row, `parent.user` would be undefined and these would throw.
+        userId: t.string({ resolve: (parent) => parent.user.id }),
+        firstName: t.string({ resolve: (parent) => parent.user.firstName }),
+        decoratedAt: t.exposeString('decoratedAt'),
+      }),
+    });
+
   // Thunk form for `args` — closes over the InputFieldBuilder lazily.
   const userSearchThunkArgs = prismaConnectionHelpers(builder, 'User', {
     cursor: 'id',
@@ -230,6 +253,33 @@ function buildSchema() {
           );
           const rows = await collection.all();
           return wrap(rows) as never;
+        },
+      }),
+      // Wrapper-shaped `resolveNode` end-to-end: the GraphQL node type reads
+      // through the wrapper, so this field only resolves if `wrap` really did
+      // replace each `edge.node`.
+      //
+      // Note the missing `as never` on the `wrap` call below — the only helper
+      // call site in this file without one. Now that the node shape is inferred
+      // from `resolveNode`, `wrap`'s result checks structurally against the
+      // `DecoratedUser` node this connection declares. Before, it was typed as
+      // the User row and could only be forced through with a cast.
+      decoratedUsers: t.connection({
+        type: DecoratedUser,
+        args: decoratedUsers.getArgs(),
+        resolve: async (_p, args, _ctx) => {
+          // `info` is deliberately withheld: the auto-include mapper descends into
+          // `edges.node` and requires that type to be prisma-backed, which a
+          // wrapper node is not. Without it the collection materializes the full
+          // row, which is what the wrapper holds anyway.
+          const { collection, wrap } = await decoratedUsers.applyPagination(
+            ctx.ormClient.User,
+            args,
+            undefined,
+            _ctx,
+          );
+          const rows = await collection.all();
+          return wrap(rows);
         },
       }),
       // Helper-with-callable-totalCount — exercises the callback path
@@ -930,6 +980,67 @@ describe('prismaConnection: end-to-end against real sqlite', () => {
       expect(edge.cursor).toBeTruthy();
       expect(edge.node.id).toBeTruthy();
     }
+  });
+
+  it('prismaConnectionHelpers resolveNode: a wrapper node resolves through the wrapper', async () => {
+    // `resolveNode: (row) => ({ user: row, decoratedAt })` — none of the row's own
+    // columns survive on the node, so every field here has to reach through
+    // `parent.user`. This is the shape `namesOnly` cannot exercise.
+    const result = await runQuery(
+      '{ decoratedUsers(first: 10) { edges { cursor node { userId firstName decoratedAt } } } }',
+    );
+    expect(result.errors).toBeUndefined();
+    const data = result.data as {
+      decoratedUsers: {
+        edges: Array<{
+          cursor: string;
+          node: { userId: string; firstName: string; decoratedAt: string };
+        }>;
+      };
+    };
+
+    expect(data.decoratedUsers.edges).toHaveLength(2);
+    expect(data.decoratedUsers.edges.map((edge) => edge.node.userId)).toEqual(['u-alice', 'u-bob']);
+    for (const edge of data.decoratedUsers.edges) {
+      // The defect this guards: before the node shape was inferred, a caller could
+      // read `node.id` as a `string` and get `undefined`.
+      expect(edge.node.userId).toBeTruthy();
+      expect(edge.node.firstName).toBeTruthy();
+      expect(edge.node.decoratedAt).toBe('decorated');
+    }
+  });
+
+  it('prismaConnectionHelpers resolveNode: cursors still encode the original rows', async () => {
+    // `resolveNode` mutates `edge.node` after `buildConnectionPage` has built the
+    // cursor getters, which close over the pre-transform row (utils/cursors.ts).
+    // Paginating with the returned `endCursor` proves the mutation left the cursor
+    // encoding intact.
+    const page1 = await runQuery(
+      '{ decoratedUsers(first: 1) { pageInfo { endCursor hasNextPage } edges { cursor node { userId } } } }',
+    );
+    expect(page1.errors).toBeUndefined();
+    const first = page1.data as {
+      decoratedUsers: {
+        pageInfo: { endCursor: string; hasNextPage: boolean };
+        edges: Array<{ cursor: string; node: { userId: string } }>;
+      };
+    };
+
+    expect(first.decoratedUsers.edges).toHaveLength(1);
+    expect(first.decoratedUsers.edges[0]!.node.userId).toBe('u-alice');
+    expect(first.decoratedUsers.edges[0]!.cursor).toBeTruthy();
+    expect(first.decoratedUsers.edges[0]!.cursor).toBe(first.decoratedUsers.pageInfo.endCursor);
+    expect(first.decoratedUsers.pageInfo.hasNextPage).toBe(true);
+
+    const page2 = await runQuery(
+      `{ decoratedUsers(first: 1, after: "${first.decoratedUsers.pageInfo.endCursor}") { edges { node { userId } } } }`,
+    );
+    expect(page2.errors).toBeUndefined();
+    const second = page2.data as {
+      decoratedUsers: { edges: Array<{ node: { userId: string } }> };
+    };
+    expect(second.decoratedUsers.edges).toHaveLength(1);
+    expect(second.decoratedUsers.edges[0]!.node.userId).toBe('u-bob');
   });
 
   it('totalCount rejection does NOT crash queries that did not select totalCount', async () => {

--- a/packages/plugin-prisma-next/tests/connection.test.ts
+++ b/packages/plugin-prisma-next/tests/connection.test.ts
@@ -149,8 +149,6 @@ function buildSchema() {
     resolveNode: (edge) => ({ id: edge.id, name: edge.firstName }),
   });
 
-  // Wrapper-shaped `resolveNode` — the node is an object holding the row plus
-  // metadata, so none of the row's own columns are reachable on it.
   const decoratedUsers = prismaConnectionHelpers(builder, 'User', {
     cursor: 'id',
     defaultSize: 10,
@@ -250,15 +248,12 @@ function buildSchema() {
           return wrap(rows) as never;
         },
       }),
-      // Wrapper-shaped `resolveNode` end-to-end — the GraphQL node type reads
-      // through the wrapper.
       decoratedUsers: t.connection({
         type: DecoratedUser,
         args: decoratedUsers.getArgs(),
         resolve: async (_p, args, _ctx) => {
-          // `info` is deliberately withheld: the auto-include mapper descends into
-          // `edges.node` and requires that type to be prisma-backed, which a
-          // wrapper node is not.
+          // `info` withheld: the auto-include mapper descends into `edges.node` and
+          // requires that type to be prisma-backed.
           const { collection, wrap } = await decoratedUsers.applyPagination(
             ctx.ormClient.User,
             args,


### PR DESCRIPTION
## The bug

`prismaConnectionHelpers` accepts a `resolveNode` callback that replaces every `edge.node`, but the declared return type never learned about it. `wrap` still returned `ConnectionPage<WrapRow>` where `WrapRow` is inferred from the array passed in, so the node type described the *pre-transform* row.

The documented wrapper form (`packages/plugin-prisma-next/docs/connections.mdx:232-246`) is:

```ts
prismaConnectionHelpers(builder, 'Post', {
  cursor: 'id',
  resolveNode: (row) => ({ post: row, decoratedAt: new Date() }),
});
```

With that helper, `result.edges[0].node.id` typed as `string` while the runtime value was `undefined` — and strict `tsc` accepted it silently. Three declarations were involved: the `=> unknown` return at `connection-helpers.ts:115` discarded the callback's type, `wrap<WrapRow>` (`:60-63`, `:214-217`) inferred the node solely from `rows`, and the exported `PrismaConnectionHelpers` interface (`:38-42`) had no parameter in which a node shape could be carried.

## The fix

Infer `resolveNode`'s return type as a `Node` generic and resolve it at `wrap`:

```ts
resolveNode?: (edge: Row<Types, M>) => Node;              // was `=> unknown`
// PrismaConnectionHelpers<Types, M, Args, Node = never, MaybeAbsent = false>
wrap<WrapRow extends ConnectionWrapRows<Types, M, Node>>(
  rows: readonly WrapRow[], totalCount?: number,
): ConnectionPage<ConnectionNodeShape<Node, WrapRow, MaybeAbsent>>;  // was ConnectionPage<WrapRow>
```

`Node` is a **defaulted fourth type parameter**, so existing `PrismaConnectionHelpers<Types, M, Args>` references keep compiling. It defaults to `never` rather than to `Row<Types, M>`: defaulting to the full row would override a caller's narrowed `WrapRow` on every helper that has no `resolveNode`. `[Node] extends [never]` is the naked-`never` guard — a bare `Node extends never` distributes and collapses to `never`.

There are three cases, and the middle one is easy to miss:

| helper | node |
| --- | --- |
| no `resolveNode` | `WrapRow` — whatever the caller passed to `wrap` |
| `resolveNode` that **may be absent** (`enabled ? fn : undefined`) | `Node \| WrapRow` — the caller must narrow |
| `resolveNode` always present | `Node` |

This mirrors how `@pothos/plugin-prisma` carries `NodeShape` (`packages/plugin-prisma/src/connection-helpers.ts:47,92,123`), but **only for the node half**. That helper's row half is a factory generic driven by a `select` option prisma-next does not have; prisma-next's row shape is only known when `wrap` is called, so the row generic stays on the method.

### `wrap` now requires the full row when a `resolveNode` is configured

Inferring `Node` from the callback's return type is only truthful if the callback's *parameter* annotation is truthful. `resolveNode` is supplied when the helper is built, so its parameter can only be annotated `Row<Types, M>` — but at runtime it receives whatever the caller handed `wrap`. Without a constraint, any callback mentioning its parameter launders the full-row annotation into the declared node type:

```ts
const h = prismaConnectionHelpers(builder, 'User', {
  cursor: 'id',
  resolveNode: (row) => ({ ...row, extra: 1 }),
});
page.wrap([{ id: 'a', firstName: 'Alice' }]).edges[0]!.node.email;
// would compile as `string`; `undefined` at runtime
```

That is the same "strict `tsc` accepts it while the value is `undefined`" failure this PR exists to remove, so `ConnectionWrapRows` constrains `wrap`'s rows to `Row<Types, M>` whenever a `resolveNode` is present — enforcing the precondition the parameter annotation already claims. Narrowed rows are rejected **at the `wrap` call**, naming the missing columns, rather than silently producing a node with columns the query never loaded:

```
Argument of type '{ id: string; firstName: string; }[]' is not assignable to parameter of
type 'readonly Row<..., "User">[]'.
  Type '{ id: string; firstName: string; }' is missing the following properties from
  type 'Row<..., "User">': email, lastName
```

Helpers **without** a `resolveNode` stay unconstrained exactly as before, so narrowing the selection remains available on that path — which is the case `Node = never` exists to protect.

Measured on both revisions, with `tsbuildinfo` deleted between measurements. Rows are `wrap([{ id, firstName }])`:

| `resolveNode` | `origin/main` | first revision of this PR | now |
|---|---|---|---|
| `(row) => ({ ...row, extra: 1 })` | `{ id, firstName }` — `.email` is TS2339 | `{ extra, email, firstName, id, lastName }` — **`.email` compiled** | rejected at `wrap`: missing `email`, `lastName` |
| `(row) => row` | `{ id, firstName }` — **correct** | `Row<Types,'User'>` — over-promised | rejected at `wrap`: missing `email`, `lastName` |
| `(row) => ({ user: row, at: 'x' })` (documented form) | `.user` is TS2339 | `node.user.email` compiled as `string` | rejected at `wrap`: missing `email`, `lastName` |
| control: `wrap(await collection.all())` | works | works | works — node type is true, because the callback really did receive the full row |

All four rows are pinned as fixtures in `narrowedRowsRejected`.

### A `resolveNode` that may never run

`Node` is read off the callback's return type, and a `fn | undefined` union still yields the function's return type — so a conditionally supplied transform declared a node the transform might never produce. `wrap` only rewrites nodes inside `if (options.resolveNode)`, so when the callback is absent the original row comes back untouched:

```ts
const h = prismaConnectionHelpers(builder, 'User', {
  cursor: 'id',
  resolveNode: enabled ? (row) => ({ user: row }) : undefined,
});
page.wrap(rows).edges[0]!.node.user.id;   // compiled; threw when `enabled` was false
```

Verified both halves before fixing: `tsc` inferred `{ user: Row }`, and a runtime probe with `enabled` false found `node.user` undefined and `node.id` equal to the seeded `u-alice`.

The factory is now split into **two overloads** so a definitely-present callback can be told apart from one that may be absent, and that distinction is carried into the helper type as a `MaybeAbsent` flag. A possibly-absent callback yields `Node | WrapRow` — exactly what `wrap` produces — and the caller narrows:

```ts
if ('user' in node) { node.user.id } else { node.id }
```

**Why permissive rather than rejecting possibly-undefined transforms.** `Node | WrapRow` describes both runtime outcomes precisely and is checkable. Rejection cannot be expressed here: detecting "possibly undefined" requires capturing the callback's *type* rather than its return type, and testing it needs a deferred conditional at the inference site, which stops the whole options object from inferring. The narrowed-rows constraint earlier in this PR could be enforced precisely, so it was; this one cannot be, so the type describes reality instead of approximating it. In both cases the choice is whatever yields a precise, checkable type.

**What a caller writing `enabled ? fn : undefined` should do instead.** Branch *inside* the callback, where the branch is visible to inference:

```ts
resolveNode: (row) => (enabled ? { user: row } : row)
```

That produces the same `{ user: Row } | Row` union honestly, and reads as what it is. Conditionally supplying the callback hides the branch from the type system; branching inside it does not. Callers who want a single non-union node type must make the callback unconditional.

Overloads are also what restores contextual typing. With the callback captured as a bare generic, TypeScript fixes that parameter to its default before checking a context-sensitive arrow, so `row` degrades to an implicit `any` and every existing `resolveNode` breaks. The overloads keep the parameter concretely typed as `Row<Types, M>` in both signatures.

### The obstacle, stated

Tying `resolveNode`'s parameter to the row shape `wrap` infers — the ideal fix — is **not expressible in TypeScript**. The callback is captured at factory time; `WrapRow` is only known per `wrap` call. Expressing the node as a type function of `WrapRow` (`Node<WrapRow>`) requires higher-kinded types, which TS does not have, and a generic contextual signature does not make TS infer a generic arrow — it instantiates the parameter at its constraint. The only shape that achieves it is moving `resolveNode` onto `wrap` (option D in the design note), which captures both shapes at one call site but is a breaking API change to every `resolveNode` caller and moves per-helper config into a per-resolve hot path. Not justified for a type-only defect, so this PR enforces the annotation instead of deferring it. If a breaking change to this helper is ever taken for other reasons, option D is the shape to land on.

## No runtime change

`buildConnectionPage` builds each edge's `cursor` as a memoized getter closing over the `map` parameter (`src/utils/cursors.ts:429,436`), **not** over `edge.node`, so the in-place mutation at `:221-224` cannot corrupt cursors. The transform's position after `buildConnectionPage` is load-bearing and is untouched here.

## Verification

**Type coverage was previously zero** — neither `tests/connection-types.test-d.ts` nor `tests/helper-types.test-d.ts` mentioned `prismaConnectionHelpers`, which is how the gap survived. Fixtures added to `tests/connection-types.test-d.ts` (inside `tsconfig.type.json`'s `include`).

Before the fix, the new fixture failed in exactly the shape that proves the bug:

```
tests/connection-types.test-d.ts(55,3): error TS2578: Unused '@ts-expect-error' directive.
tests/connection-types.test-d.ts(58,38): error TS2339: Property 'user' does not exist on type 'DefaultModelRow<Contract, "User", "__unbound__">'.
tests/connection-types.test-d.ts(74,38): error TS2339: Property 'kind' does not exist on type 'DefaultModelRow<Contract, "User", "__unbound__">'.
```

The `TS2578` is the defect itself: `node.id` compiled against a wrapper node. After the fix, all type projects pass and every `@ts-expect-error` is doing real work.

- **No-`resolveNode` path is provably unchanged.** Pinned with an exact whole-type equality, not just a member check: `expectTypeOf(page.wrap([{ id: 'a', firstName: 'Alice' }])).toEqualTypeOf<ConnectionPage<{ id: string; firstName: string }>>()`. This fixture passes identically before and after.
- **Union return probe.** The design note left open whether `Node` inference survives a union. It does: a `resolveNode` returning `{ kind: 'user', ... } | { kind: 'empty' }` keeps both members and does not collapse back to the row.
- **Other return shapes pinned.** A primitive return (`(row) => row.firstName` → `string`), `null`, and a `Promise` return all infer unchanged.
- **Conditional transform, both halves.** A type fixture pins that `node.user` is rejected without narrowing and that both narrowed branches are reachable; a runtime test builds a helper with `enabled === false` and asserts the node is the untouched row (`node.id === 'u-alice'`, no `user` key).
- **Runtime proof.** A new `decoratedUsers` connection uses a genuine wrapper node (`{ user: row, decoratedAt }`) whose GraphQL type reads every field *through* `parent.user`, so it only resolves if `wrap` really replaced each node. The existing `namesOnly` case cannot catch this — its result happens to keep an `id` of its own.
- **Cursor regression.** Asserts each `edge.cursor` is non-empty and equals `pageInfo.endCursor`, then paginates with that cursor and gets the next row — proving the cursor closure still encodes original rows after the mutation.
- **The cast disappears.** `decoratedUsers`' resolver is the only helper call site in the file without `as never`; the inferred node shape now checks structurally against the declared `DecoratedUser` node type. Verified it is real checking, not looseness: changing `decoratedAt` to a number produces a `TS2322` naming the exact node mismatch.

### Results

| Check | Result |
| --- | --- |
| `pnpm --filter @pothos/plugin-prisma-next test` | 373 passed / 13 skipped |
| non-Postgres suite, this branch vs. `origin/main` | 373 vs. 370 — exactly the 3 added tests, no regressions |
| `pnpm --filter @pothos/plugin-prisma-next type` | both `tsconfig.type.json` and `tsconfig.scope-auth.json` clean |
| `pnpm biome check packages/plugin-prisma-next` | clean |
| `pnpm build` | clean |

`tests/postgres-runtime.test.ts` fails with `ECONNREFUSED 127.0.0.1:5456` in this environment and does so on unmodified `main` — environmental, unrelated to this change. All verification here runs on SQLite.

## Known follow-ups (deliberately not fixed here)

1. **`wrap`'s return type omits `totalCount`.** The implementation writes it via a cast (`connection-helpers.ts:227-229`) while `ConnectionPage` (`utils/cursors.ts:404-407`) declares only `edges`/`pageInfo`. This is a second hole in the same return type, and part of why in-repo call sites write `wrap(rows, total) as never`.
2. **A wrapper node cannot be combined with `info`.** Surfaced while writing the runtime test: `applyPagination` passes `paths: [['edges','node']]` to the auto-include mapper, which requires that node type to be prisma-backed and otherwise throws `Expected DecoratedUser to have a model` (`packages/selection-mapper/src/plan.ts:211`). Callers using a genuine wrapper shape must withhold `info` today, losing auto-include. There is no opt-out, since `paths` is hard-coded in the helper.

The previously-listed follow-up about `resolveNode`'s parameter being "sound only by accident" is **closed** by the `ConnectionWrapRows` constraint above: the annotation is now enforced rather than assumed.

## Scope

`src/global-types.ts` is untouched (the cross-file helper parent `Shape` decision is being implemented separately). `src/types.ts` and `docs/` are untouched, so this does not conflict with #1764. Changeset is **patch** — it corrects a type that never matched runtime, and the package is private and staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
