### PR TITLE
fix(prisma-next): narrow the cross-file helper parent shape to declared dependencies

### DIFF
--- a/.changeset/prisma-next-helper-shape.md
+++ b/.changeset/prisma-next-helper-shape.md
@@ -18,7 +18,9 @@ does. Field-level `select` still layers on additively, `t.expose*` and
 
 `prismaNode`'s custom `id.resolve` additionally receives the columns named by
 `id.field` — single or compound — since those are selected for the ID field
-already, so it needs no redundant object-level `select`.
+already, so it needs no redundant object-level `select`. `prismaNode`'s
+`select` keeps its existing key validation: a misspelled column or relation is
+still rejected at the call site.
 
 Runtime behaviour is unchanged — declaring `select` is still how a field
 adds a column dependency. To opt back into the old parent type, pass `Shape`

--- a/.changeset/prisma-next-helper-shape.md
+++ b/.changeset/prisma-next-helper-shape.md
@@ -1,0 +1,21 @@
+---
+'@pothos/plugin-prisma-next': patch
+---
+
+Narrow the parent shape of the cross-file field helpers (`prismaObjectField`,
+`prismaObjectFields`, `prismaInterfaceField`, `prismaInterfaceFields`) and of
+`prismaNode` to the dependencies that were actually declared.
+
+These helpers defaulted their parent `Shape` to the full `Row<Types, M>`, so a
+resolver added with the model-name string form was typed as if every column
+were loaded, when the plugin only loads what some `select` or `t.expose*`
+declared. Reading an unselected column compiled and then failed at query time
+with `Cannot return null for non-nullable field`. The string form now starts
+from the same brand-only `ObjectBaseShape` that `prismaObject` uses, and
+`prismaNode` computes its parent from its own `select` like `prismaObject`
+does. Field-level `select` still layers on additively, `t.expose*` and
+`t.relation` are unaffected, and the ref form is unchanged.
+
+Runtime behaviour is unchanged — declaring `select` is still how a field
+adds a column dependency. To opt back into the old parent type, pass `Shape`
+explicitly: `builder.prismaObjectField<'User', Row<Types, 'User'>>('User', …)`.

--- a/.changeset/prisma-next-helper-shape.md
+++ b/.changeset/prisma-next-helper-shape.md
@@ -16,6 +16,10 @@ from the same brand-only `ObjectBaseShape` that `prismaObject` uses, and
 does. Field-level `select` still layers on additively, `t.expose*` and
 `t.relation` are unaffected, and the ref form is unchanged.
 
+`prismaNode`'s custom `id.resolve` additionally receives the columns named by
+`id.field` — single or compound — since those are selected for the ID field
+already, so it needs no redundant object-level `select`.
+
 Runtime behaviour is unchanged — declaring `select` is still how a field
 adds a column dependency. To opt back into the old parent type, pass `Shape`
 explicitly: `builder.prismaObjectField<'User', Row<Types, 'User'>>('User', …)`.

--- a/packages/plugin-prisma-next/docs/interfaces.mdx
+++ b/packages/plugin-prisma-next/docs/interfaces.mdx
@@ -53,6 +53,10 @@ builder.prismaInterfaceField(personIface, 'displayName', (t) =>
 );
 ```
 
+As with [`prismaObjectField`](./objects#extending-prisma-objects), the string
+form's parent carries only the dependencies that field declared, so `select`
+is required for the resolver to read a column.
+
 If you pass the contract model name as a string, the plugin looks up
 the registered interface. If only an interface variant is registered
 (no default), pass the ref or the variant name explicitly — otherwise

--- a/packages/plugin-prisma-next/docs/objects.mdx
+++ b/packages/plugin-prisma-next/docs/objects.mdx
@@ -231,6 +231,31 @@ builder.prismaObjectField('User', 'displayName', (t) =>
 );
 ```
 
+The `select` is what makes those columns load, and the types say so: the
+string form can't see what another file declared, so its `user` parameter
+carries only the dependencies this field declared — reading an unselected
+column is a compile error instead of an `undefined` at query time. Passing a
+ref instead gives you whatever the registered object declared.
+
+If you need the old full-row parent back — mid-migration, say — `Shape` is
+the second type argument:
+
+```ts
+import type { Row } from '@pothos/plugin-prisma-next';
+
+type Types = PothosSchemaTypes.ExtendDefaultTypes<{ PrismaNextContract: Contract }>;
+
+builder.prismaObjectField<'User', Row<Types, 'User'>>('User', 'displayName', (t) =>
+  t.string({
+    select: ['firstName', 'lastName'],
+    resolve: (user) => `${user.firstName} ${user.lastName}`,
+  }),
+);
+```
+
+That only relaxes the type. The column still has to be selected to be there
+at runtime, so prefer declaring `select` over reaching for the escape hatch.
+
 The string form requires that `User` has already been registered as a
 prismaObject. If only a variant exists (see [Variants](./variants)),
 pass the variant's ref or variant name explicitly.

--- a/packages/plugin-prisma-next/docs/relay.mdx
+++ b/packages/plugin-prisma-next/docs/relay.mdx
@@ -56,8 +56,10 @@ interface, along with the standard global-ID encoding/decoding.
   Accepts either a static `Collection` or a `(ctx) => Collection`
   callback. The callback form is what you'll usually want — it lets
   you scope the query to the per-request context.
-- **`fields`**, **`isTypeOf`**, **`interfaces`**, …: same options as
-  `prismaObject`. A user-provided `isTypeOf` is respected without overriding a false result.
+- **`select`**, **`fields`**, **`isTypeOf`**, **`interfaces`**, …: same options as
+  `prismaObject`, including how `select` shapes the parent a field resolver
+  sees — a resolver only gets the columns and relations something declared.
+  A user-provided `isTypeOf` is respected without overriding a false result.
   The plugin does not install a brand-only predicate on concrete model types.
 
 ### Loading

--- a/packages/plugin-prisma-next/docs/variants.mdx
+++ b/packages/plugin-prisma-next/docs/variants.mdx
@@ -126,6 +126,10 @@ builder.prismaObjectField(adminUserRef, 'displayName', (t) =>
 );
 ```
 
+A ref hands the resolver the parent shape that ref declared; the string form
+can't see it, so its parent carries only what this field's own `select`
+declared. Either way, `select` is what loads the column.
+
 If only a variant is registered for a model and you try to reference the
 default (e.g. by passing the model name string to `t.relation('user')`
 from somewhere else), the schema build fails with an "unresolved

--- a/packages/plugin-prisma-next/src/global-types.ts
+++ b/packages/plugin-prisma-next/src/global-types.ts
@@ -60,19 +60,10 @@ type ObjectLevelShape<
 > = ShapeFromObjectSelect<Types, M, never, Select>;
 
 /**
- * Keys an object-form `select` names that the model doesn't have.
- *
- * A generic constraint alone can't catch these. TypeScript's excess-property
- * check only fires on a fresh object literal against a *concrete* target, and
- * once `Select` is a type parameter the literal is its own instantiation — so
- * `{ email: true, emial: true }` satisfies `SelectObjectSpec` structurally and
- * `emial` rides along, to be thrown on later by `compileSelect`. An all-invalid
- * literal still fails the constraint, which is why the mixed case is the one
- * that slips through and the one worth pinning.
- *
- * The array form needs none of this: its constraint is over the element type,
- * and a tuple has no excess-property leniency, so `['email', 'emial']` is
- * already rejected.
+ * Keys an object-form `select` names that the model doesn't have. Only the object form
+ * needs this: TypeScript's excess-property check fires on a fresh literal only against a
+ * *concrete* target, so once `Select` is a type parameter `{ email: true, emial: true }`
+ * satisfies `SelectObjectSpec` structurally and `emial` rides along.
  */
 type UnknownSelectKeys<
   Types extends SchemaTypes,
@@ -85,46 +76,34 @@ type UnknownSelectKeys<
     : never;
 
 /**
- * `unknown` when every object-form `select` key is real, otherwise a type that
- * nothing satisfies and whose text names the offending keys.
+ * `unknown` when every object-form `select` key is real, otherwise a type that nothing
+ * satisfies and whose text names the offending keys. Applied as a second intersected
+ * `select` member beside the bare `select?: Select` that does the inferring: `unknown` is
+ * the identity of `&`, so a valid select is untouched and an invalid one fails *on the
+ * `select` property*.
  *
- * Applied as a second intersected `select` member on the options parameter,
- * beside the bare `select?: Select` that does the inferring. `unknown` is the
- * identity of `&`, so a valid select is untouched; an invalid one intersects
- * with an unsatisfiable object and fails *on the `select` property*, which is
- * where the reader needs the squiggle. A defaulted phantom type parameter was
- * the other candidate, but TypeScript checks a parameter default against its
- * constraint at the declaration site, where `Select` is still unresolved — so
- * that form doesn't compile.
+ * Not a defaulted phantom type parameter: TypeScript checks a parameter default against
+ * its constraint at the declaration site, where `Select` is still unresolved.
  */
 type ExactSelectCheck<Types extends SchemaTypes, M extends ModelName<Types>, Select> = [
   UnknownSelectKeys<Types, M, Select>,
 ] extends [never]
   ? unknown
   : {
-      // The key *is* the message: TypeScript reports the missing required
-      // property by name, so the diagnostic reads as a sentence naming the
-      // offending key. The `never` value makes it unsatisfiable.
+      // The key *is* the message: TypeScript names the missing required property, so the
+      // diagnostic reads as a sentence. The `never` value makes it unsatisfiable.
       [K in UnknownSelectKeys<Types, M, Select> & string as `Unknown key in select: ${K}`]: never;
     };
 
 /**
- * Columns a `prismaNode`'s `id.field` declares.
+ * Columns a `prismaNode`'s `id.field` declares — the single column, or every column of a
+ * compound tuple.
  *
- * `id.field` is a dependency declaration in its own right: the schema builder
- * registers those columns in the ID field's own selection extensions
- * (`PRISMA_NEXT_FIELD_SELECT`, `schema-builder.ts`) before it calls
- * `id.resolve`, so a custom ID resolver really is handed them. Its parent is
- * therefore the object-level shape *plus* these — requiring a redundant
- * object-level `select` to read a column the ID already declared would reject
- * code that is correct at runtime.
- *
- *   - Single column `field: 'id'` → that column.
- *   - Compound `field: ['authorId', 'id']` → every column in the tuple.
- *
- * Scoped to `id.resolve` deliberately: the selection lives on the `id` field,
- * so other field resolvers on the same type still can't assume the ID columns
- * are present.
+ * `id.field` is a dependency declaration in its own right: the schema builder registers
+ * those columns in the ID field's own selection extensions (`PRISMA_NEXT_FIELD_SELECT`,
+ * `schema-builder.ts`) before it calls `id.resolve`, so a custom ID resolver really is
+ * handed them. Scoped to `id.resolve`: the selection lives on the `id` field, so other
+ * field resolvers on the same type still can't assume the ID columns are present.
  */
 type IdFieldShape<
   Types extends SchemaTypes,
@@ -227,23 +206,12 @@ declare global {
       /**
        * Add one field to an already-registered prismaObject from another file.
        *
-       * Parent shape: passing a `PrismaNextObjectRef` carries the shape the
-       * registered object declared. Passing a model-name *string* can't see
-       * that declaration, so the parent defaults to `ObjectBaseShape` — the
-       * brand and nothing else — matching what the plugin actually loads:
-       * only columns some `select` or `t.expose*` named. Declare the columns
-       * the resolver reads with the field's own `select`, which layers onto
-       * the base additively:
-       *
-       *     builder.prismaObjectField('User', 'emailish', (t) =>
-       *       t.string({ select: ['email'], resolve: (row) => row.email }),
-       *     );
-       *
-       * Escape hatch: `Shape` is the second positional type argument, so a
-       * caller who knowingly wants the full row back can ask for it —
-       * `builder.prismaObjectField<'User', Row<Types, 'User'>>('User', …)`.
-       * That opts out of the guarantee; the `select` is still what makes the
-       * column present at runtime.
+       * A `PrismaNextObjectRef` carries the shape the registered object declared; a
+       * model-name string can't see that declaration, so the parent is
+       * `ObjectBaseShape` — the brand and nothing else — and the field declares the
+       * columns its resolver reads with its own `select`, which layers onto the base
+       * additively. `Shape` is the second positional type argument for a caller who
+       * wants the full row back.
        */
       prismaObjectField: <M extends ModelName<Types>, Shape = ObjectBaseShape<Types, M>>(
         type: M | PrismaNextObjectRef<Types, M, Shape>,
@@ -258,12 +226,10 @@ declare global {
       ) => void;
 
       /**
-       * Add fields to an already-registered prismaObject from another file.
-       *
-       * Same parent-shape rule as `prismaObjectField`: a ref carries the declared
-       * shape, a model-name string defaults to `ObjectBaseShape` (brand only),
-       * and each field's own `select` adds the columns its resolver reads.
-       * `Shape` stays the second positional type argument as the escape hatch.
+       * Add fields to an already-registered prismaObject from another file. Same
+       * parent-shape rule as `prismaObjectField`: a ref carries the declared shape, a
+       * model-name string gives the brand-only `ObjectBaseShape`, and each field's own
+       * `select` adds the columns its resolver reads.
        */
       prismaObjectFields: <M extends ModelName<Types>, Shape = ObjectBaseShape<Types, M>>(
         type: M | PrismaNextObjectRef<Types, M, Shape>,
@@ -277,12 +243,10 @@ declare global {
       ) => void;
 
       /**
-       * Add one field to an already-registered prismaInterface from another file.
-       *
-       * Same parent-shape rule as `prismaObjectField`: a ref carries the declared
-       * shape, a model-name string defaults to `ObjectBaseShape` (brand only),
-       * and each field's own `select` adds the columns its resolver reads.
-       * `Shape` stays the second positional type argument as the escape hatch.
+       * Add one field to an already-registered prismaInterface from another file. Same
+       * parent-shape rule as `prismaObjectField`: a ref carries the declared shape, a
+       * model-name string gives the brand-only `ObjectBaseShape`, and each field's own
+       * `select` adds the columns its resolver reads.
        */
       prismaInterfaceField: <M extends ModelName<Types>, Shape = ObjectBaseShape<Types, M>>(
         type: M | PrismaNextInterfaceRef<Types, M, Shape>,
@@ -297,12 +261,10 @@ declare global {
       ) => void;
 
       /**
-       * Add fields to an already-registered prismaInterface from another file.
-       *
-       * Same parent-shape rule as `prismaObjectField`: a ref carries the declared
-       * shape, a model-name string defaults to `ObjectBaseShape` (brand only),
-       * and each field's own `select` adds the columns its resolver reads.
-       * `Shape` stays the second positional type argument as the escape hatch.
+       * Add fields to an already-registered prismaInterface from another file. Same
+       * parent-shape rule as `prismaObjectField`: a ref carries the declared shape, a
+       * model-name string gives the brand-only `ObjectBaseShape`, and each field's own
+       * `select` adds the columns its resolver reads.
        */
       prismaInterfaceFields: <M extends ModelName<Types>, Shape = ObjectBaseShape<Types, M>>(
         type: M | PrismaNextInterfaceRef<Types, M, Shape>,
@@ -316,23 +278,18 @@ declare global {
       ) => void;
 
       /**
-       * Register a prismaObject that also implements the Relay `Node` interface.
-       *
-       * The parent shape is computed from `select` exactly as `prismaObject`
-       * computes it (`ObjectLevelShape`), so a resolver only sees columns and
-       * relations something declared. `Select` is the third positional type
-       * argument and `Shape` the fourth, matching `prismaObject`'s ordering.
+       * Register a prismaObject that also implements the Relay `Node` interface. The
+       * parent shape is computed from `select` exactly as `prismaObject` computes it
+       * (`ObjectLevelShape`). `Select` is the third positional type argument and `Shape`
+       * the fourth, matching `prismaObject`'s ordering.
        */
       prismaNode: 'relay' extends PluginName
         ? <
             const Interfaces extends InterfaceParam<Types>[],
             M extends ModelName<Types>,
-            // Constrained, unlike `prismaObject`'s `Select`: routing `select`
-            // through a generic must not cost `prismaNode` the key validation
-            // it had when it passed `PrismaNextObjectOptions` through intact.
-            // `undefined` (rather than `unknown`) is the no-select default so
-            // the constraint is satisfiable; `ShapeFromObjectSelect` maps it to
-            // the brand-only base just as it maps `unknown`.
+            // `undefined`, not `unknown`, is the no-select default so the constraint
+            // stays satisfiable; `ShapeFromObjectSelect` maps either to the brand-only
+            // base.
             const Select extends
               | readonly (keyof Row<Types, M> & string)[]
               | SelectObjectSpec<Types, M>
@@ -373,10 +330,8 @@ declare global {
               collection:
                 | CollectionFor<Types, M>
                 | ((ctx: Types['Context']) => CollectionFor<Types, M>);
-              // The bare `select?: Select` above is the inference site; this
-              // intersected member is the exactness check. It resolves to
-              // `unknown` (a no-op in the intersection) for a valid select, and
-              // to an unsatisfiable type naming the bad keys otherwise.
+              // The bare `select?: Select` above is the inference site; this intersected
+              // member is the exactness check.
             } & { select?: ExactSelectCheck<Types, M, Select> },
           ) => PrismaNextNodeRef<Types, M, Shape, IDShape>
         : '@pothos/plugin-relay is required to use this method';

--- a/packages/plugin-prisma-next/src/global-types.ts
+++ b/packages/plugin-prisma-next/src/global-types.ts
@@ -14,6 +14,7 @@ import type {
 import type { PothosPrismaNextPlugin } from './index.js';
 import type { PrismaNextInterfaceRef } from './interface-ref.js';
 import type {
+  ObjectBaseShape,
   ParamToModelName,
   ParamToTypeParam,
   ShapeFromObjectSelect,
@@ -145,7 +146,28 @@ declare global {
         },
       ) => PrismaNextInterfaceRef<Types, M, Shape>;
 
-      prismaObjectField: <M extends ModelName<Types>, Shape = Row<Types, M>>(
+      /**
+       * Add one field to an already-registered prismaObject from another file.
+       *
+       * Parent shape: passing a `PrismaNextObjectRef` carries the shape the
+       * registered object declared. Passing a model-name *string* can't see
+       * that declaration, so the parent defaults to `ObjectBaseShape` — the
+       * brand and nothing else — matching what the plugin actually loads:
+       * only columns some `select` or `t.expose*` named. Declare the columns
+       * the resolver reads with the field's own `select`, which layers onto
+       * the base additively:
+       *
+       *     builder.prismaObjectField('User', 'emailish', (t) =>
+       *       t.string({ select: ['email'], resolve: (row) => row.email }),
+       *     );
+       *
+       * Escape hatch: `Shape` is the second positional type argument, so a
+       * caller who knowingly wants the full row back can ask for it —
+       * `builder.prismaObjectField<'User', Row<Types, 'User'>>('User', …)`.
+       * That opts out of the guarantee; the `select` is still what makes the
+       * column present at runtime.
+       */
+      prismaObjectField: <M extends ModelName<Types>, Shape = ObjectBaseShape<Types, M>>(
         type: M | PrismaNextObjectRef<Types, M, Shape>,
         fieldName: string,
         field: (
@@ -157,7 +179,15 @@ declare global {
         ) => FieldRef<Types, unknown>,
       ) => void;
 
-      prismaObjectFields: <M extends ModelName<Types>, Shape = Row<Types, M>>(
+      /**
+       * Add fields to an already-registered prismaObject from another file.
+       *
+       * Same parent-shape rule as `prismaObjectField`: a ref carries the declared
+       * shape, a model-name string defaults to `ObjectBaseShape` (brand only),
+       * and each field's own `select` adds the columns its resolver reads.
+       * `Shape` stays the second positional type argument as the escape hatch.
+       */
+      prismaObjectFields: <M extends ModelName<Types>, Shape = ObjectBaseShape<Types, M>>(
         type: M | PrismaNextObjectRef<Types, M, Shape>,
         fields: (
           t: import('./prisma-next-object-field-builder.js').PrismaNextObjectFieldBuilder<
@@ -168,7 +198,15 @@ declare global {
         ) => FieldMap,
       ) => void;
 
-      prismaInterfaceField: <M extends ModelName<Types>, Shape = Row<Types, M>>(
+      /**
+       * Add one field to an already-registered prismaInterface from another file.
+       *
+       * Same parent-shape rule as `prismaObjectField`: a ref carries the declared
+       * shape, a model-name string defaults to `ObjectBaseShape` (brand only),
+       * and each field's own `select` adds the columns its resolver reads.
+       * `Shape` stays the second positional type argument as the escape hatch.
+       */
+      prismaInterfaceField: <M extends ModelName<Types>, Shape = ObjectBaseShape<Types, M>>(
         type: M | PrismaNextInterfaceRef<Types, M, Shape>,
         fieldName: string,
         field: (
@@ -180,7 +218,15 @@ declare global {
         ) => FieldRef<Types, unknown>,
       ) => void;
 
-      prismaInterfaceFields: <M extends ModelName<Types>, Shape = Row<Types, M>>(
+      /**
+       * Add fields to an already-registered prismaInterface from another file.
+       *
+       * Same parent-shape rule as `prismaObjectField`: a ref carries the declared
+       * shape, a model-name string defaults to `ObjectBaseShape` (brand only),
+       * and each field's own `select` adds the columns its resolver reads.
+       * `Shape` stays the second positional type argument as the escape hatch.
+       */
+      prismaInterfaceFields: <M extends ModelName<Types>, Shape = ObjectBaseShape<Types, M>>(
         type: M | PrismaNextInterfaceRef<Types, M, Shape>,
         fields: (
           t: import('./prisma-next-object-field-builder.js').PrismaNextObjectFieldBuilder<
@@ -191,15 +237,25 @@ declare global {
         ) => FieldMap,
       ) => void;
 
+      /**
+       * Register a prismaObject that also implements the Relay `Node` interface.
+       *
+       * The parent shape is computed from `select` exactly as `prismaObject`
+       * computes it (`ObjectLevelShape`), so a resolver only sees columns and
+       * relations something declared. `Select` is the third positional type
+       * argument and `Shape` the fourth, matching `prismaObject`'s ordering.
+       */
       prismaNode: 'relay' extends PluginName
         ? <
             const Interfaces extends InterfaceParam<Types>[],
             M extends ModelName<Types>,
-            Shape = Row<Types, M>,
+            const Select = unknown,
+            Shape = ObjectLevelShape<Types, M, Select>,
             IDShape = string,
           >(
             modelName: M,
-            options: PrismaNextObjectOptions<Types, M, Shape, Interfaces> & {
+            options: Omit<PrismaNextObjectOptions<Types, M, Shape, Interfaces>, 'select'> & {
+              select?: Select;
               id: {
                 /** Column name or non-empty tuple for composite primary keys (encoded as a JSON array). */
                 field:

--- a/packages/plugin-prisma-next/src/global-types.ts
+++ b/packages/plugin-prisma-next/src/global-types.ts
@@ -58,6 +58,34 @@ type ObjectLevelShape<
   Select,
 > = ShapeFromObjectSelect<Types, M, never, Select>;
 
+/**
+ * Columns a `prismaNode`'s `id.field` declares.
+ *
+ * `id.field` is a dependency declaration in its own right: the schema builder
+ * registers those columns in the ID field's own selection extensions
+ * (`PRISMA_NEXT_FIELD_SELECT`, `schema-builder.ts`) before it calls
+ * `id.resolve`, so a custom ID resolver really is handed them. Its parent is
+ * therefore the object-level shape *plus* these — requiring a redundant
+ * object-level `select` to read a column the ID already declared would reject
+ * code that is correct at runtime.
+ *
+ *   - Single column `field: 'id'` → that column.
+ *   - Compound `field: ['authorId', 'id']` → every column in the tuple.
+ *
+ * Scoped to `id.resolve` deliberately: the selection lives on the `id` field,
+ * so other field resolvers on the same type still can't assume the ID columns
+ * are present.
+ */
+type IdFieldShape<
+  Types extends SchemaTypes,
+  M extends ModelName<Types>,
+  IDFields,
+> = IDFields extends readonly (infer K extends keyof Row<Types, M>)[]
+  ? Pick<Row<Types, M>, K>
+  : IDFields extends keyof Row<Types, M>
+    ? Pick<Row<Types, M>, IDFields>
+    : unknown;
+
 declare global {
   export namespace PothosSchemaTypes {
     export interface Plugins<Types extends SchemaTypes> {
@@ -252,15 +280,19 @@ declare global {
             const Select = unknown,
             Shape = ObjectLevelShape<Types, M, Select>,
             IDShape = string,
+            const IDFields extends
+              | (keyof Row<Types, M> & string)
+              | readonly [
+                  keyof Row<Types, M> & string,
+                  ...(keyof Row<Types, M> & string)[],
+                ] = keyof Row<Types, M> & string,
           >(
             modelName: M,
             options: Omit<PrismaNextObjectOptions<Types, M, Shape, Interfaces>, 'select'> & {
               select?: Select;
               id: {
                 /** Column name or non-empty tuple for composite primary keys (encoded as a JSON array). */
-                field:
-                  | (keyof Row<Types, M> & string)
-                  | readonly [keyof Row<Types, M> & string, ...(keyof Row<Types, M> & string)[]];
+                field: IDFields;
                 description?: string;
                 /** Restore nonstandard ORM values such as Temporal and Decimal IDs. */
                 codecs?: {
@@ -269,7 +301,15 @@ declare global {
                   >;
                 };
                 parse?: (id: string, ctx: Types['Context']) => IDShape;
-                resolve?: (parent: Shape, ctx: Types['Context']) => string | number;
+                /**
+                 * The parent is the object-level shape plus whatever `id.field`
+                 * named — those columns are selected for this field, so reading
+                 * them needs no extra `select`.
+                 */
+                resolve?: (
+                  parent: Shape & IdFieldShape<Types, M, IDFields>,
+                  ctx: Types['Context'],
+                ) => string | number;
               };
               collection:
                 | CollectionFor<Types, M>

--- a/packages/plugin-prisma-next/src/global-types.ts
+++ b/packages/plugin-prisma-next/src/global-types.ts
@@ -60,6 +60,55 @@ type ObjectLevelShape<
 > = ShapeFromObjectSelect<Types, M, never, Select>;
 
 /**
+ * Keys an object-form `select` names that the model doesn't have.
+ *
+ * A generic constraint alone can't catch these. TypeScript's excess-property
+ * check only fires on a fresh object literal against a *concrete* target, and
+ * once `Select` is a type parameter the literal is its own instantiation — so
+ * `{ email: true, emial: true }` satisfies `SelectObjectSpec` structurally and
+ * `emial` rides along, to be thrown on later by `compileSelect`. An all-invalid
+ * literal still fails the constraint, which is why the mixed case is the one
+ * that slips through and the one worth pinning.
+ *
+ * The array form needs none of this: its constraint is over the element type,
+ * and a tuple has no excess-property leniency, so `['email', 'emial']` is
+ * already rejected.
+ */
+type UnknownSelectKeys<
+  Types extends SchemaTypes,
+  M extends ModelName<Types>,
+  Select,
+> = Select extends readonly unknown[]
+  ? never
+  : Select extends object
+    ? Exclude<keyof Select, keyof SelectObjectSpec<Types, M>>
+    : never;
+
+/**
+ * `unknown` when every object-form `select` key is real, otherwise a type that
+ * nothing satisfies and whose text names the offending keys.
+ *
+ * Applied as a second intersected `select` member on the options parameter,
+ * beside the bare `select?: Select` that does the inferring. `unknown` is the
+ * identity of `&`, so a valid select is untouched; an invalid one intersects
+ * with an unsatisfiable object and fails *on the `select` property*, which is
+ * where the reader needs the squiggle. A defaulted phantom type parameter was
+ * the other candidate, but TypeScript checks a parameter default against its
+ * constraint at the declaration site, where `Select` is still unresolved — so
+ * that form doesn't compile.
+ */
+type ExactSelectCheck<Types extends SchemaTypes, M extends ModelName<Types>, Select> = [
+  UnknownSelectKeys<Types, M, Select>,
+] extends [never]
+  ? unknown
+  : {
+      // The key *is* the message: TypeScript reports the missing required
+      // property by name, so the diagnostic reads as a sentence naming the
+      // offending key. The `never` value makes it unsatisfiable.
+      [K in UnknownSelectKeys<Types, M, Select> & string as `Unknown key in select: ${K}`]: never;
+    };
+
+/**
  * Columns a `prismaNode`'s `id.field` declares.
  *
  * `id.field` is a dependency declaration in its own right: the schema builder
@@ -324,7 +373,11 @@ declare global {
               collection:
                 | CollectionFor<Types, M>
                 | ((ctx: Types['Context']) => CollectionFor<Types, M>);
-            },
+              // The bare `select?: Select` above is the inference site; this
+              // intersected member is the exactness check. It resolves to
+              // `unknown` (a no-op in the intersection) for a valid select, and
+              // to an unsatisfiable type naming the bad keys otherwise.
+            } & { select?: ExactSelectCheck<Types, M, Select> },
           ) => PrismaNextNodeRef<Types, M, Shape, IDShape>
         : '@pothos/plugin-relay is required to use this method';
     }

--- a/packages/plugin-prisma-next/src/global-types.ts
+++ b/packages/plugin-prisma-next/src/global-types.ts
@@ -60,10 +60,9 @@ type ObjectLevelShape<
 > = ShapeFromObjectSelect<Types, M, never, Select>;
 
 /**
- * Keys an object-form `select` names that the model doesn't have. Only the object form
- * needs this: TypeScript's excess-property check fires on a fresh literal only against a
- * *concrete* target, so once `Select` is a type parameter `{ email: true, emial: true }`
- * satisfies `SelectObjectSpec` structurally and `emial` rides along.
+ * Excess-property checking fires on a fresh object literal only against a concrete target:
+ * against a type parameter `Select`, `{ email: true, emial: true }` satisfies
+ * `SelectObjectSpec` structurally and `emial` rides along.
  */
 type UnknownSelectKeys<
   Types extends SchemaTypes,
@@ -76,12 +75,6 @@ type UnknownSelectKeys<
     : never;
 
 /**
- * `unknown` when every object-form `select` key is real, otherwise a type that nothing
- * satisfies and whose text names the offending keys. Applied as a second intersected
- * `select` member beside the bare `select?: Select` that does the inferring: `unknown` is
- * the identity of `&`, so a valid select is untouched and an invalid one fails *on the
- * `select` property*.
- *
  * Not a defaulted phantom type parameter: TypeScript checks a parameter default against
  * its constraint at the declaration site, where `Select` is still unresolved.
  */
@@ -90,20 +83,13 @@ type ExactSelectCheck<Types extends SchemaTypes, M extends ModelName<Types>, Sel
 ] extends [never]
   ? unknown
   : {
-      // The key *is* the message: TypeScript names the missing required property, so the
-      // diagnostic reads as a sentence. The `never` value makes it unsatisfiable.
+      // TypeScript names a missing required property in the diagnostic text.
       [K in UnknownSelectKeys<Types, M, Select> & string as `Unknown key in select: ${K}`]: never;
     };
 
 /**
- * Columns a `prismaNode`'s `id.field` declares — the single column, or every column of a
- * compound tuple.
- *
- * `id.field` is a dependency declaration in its own right: the schema builder registers
- * those columns in the ID field's own selection extensions (`PRISMA_NEXT_FIELD_SELECT`,
- * `schema-builder.ts`) before it calls `id.resolve`, so a custom ID resolver really is
- * handed them. Scoped to `id.resolve`: the selection lives on the `id` field, so other
- * field resolvers on the same type still can't assume the ID columns are present.
+ * `schema-builder.ts` registers `id.field`'s columns in the ID field's own selection
+ * extensions (`PRISMA_NEXT_FIELD_SELECT`) before calling `id.resolve`.
  */
 type IdFieldShape<
   Types extends SchemaTypes,
@@ -203,16 +189,6 @@ declare global {
         },
       ) => PrismaNextInterfaceRef<Types, M, Shape>;
 
-      /**
-       * Add one field to an already-registered prismaObject from another file.
-       *
-       * A `PrismaNextObjectRef` carries the shape the registered object declared; a
-       * model-name string can't see that declaration, so the parent is
-       * `ObjectBaseShape` — the brand and nothing else — and the field declares the
-       * columns its resolver reads with its own `select`, which layers onto the base
-       * additively. `Shape` is the second positional type argument for a caller who
-       * wants the full row back.
-       */
       prismaObjectField: <M extends ModelName<Types>, Shape = ObjectBaseShape<Types, M>>(
         type: M | PrismaNextObjectRef<Types, M, Shape>,
         fieldName: string,
@@ -225,12 +201,6 @@ declare global {
         ) => FieldRef<Types, unknown>,
       ) => void;
 
-      /**
-       * Add fields to an already-registered prismaObject from another file. Same
-       * parent-shape rule as `prismaObjectField`: a ref carries the declared shape, a
-       * model-name string gives the brand-only `ObjectBaseShape`, and each field's own
-       * `select` adds the columns its resolver reads.
-       */
       prismaObjectFields: <M extends ModelName<Types>, Shape = ObjectBaseShape<Types, M>>(
         type: M | PrismaNextObjectRef<Types, M, Shape>,
         fields: (
@@ -242,12 +212,6 @@ declare global {
         ) => FieldMap,
       ) => void;
 
-      /**
-       * Add one field to an already-registered prismaInterface from another file. Same
-       * parent-shape rule as `prismaObjectField`: a ref carries the declared shape, a
-       * model-name string gives the brand-only `ObjectBaseShape`, and each field's own
-       * `select` adds the columns its resolver reads.
-       */
       prismaInterfaceField: <M extends ModelName<Types>, Shape = ObjectBaseShape<Types, M>>(
         type: M | PrismaNextInterfaceRef<Types, M, Shape>,
         fieldName: string,
@@ -260,12 +224,6 @@ declare global {
         ) => FieldRef<Types, unknown>,
       ) => void;
 
-      /**
-       * Add fields to an already-registered prismaInterface from another file. Same
-       * parent-shape rule as `prismaObjectField`: a ref carries the declared shape, a
-       * model-name string gives the brand-only `ObjectBaseShape`, and each field's own
-       * `select` adds the columns its resolver reads.
-       */
       prismaInterfaceFields: <M extends ModelName<Types>, Shape = ObjectBaseShape<Types, M>>(
         type: M | PrismaNextInterfaceRef<Types, M, Shape>,
         fields: (
@@ -277,19 +235,10 @@ declare global {
         ) => FieldMap,
       ) => void;
 
-      /**
-       * Register a prismaObject that also implements the Relay `Node` interface. The
-       * parent shape is computed from `select` exactly as `prismaObject` computes it
-       * (`ObjectLevelShape`). `Select` is the third positional type argument and `Shape`
-       * the fourth, matching `prismaObject`'s ordering.
-       */
       prismaNode: 'relay' extends PluginName
         ? <
             const Interfaces extends InterfaceParam<Types>[],
             M extends ModelName<Types>,
-            // `undefined`, not `unknown`, is the no-select default so the constraint
-            // stays satisfiable; `ShapeFromObjectSelect` maps either to the brand-only
-            // base.
             const Select extends
               | readonly (keyof Row<Types, M> & string)[]
               | SelectObjectSpec<Types, M>
@@ -317,11 +266,6 @@ declare global {
                   >;
                 };
                 parse?: (id: string, ctx: Types['Context']) => IDShape;
-                /**
-                 * The parent is the object-level shape plus whatever `id.field`
-                 * named — those columns are selected for this field, so reading
-                 * them needs no extra `select`.
-                 */
                 resolve?: (
                   parent: Shape & IdFieldShape<Types, M, IDFields>,
                   ctx: Types['Context'],
@@ -330,8 +274,6 @@ declare global {
               collection:
                 | CollectionFor<Types, M>
                 | ((ctx: Types['Context']) => CollectionFor<Types, M>);
-              // The bare `select?: Select` above is the inference site; this intersected
-              // member is the exactness check.
             } & { select?: ExactSelectCheck<Types, M, Select> },
           ) => PrismaNextNodeRef<Types, M, Shape, IDShape>
         : '@pothos/plugin-relay is required to use this method';

--- a/packages/plugin-prisma-next/src/global-types.ts
+++ b/packages/plugin-prisma-next/src/global-types.ts
@@ -59,11 +59,6 @@ type ObjectLevelShape<
   Select,
 > = ShapeFromObjectSelect<Types, M, never, Select>;
 
-/**
- * Excess-property checking fires on a fresh object literal only against a concrete target:
- * against a type parameter `Select`, `{ email: true, emial: true }` satisfies
- * `SelectObjectSpec` structurally and `emial` rides along.
- */
 type UnknownSelectKeys<
   Types extends SchemaTypes,
   M extends ModelName<Types>,
@@ -74,23 +69,14 @@ type UnknownSelectKeys<
     ? Exclude<keyof Select, keyof SelectObjectSpec<Types, M>>
     : never;
 
-/**
- * Not a defaulted phantom type parameter: TypeScript checks a parameter default against
- * its constraint at the declaration site, where `Select` is still unresolved.
- */
 type ExactSelectCheck<Types extends SchemaTypes, M extends ModelName<Types>, Select> = [
   UnknownSelectKeys<Types, M, Select>,
 ] extends [never]
   ? unknown
   : {
-      // TypeScript names a missing required property in the diagnostic text.
       [K in UnknownSelectKeys<Types, M, Select> & string as `Unknown key in select: ${K}`]: never;
     };
 
-/**
- * `schema-builder.ts` registers `id.field`'s columns in the ID field's own selection
- * extensions (`PRISMA_NEXT_FIELD_SELECT`) before calling `id.resolve`.
- */
 type IdFieldShape<
   Types extends SchemaTypes,
   M extends ModelName<Types>,

--- a/packages/plugin-prisma-next/src/global-types.ts
+++ b/packages/plugin-prisma-next/src/global-types.ts
@@ -17,6 +17,7 @@ import type {
   ObjectBaseShape,
   ParamToModelName,
   ParamToTypeParam,
+  SelectObjectSpec,
   ShapeFromObjectSelect,
 } from './internal-types.js';
 import type { PrismaNextNodeRef } from './node-ref.js';
@@ -277,7 +278,16 @@ declare global {
         ? <
             const Interfaces extends InterfaceParam<Types>[],
             M extends ModelName<Types>,
-            const Select = unknown,
+            // Constrained, unlike `prismaObject`'s `Select`: routing `select`
+            // through a generic must not cost `prismaNode` the key validation
+            // it had when it passed `PrismaNextObjectOptions` through intact.
+            // `undefined` (rather than `unknown`) is the no-select default so
+            // the constraint is satisfiable; `ShapeFromObjectSelect` maps it to
+            // the brand-only base just as it maps `unknown`.
+            const Select extends
+              | readonly (keyof Row<Types, M> & string)[]
+              | SelectObjectSpec<Types, M>
+              | undefined = undefined,
             Shape = ObjectLevelShape<Types, M, Select>,
             IDShape = string,
             const IDFields extends

--- a/packages/plugin-prisma-next/tests/cross-file-helper-shape.test-d.ts
+++ b/packages/plugin-prisma-next/tests/cross-file-helper-shape.test-d.ts
@@ -16,15 +16,8 @@ type Types = PothosSchemaTypes.ExtendDefaultTypes<{ PrismaNextContract: Contract
 //
 // ── Negative fixtures ───────────────────────────────────────────────────
 //
-// The string form of the four cross-file helpers must NOT promise
-// columns nobody declared. Only `select` (object-level or field-level)
-// or `t.expose*` creates a column dependency at runtime, so reading a
-// column off the parent without declaring it has to be a type error —
-// otherwise the first symptom is `Cannot return null for non-nullable
-// field User.email` at query time.
-//
-// Each `@ts-expect-error` below must stay *used*: an unused-directive
-// diagnostic is the regression signal if the narrowing stops applying.
+// Each `@ts-expect-error` below is the assertion: an unused-directive
+// diagnostic means the narrowing stopped applying.
 //
 
 builder.prismaObjectField('User', 'undeclaredViaObjectField', (t) =>
@@ -55,8 +48,6 @@ builder.prismaInterfaceFields('User', (t) => ({
   }),
 }));
 
-// `prismaNode` shares the defect and the fix: its parent shape is
-// computed from its own `select` rather than defaulted to the full row.
 builder.prismaNode('User', {
   variant: 'UndeclaredNode',
   id: { field: 'id' },
@@ -69,11 +60,6 @@ builder.prismaNode('User', {
   }),
 });
 
-// …but `id.field` *is* a declaration. `schema-builder.ts` registers those
-// columns in the ID field's own selection extensions
-// (`PRISMA_NEXT_FIELD_SELECT`) before calling `id.resolve`, so the custom ID
-// resolver really does receive them and must not need a redundant
-// object-level `select` to read them.
 builder.prismaNode('User', {
   variant: 'CustomIdResolverNode',
   id: {
@@ -87,7 +73,6 @@ builder.prismaNode('User', {
   fields: (t) => ({ firstName: t.exposeString('firstName') }),
 });
 
-// Every column a compound `id.field` names is declared, not just the first.
 builder.prismaNode('Post', {
   variant: 'CompoundIdResolverNode',
   id: {
@@ -102,8 +87,6 @@ builder.prismaNode('Post', {
   fields: (t) => ({ title: t.exposeString('title') }),
 });
 
-// The widening is scoped to what `id.field` declared — a column outside it is
-// still rejected, which is the whole point of the change.
 builder.prismaNode('User', {
   variant: 'CustomIdResolverUndeclaredNode',
   id: {
@@ -115,8 +98,6 @@ builder.prismaNode('User', {
   fields: (t) => ({ firstName: t.exposeString('firstName') }),
 });
 
-// `id.field` is now an inference site; it must still reject a column the model
-// doesn't have.
 builder.prismaNode('User', {
   variant: 'BadIdFieldNode',
   // @ts-expect-error `nope` is not a column of `User`.
@@ -125,8 +106,6 @@ builder.prismaNode('User', {
   fields: (t) => ({ firstName: t.exposeString('firstName') }),
 });
 
-// `id.field` columns compose with an object-level `select` rather than
-// replacing it.
 builder.prismaNode('User', {
   variant: 'CustomIdResolverSelectNode',
   select: ['email'],
@@ -142,10 +121,6 @@ builder.prismaNode('User', {
   fields: (t) => ({ firstName: t.exposeString('firstName') }),
 });
 
-// Routing `select` through a generic must not cost `prismaNode` its key
-// validation: a misspelled column has to fail at the call site, not turn into
-// a `no such column` at query time — which is the very failure mode this
-// change exists to remove.
 builder.prismaNode('User', {
   variant: 'TypoArraySelectNode',
   // @ts-expect-error `emial` is not a column of `User`.
@@ -173,11 +148,6 @@ builder.prismaNode('User', {
   fields: (t) => ({ firstName: t.exposeString('firstName') }),
 });
 
-// The realistic typo is one bad key among good ones — nobody misspells every
-// key. A generic constraint alone does not catch this: excess-property
-// checking only fires on a fresh literal against a concrete target, and a
-// literal with one valid key already satisfies the constraint. The extra key
-// has to be rejected explicitly, in both the object and the array form.
 builder.prismaNode('User', {
   variant: 'MixedTypoObjectSelectNode',
   // @ts-expect-error `emial` is not a column of `User`, even beside a valid key.
@@ -208,12 +178,7 @@ builder.prismaNode('User', {
 //
 // ── Positive fixtures ───────────────────────────────────────────────────
 //
-// Everything below is correct at runtime today and must keep compiling.
-//
 
-// Field-level `select` layers additively onto the brand-only base — this
-// is the case the narrowing would break if `ShapeFromSelect` failed to
-// compose with `ObjectBaseShape`. Array form:
 builder.prismaObjectField('User', 'declaredArrayForm', (t) =>
   t.string({
     select: ['email'],
@@ -224,7 +189,6 @@ builder.prismaObjectField('User', 'declaredArrayForm', (t) =>
   }),
 );
 
-// …and object form, including relations.
 builder.prismaObjectFields('User', (t) => ({
   declaredObjectForm: t.string({
     select: { email: true, posts: true },
@@ -271,8 +235,8 @@ builder.prismaNode('User', {
   }),
 });
 
-// `t.expose*` is checked against the builder's separate `ExposableShape`
-// generic, not `Shape`, so narrowing `Shape` must leave it alone.
+// `t.expose*` is checked against the builder's separate `ExposableShape` generic,
+// not `Shape`.
 builder.prismaObjectFields('User', (t) => ({
   exposedFirstName: t.exposeString('firstName'),
   exposedId: t.exposeID('id'),
@@ -284,11 +248,10 @@ builder.prismaInterfaceFields('User', (t) => ({
 }));
 
 //
-// ── The ref form is unchanged ───────────────────────────────────────────
+// ── The ref form ────────────────────────────────────────────────────────
 //
-// Passing a ref infers `Shape` from the ref, so it already reported the
-// undeclared read before this change and must still report it — and must
-// still see whatever the registered object declared.
+// Passing a ref infers `Shape` from the ref, so the parent is whatever the
+// registered object declared.
 //
 
 const bareUserRef = builder.prismaObject('User', {
@@ -321,11 +284,9 @@ builder.prismaObjectFields(selectedUserRef, (t) => ({
 //
 // ── Escape hatch ────────────────────────────────────────────────────────
 //
-// `Shape` is the second positional type parameter, so anyone who really
-// wants the old full-row parent can ask for it explicitly. This is the
-// documented unblock for a mid-migration compile error; it opts out of
-// the guarantee, so the `select` must still be declared for the read to
-// work at runtime.
+// `Shape` is the second positional type parameter, so a caller can ask for
+// the full-row parent explicitly. The `select` is still what makes the
+// column present at runtime.
 //
 
 builder.prismaObjectField<'User', Row<Types, 'User'>>('User', 'escapeHatch', (t) =>

--- a/packages/plugin-prisma-next/tests/cross-file-helper-shape.test-d.ts
+++ b/packages/plugin-prisma-next/tests/cross-file-helper-shape.test-d.ts
@@ -142,6 +142,37 @@ builder.prismaNode('User', {
   fields: (t) => ({ firstName: t.exposeString('firstName') }),
 });
 
+// Routing `select` through a generic must not cost `prismaNode` its key
+// validation: a misspelled column has to fail at the call site, not turn into
+// a `no such column` at query time — which is the very failure mode this
+// change exists to remove.
+builder.prismaNode('User', {
+  variant: 'TypoArraySelectNode',
+  // @ts-expect-error `emial` is not a column of `User`.
+  select: ['emial'],
+  id: { field: 'id' },
+  collection: null as never,
+  fields: (t) => ({ firstName: t.exposeString('firstName') }),
+});
+
+builder.prismaNode('User', {
+  variant: 'TypoObjectSelectNode',
+  // @ts-expect-error `nosuchcolumn` is not a column of `User`.
+  select: { nosuchcolumn: true },
+  id: { field: 'id' },
+  collection: null as never,
+  fields: (t) => ({ firstName: t.exposeString('firstName') }),
+});
+
+builder.prismaNode('User', {
+  variant: 'TypoRelationSelectNode',
+  // @ts-expect-error `psots` is not a relation of `User`.
+  select: { psots: { limit: 3 } },
+  id: { field: 'id' },
+  collection: null as never,
+  fields: (t) => ({ firstName: t.exposeString('firstName') }),
+});
+
 //
 // ── Positive fixtures ───────────────────────────────────────────────────
 //

--- a/packages/plugin-prisma-next/tests/cross-file-helper-shape.test-d.ts
+++ b/packages/plugin-prisma-next/tests/cross-file-helper-shape.test-d.ts
@@ -1,0 +1,203 @@
+import SchemaBuilder from '@pothos/core';
+import RelayPlugin from '@pothos/plugin-relay';
+import type { DefaultModelRow } from '@prisma/orm-family-sql/orm-client';
+import { expectTypeOf } from 'vitest';
+import prismaNextPlugin, { type Row } from '../src';
+import type { Contract } from './fixtures/sample-contract';
+
+const builder = new SchemaBuilder<{ PrismaNextContract: Contract }>({
+  plugins: [RelayPlugin, prismaNextPlugin],
+  relay: {},
+  prismaNext: { contract: null as never },
+});
+
+type Types = PothosSchemaTypes.ExtendDefaultTypes<{ PrismaNextContract: Contract }>;
+
+//
+// ── Negative fixtures ───────────────────────────────────────────────────
+//
+// The string form of the four cross-file helpers must NOT promise
+// columns nobody declared. Only `select` (object-level or field-level)
+// or `t.expose*` creates a column dependency at runtime, so reading a
+// column off the parent without declaring it has to be a type error —
+// otherwise the first symptom is `Cannot return null for non-nullable
+// field User.email` at query time.
+//
+// Each `@ts-expect-error` below must stay *used*: an unused-directive
+// diagnostic is the regression signal if the narrowing stops applying.
+//
+
+builder.prismaObjectField('User', 'undeclaredViaObjectField', (t) =>
+  t.string({
+    // @ts-expect-error The string form's parent carries only declared dependencies.
+    resolve: (row) => row.email,
+  }),
+);
+
+builder.prismaObjectFields('User', (t) => ({
+  undeclaredViaObjectFields: t.string({
+    // @ts-expect-error The string form's parent carries only declared dependencies.
+    resolve: (row) => row.email,
+  }),
+}));
+
+builder.prismaInterfaceField('User', 'undeclaredViaInterfaceField', (t) =>
+  t.string({
+    // @ts-expect-error The string form's parent carries only declared dependencies.
+    resolve: (row) => row.email,
+  }),
+);
+
+builder.prismaInterfaceFields('User', (t) => ({
+  undeclaredViaInterfaceFields: t.string({
+    // @ts-expect-error The string form's parent carries only declared dependencies.
+    resolve: (row) => row.email,
+  }),
+}));
+
+// `prismaNode` shares the defect and the fix: its parent shape is
+// computed from its own `select` rather than defaulted to the full row.
+builder.prismaNode('User', {
+  variant: 'UndeclaredNode',
+  id: { field: 'id' },
+  collection: null as never,
+  fields: (t) => ({
+    undeclared: t.string({
+      // @ts-expect-error `prismaNode`'s parent carries only declared dependencies.
+      resolve: (row) => row.email,
+    }),
+  }),
+});
+
+//
+// ── Positive fixtures ───────────────────────────────────────────────────
+//
+// Everything below is correct at runtime today and must keep compiling.
+//
+
+// Field-level `select` layers additively onto the brand-only base — this
+// is the case the narrowing would break if `ShapeFromSelect` failed to
+// compose with `ObjectBaseShape`. Array form:
+builder.prismaObjectField('User', 'declaredArrayForm', (t) =>
+  t.string({
+    select: ['email'],
+    resolve: (row) => {
+      expectTypeOf(row.email).toEqualTypeOf<string>();
+      return row.email;
+    },
+  }),
+);
+
+// …and object form, including relations.
+builder.prismaObjectFields('User', (t) => ({
+  declaredObjectForm: t.string({
+    select: { email: true, posts: true },
+    resolve: (row) => {
+      expectTypeOf(row.email).toEqualTypeOf<string>();
+      expectTypeOf(row.posts).toEqualTypeOf<readonly DefaultModelRow<Contract, 'Post'>[]>();
+      return `${row.email}:${row.posts.length}`;
+    },
+  }),
+}));
+
+builder.prismaInterfaceField('User', 'declaredOnInterfaceField', (t) =>
+  t.string({
+    select: ['email'],
+    resolve: (row) => {
+      expectTypeOf(row.email).toEqualTypeOf<string>();
+      return row.email;
+    },
+  }),
+);
+
+builder.prismaInterfaceFields('User', (t) => ({
+  declaredOnInterfaceFields: t.string({
+    select: ['lastName'],
+    resolve: (row) => {
+      expectTypeOf(row.lastName).toEqualTypeOf<string>();
+      return row.lastName;
+    },
+  }),
+}));
+
+builder.prismaNode('User', {
+  variant: 'DeclaredNode',
+  select: ['email'],
+  id: { field: 'id' },
+  collection: null as never,
+  fields: (t) => ({
+    declared: t.string({
+      resolve: (row) => {
+        expectTypeOf(row.email).toEqualTypeOf<string>();
+        return row.email;
+      },
+    }),
+  }),
+});
+
+// `t.expose*` is checked against the builder's separate `ExposableShape`
+// generic, not `Shape`, so narrowing `Shape` must leave it alone.
+builder.prismaObjectFields('User', (t) => ({
+  exposedFirstName: t.exposeString('firstName'),
+  exposedId: t.exposeID('id'),
+  relatedPosts: t.relation('posts'),
+}));
+
+builder.prismaInterfaceFields('User', (t) => ({
+  interfaceExposedFirstName: t.exposeString('firstName'),
+}));
+
+//
+// ── The ref form is unchanged ───────────────────────────────────────────
+//
+// Passing a ref infers `Shape` from the ref, so it already reported the
+// undeclared read before this change and must still report it — and must
+// still see whatever the registered object declared.
+//
+
+const bareUserRef = builder.prismaObject('User', {
+  variant: 'BareRefUser',
+  fields: (t) => ({ id: t.exposeID('id') }),
+});
+
+builder.prismaObjectField(bareUserRef, 'undeclaredViaRef', (t) =>
+  t.string({
+    // @ts-expect-error The ref's shape carries only what the object declared.
+    resolve: (row) => row.email,
+  }),
+);
+
+const selectedUserRef = builder.prismaObject('User', {
+  variant: 'SelectedRefUser',
+  select: ['email'],
+  fields: (t) => ({ id: t.exposeID('id') }),
+});
+
+builder.prismaObjectFields(selectedUserRef, (t) => ({
+  declaredViaRef: t.string({
+    resolve: (row) => {
+      expectTypeOf(row.email).toEqualTypeOf<string>();
+      return row.email;
+    },
+  }),
+}));
+
+//
+// ── Escape hatch ────────────────────────────────────────────────────────
+//
+// `Shape` is the second positional type parameter, so anyone who really
+// wants the old full-row parent can ask for it explicitly. This is the
+// documented unblock for a mid-migration compile error; it opts out of
+// the guarantee, so the `select` must still be declared for the read to
+// work at runtime.
+//
+
+builder.prismaObjectField<'User', Row<Types, 'User'>>('User', 'escapeHatch', (t) =>
+  t.string({
+    select: ['email'],
+    resolve: (row) => {
+      expectTypeOf(row.email).toEqualTypeOf<string>();
+      return row.email;
+    },
+  }),
+);

--- a/packages/plugin-prisma-next/tests/cross-file-helper-shape.test-d.ts
+++ b/packages/plugin-prisma-next/tests/cross-file-helper-shape.test-d.ts
@@ -173,6 +173,38 @@ builder.prismaNode('User', {
   fields: (t) => ({ firstName: t.exposeString('firstName') }),
 });
 
+// The realistic typo is one bad key among good ones — nobody misspells every
+// key. A generic constraint alone does not catch this: excess-property
+// checking only fires on a fresh literal against a concrete target, and a
+// literal with one valid key already satisfies the constraint. The extra key
+// has to be rejected explicitly, in both the object and the array form.
+builder.prismaNode('User', {
+  variant: 'MixedTypoObjectSelectNode',
+  // @ts-expect-error `emial` is not a column of `User`, even beside a valid key.
+  select: { email: true, emial: true },
+  id: { field: 'id' },
+  collection: null as never,
+  fields: (t) => ({ firstName: t.exposeString('firstName') }),
+});
+
+builder.prismaNode('User', {
+  variant: 'MixedTypoRelationSelectNode',
+  // @ts-expect-error `psots` is not a relation of `User`, even beside a valid key.
+  select: { posts: true, psots: { limit: 3 } },
+  id: { field: 'id' },
+  collection: null as never,
+  fields: (t) => ({ firstName: t.exposeString('firstName') }),
+});
+
+builder.prismaNode('User', {
+  variant: 'MixedTypoArraySelectNode',
+  // @ts-expect-error `emial` is not a column of `User`, even beside a valid one.
+  select: ['email', 'emial'],
+  id: { field: 'id' },
+  collection: null as never,
+  fields: (t) => ({ firstName: t.exposeString('firstName') }),
+});
+
 //
 // ── Positive fixtures ───────────────────────────────────────────────────
 //

--- a/packages/plugin-prisma-next/tests/cross-file-helper-shape.test-d.ts
+++ b/packages/plugin-prisma-next/tests/cross-file-helper-shape.test-d.ts
@@ -13,13 +13,6 @@ const builder = new SchemaBuilder<{ PrismaNextContract: Contract }>({
 
 type Types = PothosSchemaTypes.ExtendDefaultTypes<{ PrismaNextContract: Contract }>;
 
-//
-// ── Negative fixtures ───────────────────────────────────────────────────
-//
-// Each `@ts-expect-error` below is the assertion: an unused-directive
-// diagnostic means the narrowing stopped applying.
-//
-
 builder.prismaObjectField('User', 'undeclaredViaObjectField', (t) =>
   t.string({
     // @ts-expect-error The string form's parent carries only declared dependencies.
@@ -175,10 +168,6 @@ builder.prismaNode('User', {
   fields: (t) => ({ firstName: t.exposeString('firstName') }),
 });
 
-//
-// ── Positive fixtures ───────────────────────────────────────────────────
-//
-
 builder.prismaObjectField('User', 'declaredArrayForm', (t) =>
   t.string({
     select: ['email'],
@@ -235,8 +224,6 @@ builder.prismaNode('User', {
   }),
 });
 
-// `t.expose*` is checked against the builder's separate `ExposableShape` generic,
-// not `Shape`.
 builder.prismaObjectFields('User', (t) => ({
   exposedFirstName: t.exposeString('firstName'),
   exposedId: t.exposeID('id'),
@@ -246,13 +233,6 @@ builder.prismaObjectFields('User', (t) => ({
 builder.prismaInterfaceFields('User', (t) => ({
   interfaceExposedFirstName: t.exposeString('firstName'),
 }));
-
-//
-// ── The ref form ────────────────────────────────────────────────────────
-//
-// Passing a ref infers `Shape` from the ref, so the parent is whatever the
-// registered object declared.
-//
 
 const bareUserRef = builder.prismaObject('User', {
   variant: 'BareRefUser',
@@ -280,14 +260,6 @@ builder.prismaObjectFields(selectedUserRef, (t) => ({
     },
   }),
 }));
-
-//
-// ── Escape hatch ────────────────────────────────────────────────────────
-//
-// `Shape` is the second positional type parameter, so a caller can ask for
-// the full-row parent explicitly. The `select` is still what makes the
-// column present at runtime.
-//
 
 builder.prismaObjectField<'User', Row<Types, 'User'>>('User', 'escapeHatch', (t) =>
   t.string({

--- a/packages/plugin-prisma-next/tests/cross-file-helper-shape.test-d.ts
+++ b/packages/plugin-prisma-next/tests/cross-file-helper-shape.test-d.ts
@@ -69,6 +69,79 @@ builder.prismaNode('User', {
   }),
 });
 
+// …but `id.field` *is* a declaration. `schema-builder.ts` registers those
+// columns in the ID field's own selection extensions
+// (`PRISMA_NEXT_FIELD_SELECT`) before calling `id.resolve`, so the custom ID
+// resolver really does receive them and must not need a redundant
+// object-level `select` to read them.
+builder.prismaNode('User', {
+  variant: 'CustomIdResolverNode',
+  id: {
+    field: 'id',
+    resolve: (row) => {
+      expectTypeOf(row.id).toEqualTypeOf<string>();
+      return row.id;
+    },
+  },
+  collection: null as never,
+  fields: (t) => ({ firstName: t.exposeString('firstName') }),
+});
+
+// Every column a compound `id.field` names is declared, not just the first.
+builder.prismaNode('Post', {
+  variant: 'CompoundIdResolverNode',
+  id: {
+    field: ['authorId', 'id'],
+    resolve: (row) => {
+      expectTypeOf(row.authorId).toEqualTypeOf<string>();
+      expectTypeOf(row.id).toEqualTypeOf<string>();
+      return `${row.authorId}:${row.id}`;
+    },
+  },
+  collection: null as never,
+  fields: (t) => ({ title: t.exposeString('title') }),
+});
+
+// The widening is scoped to what `id.field` declared — a column outside it is
+// still rejected, which is the whole point of the change.
+builder.prismaNode('User', {
+  variant: 'CustomIdResolverUndeclaredNode',
+  id: {
+    field: 'id',
+    // @ts-expect-error `email` is declared by neither `id.field` nor `select`.
+    resolve: (row) => row.email,
+  },
+  collection: null as never,
+  fields: (t) => ({ firstName: t.exposeString('firstName') }),
+});
+
+// `id.field` is now an inference site; it must still reject a column the model
+// doesn't have.
+builder.prismaNode('User', {
+  variant: 'BadIdFieldNode',
+  // @ts-expect-error `nope` is not a column of `User`.
+  id: { field: 'nope' },
+  collection: null as never,
+  fields: (t) => ({ firstName: t.exposeString('firstName') }),
+});
+
+// `id.field` columns compose with an object-level `select` rather than
+// replacing it.
+builder.prismaNode('User', {
+  variant: 'CustomIdResolverSelectNode',
+  select: ['email'],
+  id: {
+    field: 'id',
+    resolve: (row) => {
+      expectTypeOf(row.id).toEqualTypeOf<string>();
+      expectTypeOf(row.email).toEqualTypeOf<string>();
+      return `${row.id}:${row.email}`;
+    },
+  },
+  collection: null as never,
+  fields: (t) => ({ firstName: t.exposeString('firstName') }),
+});
+
 //
 // ── Positive fixtures ───────────────────────────────────────────────────
 //

--- a/packages/plugin-prisma-next/tests/normalization-runtime.test.ts
+++ b/packages/plugin-prisma-next/tests/normalization-runtime.test.ts
@@ -75,9 +75,6 @@ it('normalizes computed counts across connection, nested relation and node loadi
     isTypeOf: () => true,
     id: { field: 'id' },
     collection: ctx.ormClient.User,
-    // `sub` is annotated for the same reason as the `prismaObject` below:
-    // the `select` option feeds the `const Select` generic that computes the
-    // parent shape, so it can't also contextually type the refinement callback.
     select: {
       posts: (
         sub: RelationRefinementCollection<

--- a/packages/plugin-prisma-next/tests/normalization-runtime.test.ts
+++ b/packages/plugin-prisma-next/tests/normalization-runtime.test.ts
@@ -75,7 +75,18 @@ it('normalizes computed counts across connection, nested relation and node loadi
     isTypeOf: () => true,
     id: { field: 'id' },
     collection: ctx.ormClient.User,
-    select: { posts: (sub) => ({ total: sub.count() }) },
+    // `sub` is annotated for the same reason as the `prismaObject` below:
+    // the `select` option feeds the `const Select` generic that computes the
+    // parent shape, so it can't also contextually type the refinement callback.
+    select: {
+      posts: (
+        sub: RelationRefinementCollection<
+          PothosSchemaTypes.ExtendDefaultTypes<{ PrismaNextContract: SampleContract }>,
+          'User',
+          'posts'
+        >,
+      ) => ({ total: sub.count() }),
+    },
     fields: (t) => ({
       total: t.int({ resolve: (p) => (p as typeof p & { total: number }).total }),
       postsPage: t.relatedConnection('posts', {

--- a/packages/plugin-prisma-next/tests/release-correctness.test.ts
+++ b/packages/plugin-prisma-next/tests/release-correctness.test.ts
@@ -110,6 +110,56 @@ describe('Relay node types across planned entry points', () => {
     expect(sql).not.toMatch(/postConnection:rows|"title"|"score"/i);
   });
 
+  it('hands a custom id.resolve the columns declared by id.field', async () => {
+    const builder = new SchemaBuilder<{ PrismaNextContract: SampleContract }>({
+      plugins: [RelayPlugin, prismaNextPlugin],
+      relay: {},
+      prismaNext: { contract: ctx.contract },
+    });
+    // Neither node declares an object-level `select`: `id.field` is the only
+    // declaration of these columns, and the ID field's own selection
+    // extensions are what load them. Both the single-column and the compound
+    // form have to reach the custom resolver.
+    builder.prismaNode('User', {
+      id: { field: 'id', resolve: (row) => `u:${row.id}` },
+      collection: ctx.ormClient.User,
+      fields: (t) => ({ firstName: t.exposeString('firstName') }),
+    });
+    builder.prismaNode('Post', {
+      id: { field: ['authorId', 'id'], resolve: (row) => `${row.authorId}/${row.id}` },
+      collection: ctx.ormClient.Post,
+      fields: (t) => ({ title: t.exposeString('title') }),
+    });
+    builder.queryType({
+      fields: (t) => ({
+        user: t.prismaField({
+          type: 'User',
+          resolve: () => ctx.ormClient.User.where({ id: 'u-alice' }),
+        }),
+        post: t.prismaField({
+          type: 'Post',
+          resolve: () => ctx.ormClient.Post.where({ id: 'p-hello' }),
+        }),
+      }),
+    });
+    const result = await execute({
+      schema: builder.toSchema(),
+      document: parse('{ user { id firstName } post { id title } }'),
+      contextValue: {},
+    });
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({
+      user: {
+        id: Buffer.from('User:u:u-alice').toString('base64'),
+        firstName: 'Alice',
+      },
+      post: {
+        id: Buffer.from('Post:u-alice/p-hello').toString('base64'),
+        title: 'Hello, Pothos',
+      },
+    });
+  });
+
   it('still resolves the abstract Node interface with the loader brand', async () => {
     const result = await execute({
       schema: nodeSchema(),

--- a/packages/plugin-prisma-next/tests/release-correctness.test.ts
+++ b/packages/plugin-prisma-next/tests/release-correctness.test.ts
@@ -116,8 +116,6 @@ describe('Relay node types across planned entry points', () => {
       relay: {},
       prismaNext: { contract: ctx.contract },
     });
-    // Neither node declares an object-level `select`: `id.field` is the only
-    // declaration of these columns.
     builder.prismaNode('User', {
       id: { field: 'id', resolve: (row) => `u:${row.id}` },
       collection: ctx.ormClient.User,

--- a/packages/plugin-prisma-next/tests/release-correctness.test.ts
+++ b/packages/plugin-prisma-next/tests/release-correctness.test.ts
@@ -117,9 +117,7 @@ describe('Relay node types across planned entry points', () => {
       prismaNext: { contract: ctx.contract },
     });
     // Neither node declares an object-level `select`: `id.field` is the only
-    // declaration of these columns, and the ID field's own selection
-    // extensions are what load them. Both the single-column and the compound
-    // form have to reach the custom resolver.
+    // declaration of these columns.
     builder.prismaNode('User', {
       id: { field: 'id', resolve: (row) => `u:${row.id}` },
       collection: ctx.ormClient.User,

--- a/packages/plugin-prisma-next/tests/scope-auth.test.ts
+++ b/packages/plugin-prisma-next/tests/scope-auth.test.ts
@@ -111,3 +111,32 @@ it('does not execute the root collection when a root scope denies access', async
   expect(result.data).toEqual({ privateUser: null });
   expect(captures).toHaveLength(0);
 });
+
+// Type-level fixture, never executed: the cross-file helpers' narrowed parent
+// shape has to survive `withAuth`'s re-parameterization of the field builder,
+// so a helper resolver behind a scope check still has to declare the columns it
+// reads. The `@ts-expect-error` must stay *used* — an unused-directive
+// diagnostic here means the narrowing stopped applying through `withAuth`.
+function _narrowedParentShapeSurvivesWithAuth() {
+  const builder = new SchemaBuilder<{
+    PrismaNextContract: SampleContract;
+    Context: { admin: boolean };
+    AuthScopes: { admin: boolean };
+  }>({
+    plugins: [ScopeAuthPlugin, RelayPlugin, prismaNextPlugin],
+    relay: {},
+    scopeAuth: { authScopes: ({ admin }) => ({ admin }) },
+    prismaNext: { contract: ctx.contract },
+  });
+
+  builder.prismaObjectFields('User', (t) => ({
+    declaredBehindScope: t.withAuth({ admin: true }).string({
+      select: ['email'],
+      resolve: (row) => row.email,
+    }),
+    undeclaredBehindScope: t.withAuth({ admin: true }).string({
+      // @ts-expect-error The string form's parent carries only declared dependencies.
+      resolve: (row) => row.email,
+    }),
+  }));
+}

--- a/packages/plugin-prisma-next/tests/scope-auth.test.ts
+++ b/packages/plugin-prisma-next/tests/scope-auth.test.ts
@@ -112,8 +112,6 @@ it('does not execute the root collection when a root scope denies access', async
   expect(captures).toHaveLength(0);
 });
 
-// Type-level fixture, never executed: the narrowed parent shape has to survive
-// `withAuth`'s re-parameterization of the field builder.
 function _narrowedParentShapeSurvivesWithAuth() {
   const builder = new SchemaBuilder<{
     PrismaNextContract: SampleContract;

--- a/packages/plugin-prisma-next/tests/scope-auth.test.ts
+++ b/packages/plugin-prisma-next/tests/scope-auth.test.ts
@@ -112,11 +112,8 @@ it('does not execute the root collection when a root scope denies access', async
   expect(captures).toHaveLength(0);
 });
 
-// Type-level fixture, never executed: the cross-file helpers' narrowed parent
-// shape has to survive `withAuth`'s re-parameterization of the field builder,
-// so a helper resolver behind a scope check still has to declare the columns it
-// reads. The `@ts-expect-error` must stay *used* — an unused-directive
-// diagnostic here means the narrowing stopped applying through `withAuth`.
+// Type-level fixture, never executed: the narrowed parent shape has to survive
+// `withAuth`'s re-parameterization of the field builder.
 function _narrowedParentShapeSurvivesWithAuth() {
   const builder = new SchemaBuilder<{
     PrismaNextContract: SampleContract;


### PR DESCRIPTION
## The bug

The four cross-file field helpers defaulted their parent `Shape` to the full `Row<Types, M>`:

| line | helper | was | now |
| --- | --- | --- | --- |
| `global-types.ts:148` | `prismaObjectField` | `Row<Types, M>` | `ObjectBaseShape<Types, M>` |
| `:160` | `prismaObjectFields` | `Row<Types, M>` | `ObjectBaseShape<Types, M>` |
| `:171` | `prismaInterfaceField` | `Row<Types, M>` | `ObjectBaseShape<Types, M>` |
| `:183` | `prismaInterfaceFields` | `Row<Types, M>` | `ObjectBaseShape<Types, M>` |
| `:198` | `prismaNode` | `Row<Types, M>` | `ObjectLevelShape<Types, M, Select>` |

So a resolver added by `builder.prismaObjectField('User', …)` was typed as if every column of `User` were loaded, when the plugin only loads what some `select` or `t.expose*` declared:

```ts
builder.prismaObject('User', { fields: (t) => ({ id: t.exposeID('id') }) });

builder.prismaObjectField('User', 'emailish', (t) =>
  t.string({ resolve: (row) => row.email }), // compiled; `row.email` typed `string`
);
```

Under `--strict` that produced no diagnostic. At runtime the auto-include selects only `id`, `row.email` is `undefined`, and the query fails with `Cannot return null for non-nullable field User.email`.

**This is a type-guarantee defect only — the runtime is correct and documented.** Declaring `select` is and remains the supported way for a field to add a column dependency; nothing about runtime behaviour changes here. `internal-types.ts:226-229` already states the rule these four broke: *"Defaulting the parent type to the full `Row<M>` would lie about what's actually present."*

## The change

The string form now starts from `ObjectBaseShape<Types, M>` — the brand-only dependency base `prismaObject` already uses — and a field's own `select` layers onto it additively through the existing `ShapeFromSelect` path, unchanged. Reading an undeclared column is now a property-does-not-exist error at the resolver, which is the right place for it.

Three things are deliberately *not* affected:

- **The ref form was already honest.** Passing a `PrismaNextObjectRef` infers `Shape` from the ref, so `row.email` errored there before this change too. The defect was string-form-only, and the ref form's behaviour is bit-for-bit unchanged. Nice side effect: this strengthens the existing "pass the variant ref" advice, since the ref form is now also the form with the precise parent type.
- **`t.expose*` is immune.** The field builder carries a separate `ExposableShape` generic defaulting to `Row<Types, M>` (`prisma-next-object-field-builder.ts:126-130`); the helpers pass only three type arguments, so narrowing `Shape` leaves every `t.exposeString(...)` / `t.relation(...)` compiling.
- **`withAuth` chains.** The narrowed `Shape` survives scope-auth's re-parameterization of the field builder (`prisma-next-object-field-builder.ts:142-152`); there's a fixture for it in the scope-auth type project.

### `prismaNode:198` is included

The design note flagged that `prismaNode` has the identical defect but is not in the original review's finding list, and asked for it to be fixed here if a `Select` generic could be added cleanly, or filed as a sibling otherwise. It could: `prismaNode` now takes the same `const Select = unknown` generic `prismaObject` takes and computes `Shape = ObjectLevelShape<Types, M, Select>`, with `options` shaped as `Omit<PrismaNextObjectOptions<…>, 'select'> & { select?: Select; … }` — exactly the `prismaObject` pattern.

Two costs, both scoped honestly.

**The cost that stands: contextual typing of a function-form `select`.** Because `select` feeds the `const Select` generic, it can no longer contextually type a `select: { posts: (sub) => … }` refinement callback. `prismaObject` has had that limitation since it gained `Select`, and `tests/normalization-runtime.test.ts` already worked around it with an explicit `RelationRefinementCollection<…>` annotation on its `prismaObject` call — the `prismaNode` call a few lines above now carries the same annotation. That's the only in-repo edit the `prismaNode` half required.

**The cost I first shipped and have now paid back, in two rounds: key validation on `select`.** My first pass used `const Select = unknown` with no constraint, which accepted any object or array — so `prismaNode` silently lost the typo checking it had on `main`, where it passed `PrismaNextObjectOptions` through intact. Constraining `Select` fixed the all-invalid cases but not the realistic one: excess-property checking only fires on a fresh literal against a *concrete* target, and once `Select` is a type parameter the literal is its own instantiation, so a literal with one good key satisfies the constraint and the typo rides along. Nobody misspells every key.

| `builder.prismaNode('User', …)` | `origin/main` | pass 1 (unconstrained) | pass 2 (constrained) | now |
| --- | --- | --- | --- | --- |
| `select: ['emial']` | TS2820 `Did you mean '"email"'?` | **compiled** | TS2820 | TS2820, suggestion included |
| `select: { nosuchcolumn: true }` | TS2353 | **compiled** | TS2353 | TS2353 |
| `select: { psots: { limit: 3 } }` | TS2353 | **compiled** | TS2353 | TS2353 |
| `select: { email: true, emial: true }` | TS2353 | **compiled** | **compiled** | `Unknown key in select: emial` |
| `select: { posts: true, psots: {…} }` | TS2353 | **compiled** | **compiled** | `Unknown key in select: psots` |
| `select: ['email', 'emial']` | TS2820 | **compiled** | TS2820 | TS2820, suggestion included |

Executed against the real SQLite fixture, pass 1 turned `select: ['emial']` into a query-time `no such column: user.emial`, and pass 2 left the mixed object form to throw in `compileSelect` — precisely the "compiles cleanly, fails at query time" shape this PR's opening paragraph calls the defect. Reaching parity with `prismaObject` by *removing* a check `prismaNode` had was the wrong trade, twice; thanks to review it isn't what ships.

**The array form never had the second hole** — its constraint is over the element type and tuples get no excess-property leniency — which I checked rather than assumed before reaching for a fix. Only the object form needed one.

Two mechanisms, then:

- `Select` is constrained to `readonly (keyof Row<Types, M> & string)[] | SelectObjectSpec<Types, M> | undefined`, with `undefined` rather than `unknown` as the no-select default so the constraint is satisfiable — `ShapeFromObjectSelect` already maps `undefined` to the brand-only base exactly as it maps `unknown`.
- `ExactSelectCheck` is intersected onto the options parameter as a second `select` member, beside the bare `select?: Select` that does the inferring. `unknown` is the identity of `&`, so a valid select passes through untouched; an invalid one intersects with an unsatisfiable object and fails *on the `select` property*, where the squiggle belongs. The bad key is the error type's property name, so the message reads `Unknown key in select: emial`.

A defaulted phantom type parameter was the obvious alternative for the second mechanism and does not work: TypeScript checks a parameter default against its constraint at the declaration site, where `Select` is still unresolved, so the signature itself fails to compile. An earlier attempt to intersect the constraint into the `select` slot as a single property (`select?: Select & (…)`) destroyed inference outright — the parent stopped narrowing even for a valid `select`. Splitting inference and validation across two intersection members is what keeps both.

All six cases are pinned as `@ts-expect-error` fixtures, and I read the raw diagnostics for each rather than trusting the directives. `prismaObject`/`prismaInterface` still carry both holes; they predate this PR and narrowing them would touch call sites that pass `select` as a variable, so I've left them rather than widen the blast radius — worth a sibling issue.

## Escape hatch (documentation, not new API)

`Shape` already is the second positional type parameter, and explicit instantiation already worked in both directions:

```ts
builder.prismaObjectField<'User', Row<Types, 'User'>>('User', 'displayName', (t) => …);
```

That's now written down — in the JSDoc on `prismaObjectField` and in `docs/objects.mdx` — as the one-line unblock for anyone hitting a compile error mid-migration. It only relaxes the type; the column still has to be selected to be there at runtime, so the docs say to prefer `select`.

## Why ship the strict default now rather than behind a flag

On a published package I'd gate this behind a `SchemaTypes` flag for a minor. Here the package is `private: true`, `0.1.0`, pinned to prisma-next RC9 by design, with no in-repo dependents — so there is no semver event and no external migration to stage. Shipping strict now beats carrying a known-unsound type into the package's first public release. Changeset is `patch` accordingly.

In-repo migration cost was zero: every existing string-form usage either declares `select` (`tests/runtime.test.ts:223-236`, all three doc examples) or uses `t.expose*` (`tests/regressions.test.ts:567`, `:866`); `tests/prisma-interface.test.ts:41` uses the ref form. Nothing outside the package calls these helpers — the `website/` and `packages/plugin-prisma` hits are the older `@pothos/plugin-prisma` API. "Zero" is a claim about this repo; private consumers of a private package aren't visible from here.

## Verification

New `tests/cross-file-helper-shape.test-d.ts`, written before the fix. Measured with `tsconfig.type.tsbuildinfo` deleted between runs, since `composite: true` otherwise caches across the source edit.

**Negative fixtures — string form, no `select`, resolver reads `row.email`.** Each carries a `@ts-expect-error` that must stay *used*; an unused-directive diagnostic is the regression signal if the narrowing silently stops applying.

| fixture | before | after |
| --- | --- | --- |
| `prismaObjectField` | compiles (TS2578 unused directive) | TS2339 `Property 'email' does not exist` |
| `prismaObjectFields` | compiles (TS2578) | errors as expected |
| `prismaInterfaceField` | compiles (TS2578) | errors as expected |
| `prismaInterfaceFields` | compiles (TS2578) | errors as expected |
| `prismaNode` | compiles (TS2578) | errors as expected |
| `withAuth` chain inside a helper (scope-auth project) | compiles (TS2578) | errors as expected |

Before the fix that's 5 unused directives in the type project and 1 in the scope-auth project; after, both projects are clean.

**Positive fixtures — all compiled before and still compile**, with `expectTypeOf` assertions that the parent is brand ∪ declared columns:

- string form with `select: ['email']`, and the object form `select: { email: true, posts: true }` (this is the case that would break if `ShapeFromSelect` failed to layer onto the brand-only base — the main risk the design note called out);
- `t.exposeString('firstName')`, `t.exposeID('id')`, `t.relation('posts')` with no `select`;
- the ref form with no `select` (still errors, as before) and with an object-level `select` (still sees `email`);
- `prismaNode` with `select: ['email']`;
- the explicit `<'User', Row<Types, 'User'>>` escape hatch.

**Project checks**

- `pnpm --filter @pothos/plugin-prisma-next run type` — both `tsconfig.type.json` and `tsconfig.scope-auth.json` pass.
- `pnpm --filter @pothos/plugin-prisma-next run test` — **371 passed / 13 skipped**. `main` is 370/13 in the same environment; the extra one is the `id.resolve` runtime test added in the follow-up commit below. `tests/postgres-runtime.test.ts` fails with `ECONNREFUSED 127.0.0.1:5456` here and on unmodified `main` — environmental, no Postgres server.
- `pnpm --filter @pothos/plugin-prisma-next run build:dts` succeeds, and `ObjectBaseShape` survives `stripInternal` — it appears in both `dts/internal-types.d.ts` and the four helper signatures in `dts/global-types.d.ts`, so the public API does not collapse to `never` (the failure mode warned about at `internal-types.ts:40-47`). Checked, not assumed.
- `pnpm build` (full monorepo) and `biome check packages/plugin-prisma-next` are clean.

### Follow-up: `id.field` columns stay in the custom ID resolver's parent

Codex caught a regression the first pass introduced, and it's exactly the class of failure the design note warned about — code that is *correct at runtime* newly failing to compile. Narrowing `prismaNode`'s parent also narrowed the parent handed to a custom `id.resolve`, so this started failing with TS2339 unless you added a redundant `select: ['id']`:

```ts
builder.prismaNode('User', {
  id: { field: 'id', resolve: (row) => row.id },
  collection: (ctx) => ctx.db.orm.User,
  fields: (t) => ({ firstName: t.exposeString('firstName') }),
});
```

`id.field` is itself a dependency declaration, so the runtime genuinely loads that column. Verified in the source rather than taken on trust: `schema-builder.ts:386` attaches `extensions: { [PRISMA_NEXT_FIELD_SELECT]: { columns: idFields } }` to the `id` field config, and the `resolve` three lines below on that same config is what calls `idOpts.resolve(parent, ctx)`. Only the type disagreed.

Fix: `id.field` is captured in a `const IDFields` generic and the custom ID resolver's parent becomes `Shape & IdFieldShape<Types, M, IDFields>`.

- **Compound IDs are covered.** `IdFieldShape` picks every column of a tuple `field: ['authorId', 'id']`, not just the first.
- **The negative case still fails.** A column declared by neither `id.field` nor `select` is still rejected *inside `id.resolve` itself* — there's a `@ts-expect-error` fixture pinning it, and it stays used.
- **The widening is scoped to `id.resolve`.** The selection lives on the `id` field, so other field resolvers on the same type still can't assume the ID columns are present.
- `id.field` became an inference site, so there's also a fixture confirming an invalid column name (`field: 'nope'`) is still rejected.

Reproduction, measured with `tsconfig.type.tsbuildinfo` deleted between runs:

| | `origin/main` | branch before this commit | after |
| --- | --- | --- | --- |
| `id: { field: 'id', resolve: (row) => row.id }`, no `select` | compiles | **TS2339** | compiles |
| compound `field: ['authorId', 'id']`, no `select` | compiles | **TS2339** (both columns) | compiles |
| `id.field` + object-level `select`, resolver reads both | compiles | **TS2339** | compiles |
| `resolve: (row) => row.email` (declared by neither) | compiles (unused directive) | correctly errors | correctly errors |

New runtime test, `tests/release-correctness.test.ts` — "hands a custom id.resolve the columns declared by id.field" — builds two nodes with **no** object-level `select`, one single-column and one compound, and asserts the encoded global IDs against the real SQLite fixture. It passes, which is direct evidence the columns are loaded and not just an argument from the source. Suite is now 371 passed / 13 skipped (the one new test); both type projects, `build:dts`, and `biome check` stay clean.

## Docs

Added to the existing `select` guidance only, one or two sentences each: why the string form's parent carries just declared dependencies (`docs/objects.mdx`, plus a pointer from `docs/interfaces.mdx` and `docs/variants.mdx`), the escape hatch example (`docs/objects.mdx`), and `select` added to `prismaNode`'s option list in `docs/relay.mdx`. This deliberately does **not** restate the variant-name-string correction landing separately in `docs/interfaces.mdx` / `objects.mdx` / `variants.mdx`.

## Signature-shape note

`prismaNode`'s type parameters were reordered: `Shape` moved 3rd → 4th and `IDShape` 4th → 5th, to make room for `Select` in the position `prismaObject` uses. So an explicit `builder.prismaNode<[], 'User', { email: string }>(…)` now feeds `Select` instead of `Shape` and would silently produce a brand-only parent rather than erroring. No in-repo call site instantiates these explicitly and the package is `private: true` at `0.1.0`, which is why this is still a patch — but it is a signature-shape change and shouldn't be buried.

## Merge order with #1764

#1764 and this PR both rewrite the same paragraph of `docs/interfaces.mdx` (both hunks start at line 53) and will conflict. `objects.mdx` and `variants.mdx` auto-merge cleanly. #1764 is smaller and already clean, so this one lands second and resolves: keep the "the string form's parent carries only the dependencies that field declared" paragraph from here, then #1764's corrected variant paragraph. I'll do that resolution.

## Scope

Only this finding. `src/connection-helpers.ts` is untouched — the `resolveNode` shape fix is being implemented separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB



