### PR TITLE
fix(prisma): await async node ID resolvers before fallback lookups

### DIFF
--- a/.changeset/brave-melons-invite.md
+++ b/.changeset/brave-melons-invite.md
@@ -1,0 +1,12 @@
+---
+'@pothos/plugin-prisma': minor
+---
+
+Await async node ID resolvers before building a custom `findUnique`'s where.
+
+`prismaNode`'s `id.resolve` is typed `MaybePromise`, but the fallback lookup handed its return
+value straight to a custom `findUnique`. An async resolver meant the callback received a promise
+where its own type promised a string, so `findUnique: (id) => ({ id: Number(id) })` built
+`where: { id: NaN }` and the row failed to load. The model loader now waits for the where before
+issuing the lookup, guarded so a synchronous resolver still issues its query in the same
+microtask and batching is unchanged. A `findUnique` of your own may now return a promise.

--- a/.changeset/brave-melons-invite.md
+++ b/.changeset/brave-melons-invite.md
@@ -9,4 +9,5 @@ value straight to a custom `findUnique`. An async resolver meant the callback re
 where its own type promised a string, so `findUnique: (id) => ({ id: Number(id) })` built
 `where: { id: NaN }` and the row failed to load. The model loader now waits for the where before
 issuing the lookup, guarded so a synchronous resolver still issues its query in the same
-microtask and batching is unchanged. A `findUnique` of your own may now return a promise.
+microtask and batching is unchanged. A where that rejects fails only its own row; the rest of the
+batch loads. A `findUnique` of your own may now return a promise.

--- a/packages/plugin-prisma/src/model-loader.ts
+++ b/packages/plugin-prisma/src/model-loader.ts
@@ -24,8 +24,6 @@ export class ModelLoader {
 
   builder: PothosSchemaTypes.SchemaBuilder<never>;
 
-  // `MaybePromise` because a node's `id.resolve` may be async and the user's `findUnique` builds
-  // the where from the ID it settles to. The flush loop below waits for it, and only for it.
   findUnique: (model: Record<string, unknown>, ctx: {}) => MaybePromise<unknown>;
 
   modelName: string;
@@ -342,21 +340,15 @@ export class ModelLoader {
       // request with it. The whole batch rejects instead, the way drizzle's loader does; a promise
       // the loop already settled ignores it. Caught rather than chained so the tick still
       // allocates no promise of its own. A failure that surfaces after the loop has finished takes
-      // only the row it belongs to — see the async branch below.
+      // only the row it belongs to.
       try {
         for (const [model, { resolve, reject }] of entry.models) {
           const where = this.findUnique(model as Record<string, unknown>, this.context);
 
-          // A where built from an async `id.resolve` settles a microtask or more later, and
-          // spreading the promise itself would make an unfiltered lookup. Only that row waits:
-          // batch membership was sealed at `stageQuery`, before this loop ran, so nothing here
-          // moves a boundary. A synchronous where never leaves this tick.
+          // A where built from an async `id.resolve` settles later, and spreading the promise
+          // itself would make an unfiltered lookup. A synchronous where never leaves this tick.
           if (isThenable(where)) {
             where.then((settled) => {
-              // Only this row. The loop has run to its end by the time any continuation of it
-              // does, so every model already holds a handler and none of them can be stranded:
-              // the reason the synchronous path rejects the whole batch does not apply here, and
-              // failing a sibling whose own where settled would be failing a row that was fine.
               try {
                 load(settled as {}).then(resolve as () => {}, reject);
               } catch (error) {

--- a/packages/plugin-prisma/src/model-loader.ts
+++ b/packages/plugin-prisma/src/model-loader.ts
@@ -337,11 +337,12 @@ export class ModelLoader {
               where: { ...where },
             } as never);
 
-      // A throw here — `toQuery`, `findUnique`, or the delegate call itself — would otherwise abort
-      // the loop, leaving every model it had not reached pending forever and the request with it.
-      // The whole batch rejects instead, the way drizzle's loader does; a promise the loop already
-      // settled ignores it. Caught rather than chained so the tick still allocates no promise of
-      // its own.
+      // A synchronous throw here — `toQuery`, `findUnique`, or the delegate call itself — would
+      // otherwise abort the loop, leaving every model it had not reached pending forever and the
+      // request with it. The whole batch rejects instead, the way drizzle's loader does; a promise
+      // the loop already settled ignores it. Caught rather than chained so the tick still
+      // allocates no promise of its own. A failure that surfaces after the loop has finished takes
+      // only the row it belongs to — see the async branch below.
       try {
         for (const [model, { resolve, reject }] of entry.models) {
           const where = this.findUnique(model as Record<string, unknown>, this.context);
@@ -352,15 +353,16 @@ export class ModelLoader {
           // moves a boundary. A synchronous where never leaves this tick.
           if (isThenable(where)) {
             where.then((settled) => {
-              // The same containment across the await: a rejected where, or a throw from the
-              // delegate call it was waiting for, takes the whole batch rather than escaping and
-              // stranding every model the loop had already reached.
+              // Only this row. The loop has run to its end by the time any continuation of it
+              // does, so every model already holds a handler and none of them can be stranded:
+              // the reason the synchronous path rejects the whole batch does not apply here, and
+              // failing a sibling whose own where settled would be failing a row that was fine.
               try {
                 load(settled as {}).then(resolve as () => {}, reject);
               } catch (error) {
-                rejectBatch(error);
+                reject(error);
               }
-            }, rejectBatch);
+            }, reject);
           } else {
             load(where as {}).then(resolve as () => {}, reject);
           }

--- a/packages/plugin-prisma/src/model-loader.ts
+++ b/packages/plugin-prisma/src/model-loader.ts
@@ -335,18 +335,10 @@ export class ModelLoader {
               where: { ...where },
             } as never);
 
-      // A synchronous throw here — `toQuery`, `findUnique`, or the delegate call itself — would
-      // otherwise abort the loop, leaving every model it had not reached pending forever and the
-      // request with it. The whole batch rejects instead, the way drizzle's loader does; a promise
-      // the loop already settled ignores it. Caught rather than chained so the tick still
-      // allocates no promise of its own. A failure that surfaces after the loop has finished takes
-      // only the row it belongs to.
       try {
         for (const [model, { resolve, reject }] of entry.models) {
           const where = this.findUnique(model as Record<string, unknown>, this.context);
 
-          // A where built from an async `id.resolve` settles later, and spreading the promise
-          // itself would make an unfiltered lookup. A synchronous where never leaves this tick.
           if (isThenable(where)) {
             where.then((settled) => {
               try {

--- a/packages/plugin-prisma/src/model-loader.ts
+++ b/packages/plugin-prisma/src/model-loader.ts
@@ -24,7 +24,9 @@ export class ModelLoader {
 
   builder: PothosSchemaTypes.SchemaBuilder<never>;
 
-  findUnique: (model: Record<string, unknown>, ctx: {}) => unknown;
+  // `MaybePromise` because a node's `id.resolve` may be async and the user's `findUnique` builds
+  // the where from the ID it settles to. The flush loop below waits for it, and only for it.
+  findUnique: (model: Record<string, unknown>, ctx: {}) => MaybePromise<unknown>;
 
   modelName: string;
 
@@ -45,7 +47,7 @@ export class ModelLoader {
     context: object,
     builder: PothosSchemaTypes.SchemaBuilder<never>,
     modelName: string,
-    findUnique: (model: Record<string, unknown>, ctx: {}) => unknown,
+    findUnique: (model: Record<string, unknown>, ctx: {}) => MaybePromise<unknown>,
   ) {
     this.context = context;
     this.builder = builder;
@@ -56,7 +58,10 @@ export class ModelLoader {
   static forRef<Types extends SchemaTypes>(
     ref: InterfaceRef<Types, unknown> | ObjectRef<Types, unknown>,
     modelName: string,
-    findUnique: ((model: Record<string, unknown>, ctx: {}) => unknown) | null | undefined,
+    findUnique:
+      | ((model: Record<string, unknown>, ctx: {}) => MaybePromise<unknown>)
+      | null
+      | undefined,
     builder: PothosSchemaTypes.SchemaBuilder<Types>,
   ) {
     return createContextCache(
@@ -314,6 +319,24 @@ export class ModelLoader {
     this.tick.then(() => {
       this.staged.delete(entry);
 
+      const rejectBatch = (error: unknown) => {
+        for (const { reject } of entry.models.values()) {
+          reject(error);
+        }
+      };
+
+      const load = (where: {}) =>
+        delegate.findUniqueOrThrow
+          ? delegate.findUniqueOrThrow({
+              ...prismaAdapter.toQuery(entry.root),
+              where: { ...where },
+            } as never)
+          : delegate.findUnique({
+              rejectOnNotFound: true,
+              ...prismaAdapter.toQuery(entry.root),
+              where: { ...where },
+            } as never);
+
       // A throw here — `toQuery`, `findUnique`, or the delegate call itself — would otherwise abort
       // the loop, leaving every model it had not reached pending forever and the request with it.
       // The whole batch rejects instead, the way drizzle's loader does; a promise the loop already
@@ -321,31 +344,29 @@ export class ModelLoader {
       // its own.
       try {
         for (const [model, { resolve, reject }] of entry.models) {
-          if (delegate.findUniqueOrThrow) {
-            delegate
-              .findUniqueOrThrow({
-                ...prismaAdapter.toQuery(entry.root),
-                where: {
-                  ...(this.findUnique(model as Record<string, unknown>, this.context) as {}),
-                },
-              } as never)
-              .then(resolve as () => {}, reject);
+          const where = this.findUnique(model as Record<string, unknown>, this.context);
+
+          // A where built from an async `id.resolve` settles a microtask or more later, and
+          // spreading the promise itself would make an unfiltered lookup. Only that row waits:
+          // batch membership was sealed at `stageQuery`, before this loop ran, so nothing here
+          // moves a boundary. A synchronous where never leaves this tick.
+          if (isThenable(where)) {
+            where.then((settled) => {
+              // The same containment across the await: a rejected where, or a throw from the
+              // delegate call it was waiting for, takes the whole batch rather than escaping and
+              // stranding every model the loop had already reached.
+              try {
+                load(settled as {}).then(resolve as () => {}, reject);
+              } catch (error) {
+                rejectBatch(error);
+              }
+            }, rejectBatch);
           } else {
-            delegate
-              .findUnique({
-                rejectOnNotFound: true,
-                ...prismaAdapter.toQuery(entry.root),
-                where: {
-                  ...(this.findUnique(model as Record<string, unknown>, this.context) as {}),
-                },
-              } as never)
-              .then(resolve as () => {}, reject);
+            load(where as {}).then(resolve as () => {}, reject);
           }
         }
       } catch (error) {
-        for (const { reject } of entry.models.values()) {
-          reject(error);
-        }
+        rejectBatch(error);
       }
     });
     setTimeout(() => nextTick.resolve(), 0);

--- a/packages/plugin-prisma/src/schema-builder.ts
+++ b/packages/plugin-prisma/src/schema-builder.ts
@@ -116,9 +116,8 @@ schemaBuilderProto.prismaNode = function prismaNode(
   const idParser = fieldName ? getDefaultIDParser(type, fieldName, this) : undefined;
   const typeName = variant ?? name ?? type;
   const nodeRef = new PrismaNodeRef(typeName, type);
-  // The ID `resolve` settles to is what the user's `findUnique` builds its where from, so an async
-  // resolver has to be awaited before the callback is called — its own type promises a string.
-  // The model loader waits on the promise this returns; a synchronous resolver never makes one.
+  // `rawFindUnique` is typed to take a string, so an async `id.resolve` is awaited before the
+  // callback is called; a synchronous resolver never makes a promise.
   const findUnique = rawFindUnique
     ? (parent: unknown, context: {}) => {
         const id = resolve(parent as never, context);
@@ -138,7 +137,6 @@ schemaBuilderProto.prismaNode = function prismaNode(
 
   const ref = this.prismaObject(type, extendedOptions as never);
 
-  // Built once per node type, not per lookup: the query the where is known for.
   const loadWhere = (delegate: PrismaDelegate, query: object, where: {}) =>
     (delegate.findUniqueOrThrow && !nullable
       ? delegate.findUniqueOrThrow({ ...query, where } as never)
@@ -153,8 +151,8 @@ schemaBuilderProto.prismaNode = function prismaNode(
       return record;
     });
 
-  // Loading with a synchronous plan and a synchronous where issues the query in the same tick,
-  // without a promise of its own; only a where the user's `findUnique` settles later waits.
+  // Built once per node type: loading with a synchronous plan and a synchronous where issues the
+  // query in the same tick, without a promise of its own; a where that settles later waits.
   const loadNode = (query: object, id: string, context: SchemaTypes['Context']) => {
     const delegate = getDelegateFromModel(getClient(this, context), type);
     const where = rawFindUnique ? rawFindUnique(id, context) : { [fieldName]: idParser!(id) };

--- a/packages/plugin-prisma/src/schema-builder.ts
+++ b/packages/plugin-prisma/src/schema-builder.ts
@@ -116,8 +116,6 @@ schemaBuilderProto.prismaNode = function prismaNode(
   const idParser = fieldName ? getDefaultIDParser(type, fieldName, this) : undefined;
   const typeName = variant ?? name ?? type;
   const nodeRef = new PrismaNodeRef(typeName, type);
-  // `rawFindUnique` is typed to take a string, so an async `id.resolve` is awaited before the
-  // callback is called; a synchronous resolver never makes a promise.
   const findUnique = rawFindUnique
     ? (parent: unknown, context: {}) => {
         const id = resolve(parent as never, context);
@@ -151,8 +149,6 @@ schemaBuilderProto.prismaNode = function prismaNode(
       return record;
     });
 
-  // Built once per node type: loading with a synchronous plan and a synchronous where issues the
-  // query in the same tick, without a promise of its own; a where that settles later waits.
   const loadNode = (query: object, id: string, context: SchemaTypes['Context']) => {
     const delegate = getDelegateFromModel(getClient(this, context), type);
     const where = rawFindUnique ? rawFindUnique(id, context) : { [fieldName]: idParser!(id) };

--- a/packages/plugin-prisma/src/schema-builder.ts
+++ b/packages/plugin-prisma/src/schema-builder.ts
@@ -12,7 +12,7 @@ import { ModelLoader } from './model-loader.js';
 import { PrismaNodeRef } from './node-ref.js';
 import { PrismaObjectRef } from './object-ref.js';
 import { PrismaObjectFieldBuilder } from './prisma-field-builder.js';
-import type { PrismaModelTypes, PrismaNodeOptions } from './types.js';
+import type { PrismaDelegate, PrismaModelTypes, PrismaNodeOptions } from './types.js';
 import { getDefaultIDParser, getDefaultIDSerializer } from './util/cursors.js';
 import { getDelegateFromModel, getRefFromModel } from './util/datamodel.js';
 import { getModelDescription } from './util/description.js';
@@ -116,9 +116,17 @@ schemaBuilderProto.prismaNode = function prismaNode(
   const idParser = fieldName ? getDefaultIDParser(type, fieldName, this) : undefined;
   const typeName = variant ?? name ?? type;
   const nodeRef = new PrismaNodeRef(typeName, type);
+  // The ID `resolve` settles to is what the user's `findUnique` builds its where from, so an async
+  // resolver has to be awaited before the callback is called — its own type promises a string.
+  // The model loader waits on the promise this returns; a synchronous resolver never makes one.
   const findUnique = rawFindUnique
-    ? (parent: unknown, context: {}) =>
-        rawFindUnique(resolve(parent as never, context) as string, context)
+    ? (parent: unknown, context: {}) => {
+        const id = resolve(parent as never, context);
+
+        return isThenable(id)
+          ? id.then((settled) => rawFindUnique(settled as string, context))
+          : rawFindUnique(id as string, context);
+      }
     : ModelLoader.getFindUniqueForField(nodeRef, type, fieldName, this);
 
   const extendedOptions = {
@@ -130,25 +138,30 @@ schemaBuilderProto.prismaNode = function prismaNode(
 
   const ref = this.prismaObject(type, extendedOptions as never);
 
-  // Built once per node type: loading with a synchronous plan issues the query in the same tick,
-  // without a promise or closure of its own.
-  const loadNode = (query: object, id: string, context: SchemaTypes['Context']) => {
-    const delegate = getDelegateFromModel(getClient(this, context), type);
-    const where = rawFindUnique ? rawFindUnique(id, context) : { [fieldName]: idParser!(id) };
-
-    return (
-      delegate.findUniqueOrThrow && !nullable
-        ? delegate.findUniqueOrThrow({ ...query, where } as never)
-        : delegate.findUnique({
-            ...query,
-            ...(nullable ? {} : { rejectOnNotFound: true }),
-            where,
-          } as never)
+  // Built once per node type, not per lookup: the query the where is known for.
+  const loadWhere = (delegate: PrismaDelegate, query: object, where: {}) =>
+    (delegate.findUniqueOrThrow && !nullable
+      ? delegate.findUniqueOrThrow({ ...query, where } as never)
+      : delegate.findUnique({
+          ...query,
+          ...(nullable ? {} : { rejectOnNotFound: true }),
+          where,
+        } as never)
     ).then((record: unknown) => {
       brandWithType(record, typeName as OutputType<SchemaTypes>);
 
       return record;
     });
+
+  // Loading with a synchronous plan and a synchronous where issues the query in the same tick,
+  // without a promise of its own; only a where the user's `findUnique` settles later waits.
+  const loadNode = (query: object, id: string, context: SchemaTypes['Context']) => {
+    const delegate = getDelegateFromModel(getClient(this, context), type);
+    const where = rawFindUnique ? rawFindUnique(id, context) : { [fieldName]: idParser!(id) };
+
+    return isThenable(where)
+      ? where.then((settled) => loadWhere(delegate, query, settled as {}))
+      : loadWhere(delegate, query, where as {});
   };
 
   (this as typeof this & { nodeRef: (ref: unknown, options: unknown) => unknown }).nodeRef(ref, {

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -427,12 +427,14 @@ export type PrismaNodeOptions<
     | PothosSchemaTypes.ObjectTypeWithInterfaceOptions<Types, Shape, Interfaces>,
     'fields' | 'isTypeOf'
   > &
+  // The where may settle later: `id.resolve` below is itself a `MaybePromise`, and a callback
+  // built from the ID it settles to is as async as the resolver that produced it.
   (UniqueField extends string
     ? {
-        findUnique?: (id: string, context: Types['Context']) => Model['WhereUnique'];
+        findUnique?: (id: string, context: Types['Context']) => MaybePromise<Model['WhereUnique']>;
       }
     : {
-        findUnique: (id: string, context: Types['Context']) => Model['WhereUnique'];
+        findUnique: (id: string, context: Types['Context']) => MaybePromise<Model['WhereUnique']>;
       }) & {
     id: Omit<
       FieldOptionsFromKind<

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -427,8 +427,7 @@ export type PrismaNodeOptions<
     | PothosSchemaTypes.ObjectTypeWithInterfaceOptions<Types, Shape, Interfaces>,
     'fields' | 'isTypeOf'
   > &
-  // The where may settle later: `id.resolve` below is itself a `MaybePromise`, and a callback
-  // built from the ID it settles to is as async as the resolver that produced it.
+  // The where may settle later: it is built from an `id.resolve` that is itself a `MaybePromise`.
   (UniqueField extends string
     ? {
         findUnique?: (id: string, context: Types['Context']) => MaybePromise<Model['WhereUnique']>;

--- a/packages/plugin-prisma/src/types.ts
+++ b/packages/plugin-prisma/src/types.ts
@@ -427,7 +427,6 @@ export type PrismaNodeOptions<
     | PothosSchemaTypes.ObjectTypeWithInterfaceOptions<Types, Shape, Interfaces>,
     'fields' | 'isTypeOf'
   > &
-  // The where may settle later: it is built from an `id.resolve` that is itself a `MaybePromise`.
   (UniqueField extends string
     ? {
         findUnique?: (id: string, context: Types['Context']) => MaybePromise<Model['WhereUnique']>;

--- a/packages/plugin-prisma/tests/async-types.test-d.ts
+++ b/packages/plugin-prisma/tests/async-types.test-d.ts
@@ -311,7 +311,6 @@ syncBuilder.prismaObject('User', {
   }),
 });
 
-// A node's `findUnique` is ungated by `AsyncSelections`, as `id.resolve` beside it already is.
 syncBuilder.prismaNode('User', {
   variant: 'SyncFindUniqueUser',
   id: { resolve: (user) => String(user.id) },

--- a/packages/plugin-prisma/tests/async-types.test-d.ts
+++ b/packages/plugin-prisma/tests/async-types.test-d.ts
@@ -311,6 +311,27 @@ syncBuilder.prismaObject('User', {
   }),
 });
 
+// A node's `findUnique` is ungated by `AsyncSelections`, as `id.resolve` beside it already is:
+// the where a custom lookup builds is as async as the ID resolver it is built from, and the model
+// loader awaits it. Both shapes compile on the builder that opted into nothing.
+syncBuilder.prismaNode('User', {
+  variant: 'SyncFindUniqueUser',
+  id: { resolve: (user) => String(user.id) },
+  findUnique: (id) => ({ id: Number(id) }),
+  fields: (t) => ({
+    email: t.exposeString('email'),
+  }),
+});
+
+syncBuilder.prismaNode('User', {
+  variant: 'AsyncFindUniqueUser',
+  id: { resolve: async (user) => String(user.id) },
+  findUnique: async (id) => ({ id: Number(id) }),
+  fields: (t) => ({
+    email: t.exposeString('email'),
+  }),
+});
+
 // The shapes above reach `CheckAsyncSelection` only if the option's own type lets them through,
 // which hides what the check itself answers. Asked directly, it answers `unknown` for a callback
 // it accepts and the diagnostic for one it rejects.

--- a/packages/plugin-prisma/tests/async-types.test-d.ts
+++ b/packages/plugin-prisma/tests/async-types.test-d.ts
@@ -311,9 +311,7 @@ syncBuilder.prismaObject('User', {
   }),
 });
 
-// A node's `findUnique` is ungated by `AsyncSelections`, as `id.resolve` beside it already is:
-// the where a custom lookup builds is as async as the ID resolver it is built from, and the model
-// loader awaits it. Both shapes compile on the builder that opted into nothing.
+// A node's `findUnique` is ungated by `AsyncSelections`, as `id.resolve` beside it already is.
 syncBuilder.prismaNode('User', {
   variant: 'SyncFindUniqueUser',
   id: { resolve: (user) => String(user.id) },

--- a/packages/plugin-prisma/tests/loader-batching.test.ts
+++ b/packages/plugin-prisma/tests/loader-batching.test.ts
@@ -324,15 +324,22 @@ async function count(document: DocumentNode): Promise<Counted> {
 
   queries.length = 0;
 
-  const result = await execute({ schema, document, contextValue: { user: { id: 1 } } });
+  let issued: { action: string; args: { include?: unknown } }[];
+  let batches: number;
 
-  expect(result.errors).toBeUndefined();
+  try {
+    const result = await execute({ schema, document, contextValue: { user: { id: 1 } } });
 
-  const issued = [...queries] as { action: string; args: { include?: unknown } }[];
-  const batches = initLoad.mock.calls.length;
+    expect(result.errors).toBeUndefined();
 
-  queries.length = 0;
-  initLoad.mockRestore();
+    issued = [...queries] as typeof issued;
+    batches = initLoad.mock.calls.length;
+  } finally {
+    // Restored even when the assertion above throws: a spy left installed counts the next test's
+    // batches too, turning one failure into a cascade of unrelated ones.
+    queries.length = 0;
+    initLoad.mockRestore();
+  }
 
   const loads = issued.filter((query) => query.action !== 'findMany');
 

--- a/packages/plugin-prisma/tests/loader-batching.test.ts
+++ b/packages/plugin-prisma/tests/loader-batching.test.ts
@@ -221,8 +221,7 @@ const User = builder.prismaObject('User', {
   }),
 });
 
-// A node whose custom `findUnique` builds its where from an ID the resolver settles later. The
-// loader waits for that where inside the flush loop, after the batch it belongs to is closed.
+// A node whose custom `findUnique` builds its where from an ID the resolver settles later.
 const AsyncIdUser = builder.prismaNode('User', {
   variant: 'AsyncIdUser',
   id: {
@@ -335,8 +334,8 @@ async function count(document: DocumentNode): Promise<Counted> {
     issued = [...queries] as typeof issued;
     batches = initLoad.mock.calls.length;
   } finally {
-    // Restored even when the assertion above throws: a spy left installed counts the next test's
-    // batches too, turning one failure into a cascade of unrelated ones.
+    // Restored even when the assertion above throws: a spy left installed counts the next
+    // test's batches too.
     queries.length = 0;
     initLoad.mockRestore();
   }
@@ -389,10 +388,8 @@ describe('model loader batching under async selections', () => {
     const sync = await count(gql`{ rawSyncIdUsers { titles } }`);
     const async = await count(gql`{ rawAsyncIdUsers { titles } }`);
 
-    // The where each row's `findUnique` builds is awaited inside the flush loop, after
-    // `stageQuery` has already decided which batch the row belongs to — so an async ID costs the
-    // same one batch and the same one merged selection a synchronous one does. `loads` stays ROWS
-    // in both: the batch merges what the rows select, not the round trips they take.
+    // The where is awaited inside the flush loop, after `stageQuery` has already chosen the
+    // batch, so an async ID costs the same one batch and one merged selection a sync one does.
     expect(sync).toMatchObject({ batches: 1, loads: ROWS, selections: 1 });
     expect(async).toMatchObject({ batches: 1, loads: ROWS, selections: 1 });
     expect(async.selections).toBe(sync.selections);

--- a/packages/plugin-prisma/tests/loader-batching.test.ts
+++ b/packages/plugin-prisma/tests/loader-batching.test.ts
@@ -221,6 +221,39 @@ const User = builder.prismaObject('User', {
   }),
 });
 
+// A node whose custom `findUnique` builds its where from an ID the resolver settles later. The
+// loader waits for that where inside the flush loop, after the batch it belongs to is closed.
+const AsyncIdUser = builder.prismaNode('User', {
+  variant: 'AsyncIdUser',
+  id: {
+    resolve: async (user) => {
+      await macrotask();
+
+      return String(user.id);
+    },
+  },
+  findUnique: (id) => ({ id: Number(id) }),
+  fields: (t) => ({
+    titles: t.stringList({
+      select: { posts: postsSelect },
+      resolve: (user) => user.posts.map((post) => post.title),
+    }),
+  }),
+});
+
+// The same node with the ID resolved in place: the counts the async one is read against.
+const SyncIdUser = builder.prismaNode('User', {
+  variant: 'SyncIdUser',
+  id: { resolve: (user) => String(user.id) },
+  findUnique: (id) => ({ id: Number(id) }),
+  fields: (t) => ({
+    titles: t.stringList({
+      select: { posts: postsSelect },
+      resolve: (user) => user.posts.map((post) => post.title),
+    }),
+  }),
+});
+
 // The same rows behind a field that returns each of them a different number of macrotasks later:
 // the shape a batch cannot hold together, and the control the counts below are read against.
 const StaggeredUser = builder.prismaObject('User', {
@@ -250,6 +283,14 @@ builder.queryType({
     }),
     staggeredUsers: t.field({
       type: [StaggeredUser],
+      resolve: () => prisma.user.findMany({ take: ROWS, orderBy: { id: 'asc' } }),
+    }),
+    rawAsyncIdUsers: t.field({
+      type: [AsyncIdUser],
+      resolve: () => prisma.user.findMany({ take: ROWS, orderBy: { id: 'asc' } }),
+    }),
+    rawSyncIdUsers: t.field({
+      type: [SyncIdUser],
       resolve: () => prisma.user.findMany({ take: ROWS, orderBy: { id: 'asc' } }),
     }),
     // The same rows with their posts loaded raw beside them, so the nested list resolves
@@ -335,6 +376,19 @@ describe('model loader batching under async selections', () => {
     expect(async.batches).toBe(sync.batches);
     expect(async.loads).toBe(sync.loads);
     expect(async).toMatchObject({ batches: 1, loads: ROWS, selections: 1 });
+  });
+
+  it('batches a list of rows whose node IDs resolve asynchronously', async () => {
+    const sync = await count(gql`{ rawSyncIdUsers { titles } }`);
+    const async = await count(gql`{ rawAsyncIdUsers { titles } }`);
+
+    // The where each row's `findUnique` builds is awaited inside the flush loop, after
+    // `stageQuery` has already decided which batch the row belongs to — so an async ID costs the
+    // same one batch and the same one merged selection a synchronous one does. `loads` stays ROWS
+    // in both: the batch merges what the rows select, not the round trips they take.
+    expect(sync).toMatchObject({ batches: 1, loads: ROWS, selections: 1 });
+    expect(async).toMatchObject({ batches: 1, loads: ROWS, selections: 1 });
+    expect(async.selections).toBe(sync.selections);
   });
 
   it('batches two async selections that settle in one drain', async () => {

--- a/packages/plugin-prisma/tests/loader-batching.test.ts
+++ b/packages/plugin-prisma/tests/loader-batching.test.ts
@@ -221,7 +221,6 @@ const User = builder.prismaObject('User', {
   }),
 });
 
-// A node whose custom `findUnique` builds its where from an ID the resolver settles later.
 const AsyncIdUser = builder.prismaNode('User', {
   variant: 'AsyncIdUser',
   id: {
@@ -240,7 +239,6 @@ const AsyncIdUser = builder.prismaNode('User', {
   }),
 });
 
-// The same node with the ID resolved in place: the counts the async one is read against.
 const SyncIdUser = builder.prismaNode('User', {
   variant: 'SyncIdUser',
   id: { resolve: (user) => String(user.id) },
@@ -334,8 +332,6 @@ async function count(document: DocumentNode): Promise<Counted> {
     issued = [...queries] as typeof issued;
     batches = initLoad.mock.calls.length;
   } finally {
-    // Restored even when the assertion above throws: a spy left installed counts the next
-    // test's batches too.
     queries.length = 0;
     initLoad.mockRestore();
   }
@@ -388,8 +384,6 @@ describe('model loader batching under async selections', () => {
     const sync = await count(gql`{ rawSyncIdUsers { titles } }`);
     const async = await count(gql`{ rawAsyncIdUsers { titles } }`);
 
-    // The where is awaited inside the flush loop, after `stageQuery` has already chosen the
-    // batch, so an async ID costs the same one batch and one merged selection a sync one does.
     expect(sync).toMatchObject({ batches: 1, loads: ROWS, selections: 1 });
     expect(async).toMatchObject({ batches: 1, loads: ROWS, selections: 1 });
     expect(async.selections).toBe(sync.selections);

--- a/packages/plugin-prisma/tests/node-async-id.test.ts
+++ b/packages/plugin-prisma/tests/node-async-id.test.ts
@@ -8,7 +8,6 @@ import { ModelLoader } from '../src/model-loader';
 import { prisma, queries } from './example/builder';
 import { getDatamodel } from './generated.js';
 
-/** The ID the user's `findUnique` callback was handed. */
 const seen: unknown[] = [];
 
 const builder = new SchemaBuilder<{
@@ -38,7 +37,6 @@ const AsyncIdUser = builder.prismaNode('User', {
     return { id: Number(id) };
   },
   fields: (t) => ({
-    // Nothing the raw root field below loads, so the row falls back through the model loader.
     name: t.string({
       select: { name: true },
       resolve: (user) => user.name ?? '',
@@ -77,7 +75,6 @@ builder.queryType({
 
 const schema = builder.toSchema();
 
-/** The `where` of every loader lookup the client issued; the parent `findMany`s are excluded. */
 function loaderWheres() {
   return (queries as { action: string; args: { where?: unknown } }[])
     .filter((query) => query.action !== 'findMany')
@@ -121,21 +118,14 @@ describe('async custom node IDs on the fallback lookup', () => {
   });
 });
 
-// A real client cannot show which microtask a delegate call was issued in, so the rest of these
-// drive the flush loop against a stub delegate.
-
 const ROWS = 5;
 
-/** The row whose ID resolver fails in the containment cases below. */
 const FAILING_ROW = 3;
 
-/** Microtask boundaries crossed since the batch that is loading was opened. */
 let microtasks = 0;
 
-/** The value of `microtasks` at each delegate call, in the order the flush loop issued them. */
 const issuedAt: number[] = [];
 
-/** How long the stub delegate takes to answer. `never` leaves the query pending forever. */
 let delegateSettles: 'immediately' | 'a macrotask later' | 'never' = 'immediately';
 
 const stubClient = {
@@ -169,7 +159,6 @@ const stubBuilder = new SchemaBuilder<{
   },
 });
 
-/** The ID resolvers each node below is built with, swapped per test. */
 let resolveId: (user: { id: number }) => unknown = (user) => String(user.id);
 
 const StubUser = stubBuilder.prismaNode('User', {
@@ -177,7 +166,6 @@ const StubUser = stubBuilder.prismaNode('User', {
   id: { resolve: (user) => resolveId(user) as never },
   findUnique: (id) => ({ id: Number(id) }),
   fields: (t) => ({
-    // Nullable so a row that fails shows as its own null instead of taking the list with it.
     name: t.string({
       nullable: true,
       select: { name: true },
@@ -197,10 +185,6 @@ stubBuilder.queryType({
 
 const stubSchema = stubBuilder.toSchema();
 
-/**
- * Runs `{ rows { name } }` while counting microtask boundaries from the moment the loader opens
- * its batch.
- */
 async function countMicrotasks() {
   issuedAt.length = 0;
   microtasks = 0;
@@ -242,7 +226,6 @@ describe('the flush loop under an async where', () => {
     const result = await countMicrotasks();
 
     expect(result.errors).toBeUndefined();
-    // Zero boundaries crossed: the delegate call is made inside the flush callback itself.
     expect(issuedAt).toEqual(Array.from({ length: ROWS }, () => 0));
   });
 
@@ -260,7 +243,6 @@ describe('the flush loop under an async where', () => {
     expect(issuedAt.every((at) => at > 0)).toBe(true);
   });
 
-  // Both settling speeds: the outcome must not depend on whether a row's query beat the rejection.
   it.each([
     'immediately',
     'a macrotask later',
@@ -288,8 +270,6 @@ describe('the flush loop under an async where', () => {
   });
 
   it('rejects every model in the batch when findUnique throws synchronously', async () => {
-    // The stub never settles, so the request can only complete if the whole batch rejected: the
-    // rows the loop never reached would otherwise hang.
     delegateSettles = 'never';
     resolveId = (user) => {
       if (user.id === FAILING_ROW) {

--- a/packages/plugin-prisma/tests/node-async-id.test.ts
+++ b/packages/plugin-prisma/tests/node-async-id.test.ts
@@ -1,0 +1,285 @@
+import SchemaBuilder from '@pothos/core';
+import RelayPlugin from '@pothos/plugin-relay';
+import { execute } from '@pothos/test-utils';
+import { gql } from 'graphql-tag';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import PrismaPlugin, { type PrismaTypesFromClient } from '../src';
+import { ModelLoader } from '../src/model-loader';
+import { prisma, queries } from './example/builder';
+import { getDatamodel } from './generated.js';
+
+// `prismaNode`'s `id.resolve` is typed `MaybePromise`, and a node with a custom `findUnique`
+// composes the two: the ID the resolver settles to is what the fallback lookup's `where` is built
+// from. Only the loader path is covered here — `node(id:)` and the exposed ID field both decode
+// the ID before they reach `findUnique`, and never saw the promise.
+
+/** The ID the user's `findUnique` callback was handed, recorded as it actually received it. */
+const seen: unknown[] = [];
+
+const builder = new SchemaBuilder<{
+  PrismaTypes: PrismaTypesFromClient<typeof prisma>;
+  Context: { user: { id: number } };
+}>({
+  plugins: [PrismaPlugin, RelayPlugin],
+  relay: {},
+  prisma: {
+    client: () => prisma,
+    dmmf: getDatamodel(),
+  },
+});
+
+const AsyncIdUser = builder.prismaNode('User', {
+  variant: 'AsyncIdUser',
+  id: {
+    resolve: async (user) => {
+      await Promise.resolve();
+
+      return String(user.id);
+    },
+  },
+  findUnique: (id) => {
+    seen.push(id);
+
+    return { id: Number(id) };
+  },
+  fields: (t) => ({
+    // Nothing the raw root field below loads, so the row falls back through the model loader.
+    name: t.string({
+      select: { name: true },
+      resolve: (user) => user.name ?? '',
+    }),
+  }),
+});
+
+const SyncIdUser = builder.prismaNode('User', {
+  variant: 'SyncIdUser',
+  id: { resolve: (user) => String(user.id) },
+  findUnique: (id) => {
+    seen.push(id);
+
+    return { id: Number(id) };
+  },
+  fields: (t) => ({
+    name: t.string({
+      select: { name: true },
+      resolve: (user) => user.name ?? '',
+    }),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    // A row carrying none of the node's own selection: `name` has to reload it.
+    rawAsync: t.field({
+      type: AsyncIdUser,
+      resolve: () => ({ id: 1 }) as never,
+    }),
+    rawSync: t.field({
+      type: SyncIdUser,
+      resolve: () => ({ id: 1 }) as never,
+    }),
+  }),
+});
+
+const schema = builder.toSchema();
+
+/** The `where` of every loader lookup the client issued; the parent `findMany`s are excluded. */
+function loaderWheres() {
+  return (queries as { action: string; args: { where?: unknown } }[])
+    .filter((query) => query.action !== 'findMany')
+    .map((query) => query.args.where);
+}
+
+describe('async custom node IDs on the fallback lookup', () => {
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('awaits an async id resolver before calling findUnique', async () => {
+    seen.length = 0;
+    queries.length = 0;
+
+    const result = await execute({
+      schema,
+      document: gql`{ rawAsync { name } }`,
+      contextValue: { user: { id: 1 } },
+    });
+
+    expect(result.errors).toBeUndefined();
+    // The callback's own type promises a string. Unawaited it received the promise the resolver
+    // returned, and `Number(promise)` made the where below `{ id: NaN }`.
+    expect(seen).toEqual(['1']);
+    expect(loaderWheres()).toEqual([{ id: 1 }]);
+    expect(result.data).toMatchObject({ rawAsync: { name: expect.any(String) } });
+  });
+
+  it('builds the same where from a synchronous id resolver', async () => {
+    seen.length = 0;
+    queries.length = 0;
+
+    const result = await execute({
+      schema,
+      document: gql`{ rawSync { name } }`,
+      contextValue: { user: { id: 1 } },
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(seen).toEqual(['1']);
+    expect(loaderWheres()).toEqual([{ id: 1 }]);
+  });
+});
+
+// The loader's flush loop is what awaits the where, and neither the microtask a delegate call is
+// issued in nor the fate of a batch whose where rejects is legible through a real client. Both
+// are driven against a stub delegate below.
+
+const ROWS = 4;
+
+/** Microtask boundaries crossed since the batch that is loading was opened. */
+let microtasks = 0;
+
+/** The value of `microtasks` at each delegate call, in the order the flush loop issued them. */
+const issuedAt: number[] = [];
+
+/** Batches whose queries the stub leaves pending, to prove the batch itself rejected them. */
+let hangingQueries = 0;
+
+const stubClient = {
+  user: {
+    findUniqueOrThrow: (args: { where: { id: number } }) => {
+      issuedAt.push(microtasks);
+
+      return hangingQueries > 0
+        ? new Promise(() => {})
+        : Promise.resolve({ id: args.where.id, name: `user-${args.where.id}` });
+    },
+  },
+};
+
+const stubBuilder = new SchemaBuilder<{
+  PrismaTypes: PrismaTypesFromClient<typeof prisma>;
+  Context: {};
+}>({
+  plugins: [PrismaPlugin, RelayPlugin],
+  relay: {},
+  prisma: {
+    client: stubClient as never,
+    dmmf: getDatamodel(),
+  },
+});
+
+/** The ID resolvers each node below is built with, swapped per test. */
+let resolveId: (user: { id: number }) => unknown = (user) => String(user.id);
+
+const StubUser = stubBuilder.prismaNode('User', {
+  variant: 'StubUser',
+  id: { resolve: (user) => resolveId(user) as never },
+  findUnique: (id) => ({ id: Number(id) }),
+  fields: (t) => ({
+    name: t.string({
+      select: { name: true },
+      resolve: (user) => user.name ?? '',
+    }),
+  }),
+});
+
+stubBuilder.queryType({
+  fields: (t) => ({
+    rows: t.field({
+      type: [StubUser],
+      resolve: () => Array.from({ length: ROWS }, (_, index) => ({ id: index + 1 })) as never,
+    }),
+  }),
+});
+
+const stubSchema = stubBuilder.toSchema();
+
+/**
+ * Runs `{ rows { name } }` while counting microtask boundaries from the moment the loader opens
+ * its batch: `initLoad` registers the flush on an already-settled tick, so a synchronous
+ * `findUnique` issues its delegate call before the first boundary counted here.
+ */
+async function countMicrotasks() {
+  issuedAt.length = 0;
+  microtasks = 0;
+
+  const original = ModelLoader.prototype.initLoad;
+  const opened = vi.spyOn(ModelLoader.prototype, 'initLoad');
+
+  opened.mockImplementation(function tracked(this: ModelLoader, played, model) {
+    const promise = original.call(this, played, model);
+
+    const bump = () => {
+      microtasks += 1;
+
+      if (microtasks < 50) {
+        Promise.resolve().then(bump);
+      }
+    };
+
+    Promise.resolve().then(bump);
+
+    return promise;
+  });
+
+  const result = await execute({
+    schema: stubSchema,
+    document: gql`{ rows { name } }`,
+    contextValue: {},
+  });
+
+  opened.mockRestore();
+
+  return result;
+}
+
+describe('the flush loop under an async where', () => {
+  it('issues a synchronous findUnique in the microtask the batch flushes in', async () => {
+    resolveId = (user) => String(user.id);
+
+    const result = await countMicrotasks();
+
+    expect(result.errors).toBeUndefined();
+    // Zero boundaries crossed: the delegate call is made inside the flush callback itself, which
+    // a blanket `await` over the loop would push past at least one of the ticks counted here.
+    expect(issuedAt).toEqual(Array.from({ length: ROWS }, () => 0));
+  });
+
+  it('issues an async findUnique only once its where has settled', async () => {
+    resolveId = async (user) => {
+      await Promise.resolve();
+
+      return String(user.id);
+    };
+
+    const result = await countMicrotasks();
+
+    expect(result.errors).toBeUndefined();
+    expect(issuedAt).toHaveLength(ROWS);
+    // Every row waits for its own where, and none of them jumps the flush it belongs to.
+    expect(issuedAt.every((at) => at > 0)).toBe(true);
+  });
+
+  it('rejects every model in the batch when one row’s where rejects', async () => {
+    // The rest of the batch is left pending by the stub, so the request can only complete if the
+    // rejection reached models the loop had already issued queries for — the invariant the
+    // synchronous `try/catch` gives a throwing `findUnique`.
+    hangingQueries = 1;
+    resolveId = (user) =>
+      user.id === 1 ? Promise.reject(new Error('id resolver failed')) : String(user.id);
+
+    const result = await execute({
+      schema: stubSchema,
+      document: gql`{ rows { name } }`,
+      contextValue: {},
+    });
+
+    hangingQueries = 0;
+    resolveId = (user) => String(user.id);
+
+    expect(result.errors).toHaveLength(ROWS);
+    expect(result.errors?.map((error) => error.message)).toEqual(
+      Array.from({ length: ROWS }, () => 'id resolver failed'),
+    );
+  });
+});

--- a/packages/plugin-prisma/tests/node-async-id.test.ts
+++ b/packages/plugin-prisma/tests/node-async-id.test.ts
@@ -129,11 +129,13 @@ describe('async custom node IDs on the fallback lookup', () => {
   });
 });
 
-// The loader's flush loop is what awaits the where, and neither the microtask a delegate call is
-// issued in nor the fate of a batch whose where rejects is legible through a real client. Both
-// are driven against a stub delegate below.
+// The loader's flush loop is what awaits the where, and the microtask a delegate call is issued
+// in is not legible through a real client. The rest of these drive it against a stub delegate.
 
-const ROWS = 4;
+const ROWS = 5;
+
+/** The row whose ID resolver fails in the containment cases below. */
+const FAILING_ROW = 3;
 
 /** Microtask boundaries crossed since the batch that is loading was opened. */
 let microtasks = 0;
@@ -141,17 +143,28 @@ let microtasks = 0;
 /** The value of `microtasks` at each delegate call, in the order the flush loop issued them. */
 const issuedAt: number[] = [];
 
-/** Batches whose queries the stub leaves pending, to prove the batch itself rejected them. */
-let hangingQueries = 0;
+/**
+ * How long the stub delegate takes to answer. `never` is only for the synchronous-throw case,
+ * where a query the loop never issued is the thing being observed; every other case settles, and
+ * is asserted to reach the same outcome whichever of the two settling speeds it runs at.
+ */
+let delegateSettles: 'immediately' | 'a macrotask later' | 'never' = 'immediately';
 
 const stubClient = {
   user: {
     findUniqueOrThrow: (args: { where: { id: number } }) => {
       issuedAt.push(microtasks);
 
-      return hangingQueries > 0
-        ? new Promise(() => {})
-        : Promise.resolve({ id: args.where.id, name: `user-${args.where.id}` });
+      const row = { id: args.where.id, name: `user-${args.where.id}` };
+
+      switch (delegateSettles) {
+        case 'never':
+          return new Promise(() => {});
+        case 'a macrotask later':
+          return new Promise((resolve) => setTimeout(() => resolve(row), 1));
+        default:
+          return Promise.resolve(row);
+      }
     },
   },
 };
@@ -176,9 +189,12 @@ const StubUser = stubBuilder.prismaNode('User', {
   id: { resolve: (user) => resolveId(user) as never },
   findUnique: (id) => ({ id: Number(id) }),
   fields: (t) => ({
+    // Nullable so a row that fails shows as its own null beside the rows that loaded, rather
+    // than bubbling up and taking the list with it.
     name: t.string({
+      nullable: true,
       select: { name: true },
-      resolve: (user) => user.name ?? '',
+      resolve: (user) => user.name,
     }),
   }),
 });
@@ -260,13 +276,17 @@ describe('the flush loop under an async where', () => {
     expect(issuedAt.every((at) => at > 0)).toBe(true);
   });
 
-  it('rejects every model in the batch when one row’s where rejects', async () => {
-    // The rest of the batch is left pending by the stub, so the request can only complete if the
-    // rejection reached models the loop had already issued queries for — the invariant the
-    // synchronous `try/catch` gives a throwing `findUnique`.
-    hangingQueries = 1;
+  // A where that rejects does so after the flush loop has run to its end, so every model already
+  // holds a handler and none of them can be stranded. Rejecting the batch there would fail rows
+  // whose own where was fine, and which of them it actually reached would depend on whether their
+  // queries beat the rejection — so both settling speeds are asserted to the same outcome.
+  it.each([
+    'immediately',
+    'a macrotask later',
+  ] as const)('fails only the row whose where rejected, with a delegate that settles %s', async (settles) => {
+    delegateSettles = settles;
     resolveId = (user) =>
-      user.id === 1 ? Promise.reject(new Error('id resolver failed')) : String(user.id);
+      user.id === FAILING_ROW ? Promise.reject(new Error('id resolver failed')) : String(user.id);
 
     const result = await execute({
       schema: stubSchema,
@@ -274,12 +294,49 @@ describe('the flush loop under an async where', () => {
       contextValue: {},
     });
 
-    hangingQueries = 0;
+    delegateSettles = 'immediately';
+    resolveId = (user) => String(user.id);
+
+    expect(result.errors?.map((error) => error.message)).toEqual(['id resolver failed']);
+    expect(result.errors?.[0].path).toEqual(['rows', FAILING_ROW - 1, 'name']);
+    // The rows either side of it loaded; only the one that failed is null.
+    expect(result.data).toEqual({
+      rows: Array.from({ length: ROWS }, (_, index) => ({
+        name: index + 1 === FAILING_ROW ? null : `user-${index + 1}`,
+      })),
+    });
+  });
+
+  it('rejects every model in the batch when findUnique throws synchronously', async () => {
+    // A synchronous throw aborts the loop, so the rows after it were never issued a query at all.
+    // The stub leaves the ones before it pending, so the request can only complete if the whole
+    // batch rejected: without that, the rows the loop never reached hang and take the request
+    // with them. This is the path `rejectBatch` exists for, and the one the async branch above
+    // deliberately does not share.
+    delegateSettles = 'never';
+    resolveId = (user) => {
+      if (user.id === FAILING_ROW) {
+        throw new Error('findUnique threw');
+      }
+
+      return String(user.id);
+    };
+
+    const result = await execute({
+      schema: stubSchema,
+      document: gql`{ rows { name } }`,
+      contextValue: {},
+    });
+
+    delegateSettles = 'immediately';
     resolveId = (user) => String(user.id);
 
     expect(result.errors).toHaveLength(ROWS);
     expect(result.errors?.map((error) => error.message)).toEqual(
-      Array.from({ length: ROWS }, () => 'id resolver failed'),
+      Array.from({ length: ROWS }, () => 'findUnique threw'),
     );
+    // The rows the loop never reached, named explicitly: these are the ones that would hang.
+    expect(result.errors?.map((error) => error.path?.[1])).toContain(FAILING_ROW);
+    expect(result.errors?.map((error) => error.path?.[1])).toContain(ROWS - 1);
   });
 });

--- a/packages/plugin-prisma/tests/node-async-id.test.ts
+++ b/packages/plugin-prisma/tests/node-async-id.test.ts
@@ -8,12 +8,7 @@ import { ModelLoader } from '../src/model-loader';
 import { prisma, queries } from './example/builder';
 import { getDatamodel } from './generated.js';
 
-// `prismaNode`'s `id.resolve` is typed `MaybePromise`, and a node with a custom `findUnique`
-// composes the two: the ID the resolver settles to is what the fallback lookup's `where` is built
-// from. Only the loader path is covered here — `node(id:)` and the exposed ID field both decode
-// the ID before they reach `findUnique`, and never saw the promise.
-
-/** The ID the user's `findUnique` callback was handed, recorded as it actually received it. */
+/** The ID the user's `findUnique` callback was handed. */
 const seen: unknown[] = [];
 
 const builder = new SchemaBuilder<{
@@ -69,7 +64,6 @@ const SyncIdUser = builder.prismaNode('User', {
 
 builder.queryType({
   fields: (t) => ({
-    // A row carrying none of the node's own selection: `name` has to reload it.
     rawAsync: t.field({
       type: AsyncIdUser,
       resolve: () => ({ id: 1 }) as never,
@@ -106,8 +100,6 @@ describe('async custom node IDs on the fallback lookup', () => {
     });
 
     expect(result.errors).toBeUndefined();
-    // The callback's own type promises a string. Unawaited it received the promise the resolver
-    // returned, and `Number(promise)` made the where below `{ id: NaN }`.
     expect(seen).toEqual(['1']);
     expect(loaderWheres()).toEqual([{ id: 1 }]);
     expect(result.data).toMatchObject({ rawAsync: { name: expect.any(String) } });
@@ -129,8 +121,8 @@ describe('async custom node IDs on the fallback lookup', () => {
   });
 });
 
-// The loader's flush loop is what awaits the where, and the microtask a delegate call is issued
-// in is not legible through a real client. The rest of these drive it against a stub delegate.
+// A real client cannot show which microtask a delegate call was issued in, so the rest of these
+// drive the flush loop against a stub delegate.
 
 const ROWS = 5;
 
@@ -143,11 +135,7 @@ let microtasks = 0;
 /** The value of `microtasks` at each delegate call, in the order the flush loop issued them. */
 const issuedAt: number[] = [];
 
-/**
- * How long the stub delegate takes to answer. `never` is only for the synchronous-throw case,
- * where a query the loop never issued is the thing being observed; every other case settles, and
- * is asserted to reach the same outcome whichever of the two settling speeds it runs at.
- */
+/** How long the stub delegate takes to answer. `never` leaves the query pending forever. */
 let delegateSettles: 'immediately' | 'a macrotask later' | 'never' = 'immediately';
 
 const stubClient = {
@@ -189,8 +177,7 @@ const StubUser = stubBuilder.prismaNode('User', {
   id: { resolve: (user) => resolveId(user) as never },
   findUnique: (id) => ({ id: Number(id) }),
   fields: (t) => ({
-    // Nullable so a row that fails shows as its own null beside the rows that loaded, rather
-    // than bubbling up and taking the list with it.
+    // Nullable so a row that fails shows as its own null instead of taking the list with it.
     name: t.string({
       nullable: true,
       select: { name: true },
@@ -212,8 +199,7 @@ const stubSchema = stubBuilder.toSchema();
 
 /**
  * Runs `{ rows { name } }` while counting microtask boundaries from the moment the loader opens
- * its batch: `initLoad` registers the flush on an already-settled tick, so a synchronous
- * `findUnique` issues its delegate call before the first boundary counted here.
+ * its batch.
  */
 async function countMicrotasks() {
   issuedAt.length = 0;
@@ -256,8 +242,7 @@ describe('the flush loop under an async where', () => {
     const result = await countMicrotasks();
 
     expect(result.errors).toBeUndefined();
-    // Zero boundaries crossed: the delegate call is made inside the flush callback itself, which
-    // a blanket `await` over the loop would push past at least one of the ticks counted here.
+    // Zero boundaries crossed: the delegate call is made inside the flush callback itself.
     expect(issuedAt).toEqual(Array.from({ length: ROWS }, () => 0));
   });
 
@@ -272,14 +257,10 @@ describe('the flush loop under an async where', () => {
 
     expect(result.errors).toBeUndefined();
     expect(issuedAt).toHaveLength(ROWS);
-    // Every row waits for its own where, and none of them jumps the flush it belongs to.
     expect(issuedAt.every((at) => at > 0)).toBe(true);
   });
 
-  // A where that rejects does so after the flush loop has run to its end, so every model already
-  // holds a handler and none of them can be stranded. Rejecting the batch there would fail rows
-  // whose own where was fine, and which of them it actually reached would depend on whether their
-  // queries beat the rejection — so both settling speeds are asserted to the same outcome.
+  // Both settling speeds: the outcome must not depend on whether a row's query beat the rejection.
   it.each([
     'immediately',
     'a macrotask later',
@@ -299,7 +280,6 @@ describe('the flush loop under an async where', () => {
 
     expect(result.errors?.map((error) => error.message)).toEqual(['id resolver failed']);
     expect(result.errors?.[0].path).toEqual(['rows', FAILING_ROW - 1, 'name']);
-    // The rows either side of it loaded; only the one that failed is null.
     expect(result.data).toEqual({
       rows: Array.from({ length: ROWS }, (_, index) => ({
         name: index + 1 === FAILING_ROW ? null : `user-${index + 1}`,
@@ -308,11 +288,8 @@ describe('the flush loop under an async where', () => {
   });
 
   it('rejects every model in the batch when findUnique throws synchronously', async () => {
-    // A synchronous throw aborts the loop, so the rows after it were never issued a query at all.
-    // The stub leaves the ones before it pending, so the request can only complete if the whole
-    // batch rejected: without that, the rows the loop never reached hang and take the request
-    // with them. This is the path `rejectBatch` exists for, and the one the async branch above
-    // deliberately does not share.
+    // The stub never settles, so the request can only complete if the whole batch rejected: the
+    // rows the loop never reached would otherwise hang.
     delegateSettles = 'never';
     resolveId = (user) => {
       if (user.id === FAILING_ROW) {
@@ -335,7 +312,6 @@ describe('the flush loop under an async where', () => {
     expect(result.errors?.map((error) => error.message)).toEqual(
       Array.from({ length: ROWS }, () => 'findUnique threw'),
     );
-    // The rows the loop never reached, named explicitly: these are the ones that would hang.
     expect(result.errors?.map((error) => error.path?.[1])).toContain(FAILING_ROW);
     expect(result.errors?.map((error) => error.path?.[1])).toContain(ROWS - 1);
   });


### PR DESCRIPTION
`prismaNode`'s public contract lets `id.resolve` return a `MaybePromise`, but the fallback lookup built beside it handed the resolver's return value straight to a custom `findUnique`, behind an `as string` cast that erased the promise:

```ts
// src/schema-builder.ts, before
const findUnique = rawFindUnique
  ? (parent: unknown, context: {}) =>
      rawFindUnique(resolve(parent as never, context) as string, context)
  : ModelLoader.getFindUniqueForField(nodeRef, type, fieldName, this);
```

With an async resolver the callback receives a promise where its own type promises a string, so the idiomatic `findUnique: (id) => ({ id: Number(id) })` builds `where: { id: NaN }`.

Reproduced against the real sqlite client with a node declaring `id: { resolve: async (user) => String(user.id) }` and a `findUnique` recording what it was handed:

| | before | after |
| --- | --- | --- |
| what `findUnique` received | `Promise { '1' }` | `'1'` |
| the `where` it built | `{ id: NaN }` | `{ id: 1 }` |
| what the client did with it | `PrismaClientValidationError: Argument 'id' is missing` | loads the row |

Only the loader's fallback path was affected. `node(id:)` and the exposed ID field both decode the ID before they call `findUnique`, which is why async resolvers appear to work until a field with a `select` falls back.

## The fix

The await is honoured inside `ModelLoader`'s flush loop, guarded by `isThenable`:

- **Batching is unchanged**, and provably so rather than incidentally. Batch membership is sealed at `stageQuery`, which never calls `this.findUnique`; the flush loop where the where is built runs later, and the `setTimeout` that arms the next batch boundary is untouched. Waiting there cannot fragment a batch or move a boundary. Awaiting *before* staging would — every row of a list would stage a microtask late, miss the open batch and open its own.
- **The synchronous path does not move.** The `isThenable` guard keeps a synchronous where issuing its delegate call in the same microtask it does today; a blanket `await` over the loop would push every existing fallback a tick later.
- **A failure fails one row, and stranding is still impossible.** These are two different paths and they get two different answers. A `findUnique` that *throws synchronously* aborts the `for` loop, so models it never reached would hang forever and take the request with them — that path still rejects the whole batch, as it does today. A where that *rejects* settles after the loop has run to its end, by which point every model already holds a handler and none of them can be stranded, so it fails only its own row. Rejecting the batch there would fail rows whose own where was fine.

`findUnique`'s public return type widens to `MaybePromise<Model['WhereUnique']>` — additive, and it accepts strictly more implementations, so existing synchronous callbacks still typecheck. The direct node lookup (`loadNode`) awaits it too, so the widened type holds on both paths rather than moving the same bug one call site over. `ModelLoader` itself is internal: type-only at `src/index.ts`, no `exports` subpath.

Changeset: minor.

### On the row-scoped rejection

The first push of this branch rejected the whole batch on a rejected where too, reasoning by analogy from the synchronous path. Review caught that this was wrong twice over. A 5-row list whose node ID resolver throws for row 3, against the real client:

```
before:  errors: 5   messages: ["row 3 is forbidden" x5]
                     data: rows: [null, null, null, null, null]
after:   errors: 1   messages: ["row 3 is forbidden"]
                     data: rows: [{name:"Maurine Ratke"}, {name:"Kyle Schoen"}, {name:null},
                                  {name:"Marianna Murphy"}, {name:"Jennyfer Lindgren"}]
```

Rows 1, 2, 4 and 5 had settled synchronous wheres with queries already in flight and were failed with an error belonging to row 3. And whether they were was a *race*: against a delegate that answers immediately the siblings' `resolve` wins the microtask and only one row fails; against one that answers a macrotask later, all five fail. The containment rationale simply does not carry across the await, for the reason given above.

## Tests

`packages/plugin-prisma/tests/node-async-id.test.ts` (new):

- DB-backed: an async `id.resolve` with a custom `findUnique` — the callback receives `'1'` and the issued query's `where` is `{ id: 1 }`.
- The synchronous resolver builds the same where.
- A synchronous `findUnique` issues its delegate call in the microtask the batch flushes in, with zero boundaries crossed — the guard against an accidental blanket `await`.
- An async `findUnique` issues only once its where has settled.
- **A rejected where fails only its own row** — asserted twice over, against a delegate that settles immediately and one that settles a macrotask later, to the same outcome: one error on row 3, rows 1, 2, 4, 5 loading their names. A test whose result flips with stub latency pins nothing, so the latency is a parameter rather than a fixed choice. (Under the whole-batch version the "immediately" case passes and the "macrotask later" case fails — which is exactly the point.)
- **A synchronous throw still rejects every model in the batch**, with a delegate that never answers, so the rows the loop never reached are observably contained rather than raced.

`tests/loader-batching.test.ts` gains an async-node-ID case, phrased against what the loader actually guarantees:

```ts
expect(sync).toMatchObject({ batches: 1, loads: ROWS, selections: 1 });
expect(async).toMatchObject({ batches: 1, loads: ROWS, selections: 1 });
```

One batch and one merged selection across all 20 rows, sync and async alike. `loads` stays `ROWS` in both — the loader issues one `findUnique` per staged row by design, today and after this change; what a batch merges is the selection, not the round trips. The file's existing positive control (`batches === ROWS` when rows are deliberately spread across macrotasks) is untouched, so `batches: 1` stays meaningful.

Also fixes a pre-existing hygiene bug in that file: `count()` called `initLoad.mockRestore()` after an assertion that can throw, so one failing test leaked the spy into the next and turned a single red into a cascade. It now restores in a `finally`.

`tests/async-types.test-d.ts` pins that both a sync and an async `findUnique` compile, on a builder that opted into nothing — the widening is deliberately ungated by `AsyncSelections`, as `id.resolve` beside it already is.

Checked against the unfixed source: the DB-backed repro, the batching case and the batch-containment tests all fail without the change.

`@pothos/plugin-prisma`: 41 files / 261 tests passing, no type errors (40 / 253 before this change); `pnpm --filter @pothos/plugin-prisma run type` and `pnpm biome check packages/plugin-prisma` clean. `plugin-prisma-utils`, `plugin-scope-auth` and `plugin-with-input` typecheck clean against the widened types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB
