### PR TITLE
fix(prisma): plan nodes for custom relatedConnection fallbacks

### DIFF
--- a/.changeset/prisma-related-connection-planning.md
+++ b/.changeset/prisma-related-connection-planning.md
@@ -5,5 +5,6 @@
 Fix `relatedConnection` fields with a custom `resolve` when the parent row was not planned:
 
 - The fallback planned its query from the connection wrapper type, which has no prisma model, so an unplanned parent threw `Expected UserPostsConnection to have a model` before the custom resolver ran. The field now records the node type, the `nodes`/`edges.node` paths and the cursor selection to seed, and the fallback plans from those.
-- `totalCount` on the fallback branch had no count source and resolved `null` on a non-nullable `Int`. It is now counted from the parent, lazily, only when the document selects it.
+- `totalCount` on the fallback branch had no count source and resolved `null` on a non-nullable `Int`. It is now counted from the parent, only when the document selects it, and reaches user-defined fields on the connection object as the same number the generated `totalCount` field gets. When the parent does not correspond to a row — which only a custom `resolve` can produce — the field now errors naming the field and model rather than reporting a count of `0`.
 - `hasNextPage` was always `false` on the fallback branch, because the page size was read from the plan's selection map instead of the connection query, so the extra probe row was never sliced off.
+- A `totalCount`-only selection no longer runs the custom `resolve` for rows it would discard, matching what the loaded path already did.

--- a/.changeset/prisma-related-connection-planning.md
+++ b/.changeset/prisma-related-connection-planning.md
@@ -1,0 +1,9 @@
+---
+'@pothos/plugin-prisma': patch
+---
+
+Fix `relatedConnection` fields with a custom `resolve` when the parent row was not planned:
+
+- The fallback planned its query from the connection wrapper type, which has no prisma model, so an unplanned parent threw `Expected UserPostsConnection to have a model` before the custom resolver ran. The field now records the node type, the `nodes`/`edges.node` paths and the cursor selection to seed, and the fallback plans from those.
+- `totalCount` on the fallback branch had no count source and resolved `null` on a non-nullable `Int`. It is now counted from the parent, lazily, only when the document selects it.
+- `hasNextPage` was always `false` on the fallback branch, because the page size was read from the plan's selection map instead of the connection query, so the extra probe row was never sliced off.

--- a/packages/plugin-prisma/src/index.ts
+++ b/packages/plugin-prisma/src/index.ts
@@ -21,7 +21,7 @@ import type { IncludeMap, PrismaModelTypes } from './types.js';
 import { INCLUDE_ALL, type PrismaPlan } from './util/adapter.js';
 import { formatPrismaCursor, parsePrismaCursor } from './util/cursors.js';
 import { getModel, getRefFromModel } from './util/datamodel.js';
-import { fallbackQueryFromInfo, queryFromInfo } from './util/map-query.js';
+import { type FallbackPlanRecipe, fallbackQueryFromInfo, queryFromInfo } from './util/map-query.js';
 import type { FieldMap } from './util/relation-map.js';
 
 export { prismaConnectionHelpers } from './connection-helpers.js';
@@ -148,7 +148,21 @@ export class PothosPrismaPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
     ) => ModelLoader;
 
     const resolveFallback = fieldConfig.extensions?.pothosPrismaFallback as
-      | ((query: {}, parent: unknown, args: {}, context: {}, info: {}) => unknown)
+      | ((
+          query: {},
+          parent: unknown,
+          args: {},
+          context: {},
+          info: {},
+          loader?: (model: unknown) => ModelLoader,
+        ) => unknown)
+      | undefined;
+
+    // How the field wants its fallback planned, when planning from the field's return type is not
+    // enough. A connection records the node type and the path down to it here; `t.relation`
+    // records nothing, since its return type is the model.
+    const fallbackPlan = fieldConfig.extensions?.pothosPrismaFallbackPlan as
+      | FallbackPlanRecipe
       | undefined;
 
     // The fallback with one settled plan per `Type@path` per request beside it, since it plans
@@ -157,6 +171,7 @@ export class PothosPrismaPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
     // request and the builder's own `skipDeferredFragments` is the one that applies.
     const fallback = resolveFallback && {
       resolve: resolveFallback,
+      plan: fallbackPlan,
       plans: createContextCache(() => new Map<string, MaybePromise<PrismaPlan>>()),
     };
 
@@ -199,11 +214,18 @@ export class PothosPrismaPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
           context,
           info,
           this.builder.options.prisma.skipDeferredFragments,
+          fallback.plan,
         );
 
+        // The parent's own loader goes along, as the cache rather than an instance: a fallback
+        // that needs something of the parent the row does not carry — a connection's `totalCount`
+        // — reaches it through the same `findUnique` every other load of this parent uses, and one
+        // that needs nothing never asks for it.
         return isThenable(query)
-          ? query.then((resolved) => fallback.resolve(resolved as {}, parent, args, context, info))
-          : fallback.resolve(query, parent, args, context, info);
+          ? query.then((resolved) =>
+              fallback.resolve(resolved as {}, parent, args, context, info, loaderCache),
+            )
+          : fallback.resolve(query, parent, args, context, info, loaderCache);
       }
 
       return loaderCache(context)

--- a/packages/plugin-prisma/src/index.ts
+++ b/packages/plugin-prisma/src/index.ts
@@ -214,9 +214,6 @@ export class PothosPrismaPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
           fallback.plan,
         );
 
-        // The loader cache rather than a loader: a fallback that needs something of the parent
-        // the row does not carry reaches it through the same `findUnique` every other load of
-        // this parent uses, and one that needs nothing never creates it.
         return isThenable(query)
           ? query.then((resolved) =>
               fallback.resolve(resolved as {}, parent, args, context, info, loaderCache),

--- a/packages/plugin-prisma/src/index.ts
+++ b/packages/plugin-prisma/src/index.ts
@@ -158,9 +158,6 @@ export class PothosPrismaPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
         ) => unknown)
       | undefined;
 
-    // How the field wants its fallback planned, when planning from the field's return type is not
-    // enough. A connection records the node type and the path down to it here; `t.relation`
-    // records nothing, since its return type is the model.
     const fallbackPlan = fieldConfig.extensions?.pothosPrismaFallbackPlan as
       | FallbackPlanRecipe
       | undefined;
@@ -217,10 +214,9 @@ export class PothosPrismaPlugin<Types extends SchemaTypes> extends BasePlugin<Ty
           fallback.plan,
         );
 
-        // The parent's own loader goes along, as the cache rather than an instance: a fallback
-        // that needs something of the parent the row does not carry — a connection's `totalCount`
-        // — reaches it through the same `findUnique` every other load of this parent uses, and one
-        // that needs nothing never asks for it.
+        // The loader cache rather than a loader: a fallback that needs something of the parent
+        // the row does not carry reaches it through the same `findUnique` every other load of
+        // this parent uses, and one that needs nothing never creates it.
         return isThenable(query)
           ? query.then((resolved) =>
               fallback.resolve(resolved as {}, parent, args, context, info, loaderCache),

--- a/packages/plugin-prisma/src/prisma-field-builder.ts
+++ b/packages/plugin-prisma/src/prisma-field-builder.ts
@@ -338,38 +338,36 @@ export class PrismaObjectFieldBuilder<
     // The fallback branch's count, which the parent row cannot carry: the rows it pages come from
     // the user's own resolver, not from a query that could have selected `_count` alongside them.
     // So the count is asked of the parent, through the same `findUnique` every other load of this
-    // parent uses, and asked lazily — a document that does not select `totalCount` never runs it.
-    const totalCountFromParent =
-      (
-        connectionQuery: { where?: {} },
-        parent: unknown,
-        context: {},
-        loaderCache: ((model: unknown) => ModelLoader) | undefined,
-      ) =>
-      () => {
-        const loader = loaderCache?.(context);
+    // parent uses, and the `_count` select the planned path would have used.
+    const totalCountFromParent = (
+      connectionQuery: { where?: {} },
+      parent: unknown,
+      context: {},
+      loaderCache: ((model: unknown) => ModelLoader) | undefined,
+    ) => {
+      const loader = loaderCache?.(context);
 
-        if (!loader) {
-          throw new PothosSchemaError(
-            `Unable to load totalCount for ${this.model}.${name}: no loader for the parent type`,
-          );
-        }
+      if (!loader) {
+        throw new PothosSchemaError(
+          `Unable to load totalCount for ${this.model}.${name}: no loader for the parent type`,
+        );
+      }
 
-        const countSelect =
-          this.builder.options.prisma.filterConnectionTotalCount !== false && connectionQuery.where
-            ? { where: connectionQuery.where }
-            : true;
+      const countSelect =
+        this.builder.options.prisma.filterConnectionTotalCount !== false && connectionQuery.where
+          ? { where: connectionQuery.where }
+          : true;
 
-        return Promise.resolve(
-          getDelegateFromModel(
-            getClient(this.builder, context as never),
-            loader.modelName,
-          ).findUnique({
-            where: loader.findUnique(parent as Record<string, unknown>, context) as never,
-            select: { _count: { select: { [name]: countSelect } } },
-          } as never) as PromiseLike<{ _count?: Record<string, number> } | null>,
-        ).then((row) => row?._count?.[name] ?? 0);
-      };
+      return Promise.resolve(
+        getDelegateFromModel(
+          getClient(this.builder, context as never),
+          loader.modelName,
+        ).findUnique({
+          where: loader.findUnique(parent as Record<string, unknown>, context) as never,
+          select: { _count: { select: { [name]: countSelect } } },
+        } as never) as PromiseLike<{ _count?: Record<string, number> } | null>,
+      ).then((row) => row?._count?.[name] ?? 0);
+    };
 
     const resolveFallback =
       resolve &&
@@ -381,10 +379,20 @@ export class PrismaObjectFieldBuilder<
         context: {},
         info: GraphQLResolveInfo,
         loaderCache: ((model: unknown) => ModelLoader) | undefined,
-      ) =>
-        Promise.resolve(
+      ) => {
+        // What the document asks of this connection, read exactly as the loaded path reads it.
+        // The count is loaded only when `totalCount` is selected — the same signal the planned
+        // path uses to decide whether to select `_count` at all — rather than deferred behind a
+        // thunk, so what lands on the connection is a plain number for every field that reads it,
+        // user-defined ones included, and not just for the generated one.
+        const { hasTotalCount } = connectionSelection(context, info);
+
+        return Promise.all([
           resolve({ ...q, ...connectionQuery } as never, parent, args, context, info),
-        ).then((result) =>
+          hasTotalCount
+            ? totalCountFromParent(connectionQuery, parent, context, loaderCache)
+            : undefined,
+        ]).then(([result, count]) =>
           wrapConnectionResult(
             parent,
             result,
@@ -394,11 +402,10 @@ export class PrismaObjectFieldBuilder<
             // reporting `hasNextPage: false`.
             connectionQuery.take,
             formatCursor,
-            totalCount
-              ? totalCountFromParent(connectionQuery, parent, context, loaderCache)
-              : undefined,
+            count,
           ),
-        ));
+        );
+      });
 
     // The recipe for planning the fallback's own query. The field's return type is the relay
     // wrapper, which has no model, so the planner is told the same three things `relationSelect`
@@ -495,23 +502,14 @@ export class PrismaObjectFieldBuilder<
             ...connectionOptions,
             fields: totalCount
               ? (
-                  t: PothosSchemaTypes.ObjectFieldBuilder<
-                    SchemaTypes,
-                    { totalCount?: number | (() => MaybePromise<number>) }
-                  >,
+                  t: PothosSchemaTypes.ObjectFieldBuilder<SchemaTypes, { totalCount?: number }>,
                 ) => ({
                   totalCount: t.int({
                     nullable: false,
                     extensions: {
                       pothosPrismaTotalCount: true,
                     },
-                    // The loaded path has the count on the parent row already and passes the
-                    // number; the fallback has to go and ask for it, and passes a thunk so a
-                    // document that never selects this field never runs that query.
-                    resolve: (parent, _args, _context) =>
-                      typeof parent.totalCount === 'function'
-                        ? parent.totalCount()
-                        : parent.totalCount,
+                    resolve: (parent, _args, _context) => parent.totalCount,
                   }),
                   ...(connectionOptions as { fields?: (t: unknown) => {} }).fields?.(t),
                 })

--- a/packages/plugin-prisma/src/prisma-field-builder.ts
+++ b/packages/plugin-prisma/src/prisma-field-builder.ts
@@ -13,6 +13,7 @@ import {
   ObjectRef,
   type PluginName,
   PothosSchemaError,
+  PothosValidationError,
   RootFieldBuilder,
   type SchemaTypes,
   type ShapeFromTypeParam,
@@ -344,12 +345,15 @@ export class PrismaObjectFieldBuilder<
       parent: unknown,
       context: {},
       loaderCache: ((model: unknown) => ModelLoader) | undefined,
+      info: GraphQLResolveInfo,
     ) => {
+      // Named as the document names it, which is what a reader of the error has in front of them.
+      const field = `${info.parentType.name}.${info.fieldName}`;
       const loader = loaderCache?.(context);
 
       if (!loader) {
         throw new PothosSchemaError(
-          `Unable to load totalCount for ${this.model}.${name}: no loader for the parent type`,
+          `Unable to load totalCount for ${field}: no loader for the parent type`,
         );
       }
 
@@ -366,7 +370,22 @@ export class PrismaObjectFieldBuilder<
           where: loader.findUnique(parent as Record<string, unknown>, context) as never,
           select: { _count: { select: { [name]: countSelect } } },
         } as never) as PromiseLike<{ _count?: Record<string, number> } | null>,
-      ).then((row) => row?._count?.[name] ?? 0);
+      ).then((row) => {
+        const count = row?._count?.[name];
+
+        // The reason this branch exists is that the parent did not come from a prisma query, so
+        // it need not correspond to a row at all. When it does not there is no count to report,
+        // and `totalCount` is a non-nullable Int: answering 0 would put a number the schema
+        // promises is the truth next to a page of edges the resolver did return. Say what
+        // happened instead.
+        if (count === undefined) {
+          throw new PothosValidationError(
+            `Unable to load totalCount for ${field}: no ${loader.modelName} row matches the parent this connection resolved from`,
+          );
+        }
+
+        return count;
+      });
     };
 
     const resolveFallback =
@@ -390,7 +409,7 @@ export class PrismaObjectFieldBuilder<
         return Promise.all([
           resolve({ ...q, ...connectionQuery } as never, parent, args, context, info),
           hasTotalCount
-            ? totalCountFromParent(connectionQuery, parent, context, loaderCache)
+            ? totalCountFromParent(connectionQuery, parent, context, loaderCache, info)
             : undefined,
         ]).then(([result, count]) =>
           wrapConnectionResult(

--- a/packages/plugin-prisma/src/prisma-field-builder.ts
+++ b/packages/plugin-prisma/src/prisma-field-builder.ts
@@ -51,9 +51,8 @@ import type { FallbackPlanRecipe } from './util/map-query.js';
 
 import type { FieldMap } from './util/relation-map.js';
 
-// The two ways a relay connection exposes its nodes. Shared by the planned path's select function
-// and by the fallback's plan recipe, so the two plan the same selection by construction rather
-// than by two copies of the same guess drifting apart.
+// The two ways a relay connection exposes its nodes, shared by the planned path's select function
+// and the fallback's plan recipe so both plan the same selection.
 const CONNECTION_NODE_PATHS: IndirectPathSegment[][] = [
   [{ name: 'nodes' }],
   [{ name: 'edges' }, { name: 'node' }],
@@ -336,10 +335,9 @@ export class PrismaObjectFieldBuilder<
         (parent as { _count?: Record<string, number> })._count?.[name],
       );
 
-    // The fallback branch's count, which the parent row cannot carry: the rows it pages come from
-    // the user's own resolver, not from a query that could have selected `_count` alongside them.
-    // So the count is asked of the parent, through the same `findUnique` every other load of this
-    // parent uses, and the `_count` select the planned path would have used.
+    // The fallback branch's count: its rows come from the user's own resolver, not from a query
+    // that could have selected `_count` beside them, so the count is asked of the parent through
+    // the same `findUnique` every other load of it uses.
     const totalCountFromParent = (
       connectionQuery: { where?: {} },
       parent: unknown,
@@ -347,7 +345,6 @@ export class PrismaObjectFieldBuilder<
       loaderCache: ((model: unknown) => ModelLoader) | undefined,
       info: GraphQLResolveInfo,
     ) => {
-      // Named as the document names it, which is what a reader of the error has in front of them.
       const field = `${info.parentType.name}.${info.fieldName}`;
       const loader = loaderCache?.(context);
 
@@ -373,11 +370,8 @@ export class PrismaObjectFieldBuilder<
       ).then((row) => {
         const count = row?._count?.[name];
 
-        // The reason this branch exists is that the parent did not come from a prisma query, so
-        // it need not correspond to a row at all. When it does not there is no count to report,
-        // and `totalCount` is a non-nullable Int: answering 0 would put a number the schema
-        // promises is the truth next to a page of edges the resolver did return. Say what
-        // happened instead.
+        // `totalCount` is a non-nullable Int, and a parent the fallback was handed need not be a
+        // row at all, so a parent that matches none has no count to report.
         if (count === undefined) {
           throw new PothosValidationError(
             `Unable to load totalCount for ${field}: no ${loader.modelName} row matches the parent this connection resolved from`,
@@ -399,18 +393,11 @@ export class PrismaObjectFieldBuilder<
         info: GraphQLResolveInfo,
         loaderCache: ((model: unknown) => ModelLoader) | undefined,
       ) => {
-        // What the document asks of this connection, read exactly as the loaded path reads it.
-        // The count is loaded only when `totalCount` is selected — the same signal the planned
-        // path uses to decide whether to select `_count` at all — rather than deferred behind a
-        // thunk, so what lands on the connection is a plain number for every field that reads it,
-        // user-defined ones included, and not just for the generated one.
         const { hasTotalCount, totalCountOnly } = connectionSelection(context, info);
 
         return Promise.all([
           // Nothing beneath this connection but `totalCount`, so every row the resolver returned
-          // would be dropped on the floor. The loaded path already passes `[]` here rather than
-          // reading rows it will discard; the fallback does the same, rather than paying for a
-          // page of up to `maxSize` rows per parent that nothing reads.
+          // would be dropped on the floor; the planned path passes `[]` here too.
           totalCountOnly
             ? []
             : resolve({ ...q, ...connectionQuery } as never, parent, args, context, info),
@@ -422,9 +409,8 @@ export class PrismaObjectFieldBuilder<
             parent,
             result,
             args,
-            // The page size of the *connection* query, probe row included. `q` is the plan's
-            // selection map and has no `take` of its own; reading it there left every page
-            // reporting `hasNextPage: false`.
+            // The page size of the *connection* query, probe row included; `q` is the plan's
+            // selection map and has no `take` of its own.
             connectionQuery.take,
             formatCursor,
             count,
@@ -432,12 +418,10 @@ export class PrismaObjectFieldBuilder<
         );
       });
 
-    // The recipe for planning the fallback's own query. The field's return type is the relay
-    // wrapper, which has no model, so the planner is told the same three things `relationSelect`
-    // already computes for the planned path: the node type (from `ref`, never the wrapper, so a
-    // shared connection object still resolves to one model), the paths down to it, and the cursor
-    // columns to seed so `formatCursor` has something to read. Every value here is static, fixed
-    // where the field is defined; the plan itself is still built per request from `info`.
+    // The field's return type is the relay wrapper, which has no model, so the planner is told
+    // what `relationSelect` computes for the planned path: the node type (from `ref`, never the
+    // wrapper, so a shared connection object still resolves to one model), the paths down to it,
+    // and the cursor columns to seed so `formatCursor` has something to read.
     const fallbackPlan: FallbackPlanRecipe | undefined =
       typeof resolve === 'function'
         ? () => {

--- a/packages/plugin-prisma/src/prisma-field-builder.ts
+++ b/packages/plugin-prisma/src/prisma-field-builder.ts
@@ -12,12 +12,17 @@ import {
   type NormalizeArgs,
   ObjectRef,
   type PluginName,
+  PothosSchemaError,
   RootFieldBuilder,
   type SchemaTypes,
   type ShapeFromTypeParam,
   type TypeParam,
 } from '@pothos/core';
-import { type SelectedFieldNode, selectedFieldNames } from '@pothos/selection-mapper';
+import {
+  type IndirectPathSegment,
+  type SelectedFieldNode,
+  selectedFieldNames,
+} from '@pothos/selection-mapper';
 import type { GraphQLResolveInfo } from 'graphql';
 import type { PrismaRef } from './interface-ref.js';
 import { ModelLoader } from './model-loader.js';
@@ -38,10 +43,20 @@ import {
   prismaCursorConnectionQuery,
   wrapConnectionResult,
 } from './util/cursors.js';
-import { getRefFromModel, getRelation } from './util/datamodel.js';
+import { getDelegateFromModel, getRefFromModel, getRelation } from './util/datamodel.js';
 import { getFieldDescription } from './util/description.js';
+import { getClient } from './util/get-client.js';
+import type { FallbackPlanRecipe } from './util/map-query.js';
 
 import type { FieldMap } from './util/relation-map.js';
+
+// The two ways a relay connection exposes its nodes. Shared by the planned path's select function
+// and by the fallback's plan recipe, so the two plan the same selection by construction rather
+// than by two copies of the same guess drifting apart.
+const CONNECTION_NODE_PATHS: IndirectPathSegment[][] = [
+  [{ name: 'nodes' }],
+  [{ name: 'edges' }, { name: 'node' }],
+];
 
 // Workaround for FieldKind not being extended on Builder classes
 const RootBuilder: {
@@ -294,7 +309,7 @@ export class PrismaObjectFieldBuilder<
       // A maybe-promise query starts the nested plan now; its merge waits for the query.
       const nested = nestedQuery(getQuery(args, context), {
         getType: () => typeName!,
-        paths: [[{ name: 'nodes' }], [{ name: 'edges' }, { name: 'node' }]],
+        paths: CONNECTION_NODE_PATHS,
       }) as MaybePromise<SelectionMap>;
 
       const { hasTotalCount, totalCountOnly } = connectionSelectionFromNames(getSelection());
@@ -320,19 +335,89 @@ export class PrismaObjectFieldBuilder<
         (parent as { _count?: Record<string, number> })._count?.[name],
       );
 
+    // The fallback branch's count, which the parent row cannot carry: the rows it pages come from
+    // the user's own resolver, not from a query that could have selected `_count` alongside them.
+    // So the count is asked of the parent, through the same `findUnique` every other load of this
+    // parent uses, and asked lazily — a document that does not select `totalCount` never runs it.
+    const totalCountFromParent =
+      (
+        connectionQuery: { where?: {} },
+        parent: unknown,
+        context: {},
+        loaderCache: ((model: unknown) => ModelLoader) | undefined,
+      ) =>
+      () => {
+        const loader = loaderCache?.(context);
+
+        if (!loader) {
+          throw new PothosSchemaError(
+            `Unable to load totalCount for ${this.model}.${name}: no loader for the parent type`,
+          );
+        }
+
+        const countSelect =
+          this.builder.options.prisma.filterConnectionTotalCount !== false && connectionQuery.where
+            ? { where: connectionQuery.where }
+            : true;
+
+        return Promise.resolve(
+          getDelegateFromModel(
+            getClient(this.builder, context as never),
+            loader.modelName,
+          ).findUnique({
+            where: loader.findUnique(parent as Record<string, unknown>, context) as never,
+            select: { _count: { select: { [name]: countSelect } } },
+          } as never) as PromiseLike<{ _count?: Record<string, number> } | null>,
+        ).then((row) => row?._count?.[name] ?? 0);
+      };
+
     const resolveFallback =
       resolve &&
       ((
-        connectionQuery: {},
-        q: { take: number },
+        connectionQuery: { take: number; where?: {} },
+        q: {},
         parent: unknown,
         args: PothosSchemaTypes.DefaultConnectionArguments,
         context: {},
         info: GraphQLResolveInfo,
+        loaderCache: ((model: unknown) => ModelLoader) | undefined,
       ) =>
         Promise.resolve(
           resolve({ ...q, ...connectionQuery } as never, parent, args, context, info),
-        ).then((result) => wrapConnectionResult(parent, result, args, q.take, formatCursor)));
+        ).then((result) =>
+          wrapConnectionResult(
+            parent,
+            result,
+            args,
+            // The page size of the *connection* query, probe row included. `q` is the plan's
+            // selection map and has no `take` of its own; reading it there left every page
+            // reporting `hasNextPage: false`.
+            connectionQuery.take,
+            formatCursor,
+            totalCount
+              ? totalCountFromParent(connectionQuery, parent, context, loaderCache)
+              : undefined,
+          ),
+        ));
+
+    // The recipe for planning the fallback's own query. The field's return type is the relay
+    // wrapper, which has no model, so the planner is told the same three things `relationSelect`
+    // already computes for the planned path: the node type (from `ref`, never the wrapper, so a
+    // shared connection object still resolves to one model), the paths down to it, and the cursor
+    // columns to seed so `formatCursor` has something to read. Every value here is static, fixed
+    // where the field is defined; the plan itself is still built per request from `info`.
+    const fallbackPlan: FallbackPlanRecipe | undefined =
+      typeof resolve === 'function'
+        ? () => {
+            typeName ??= this.builder.configStore.getTypeConfig(ref).name;
+
+            return {
+              typeName,
+              paths: CONNECTION_NODE_PATHS,
+              initial: { select: { ...cursorSelection } },
+            };
+          }
+        : undefined;
 
     const fieldRef = (
       this as unknown as {
@@ -362,20 +447,30 @@ export class PrismaObjectFieldBuilder<
           pothosPrismaFallback:
             resolveFallback &&
             ((
-              q: { take: number },
+              q: {},
               parent: unknown,
               args: PothosSchemaTypes.DefaultConnectionArguments,
               context: {},
               info: GraphQLResolveInfo,
+              loaderCache: ((model: unknown) => ModelLoader) | undefined,
             ) => {
               const connectionQuery = getQuery(args, context);
 
               return isThenable(connectionQuery)
                 ? connectionQuery.then((resolved) =>
-                    resolveFallback(resolved as {}, q, parent, args, context, info),
+                    resolveFallback(
+                      resolved as { take: number },
+                      q,
+                      parent,
+                      args,
+                      context,
+                      info,
+                      loaderCache,
+                    ),
                   )
-                : resolveFallback(connectionQuery, q, parent, args, context, info);
+                : resolveFallback(connectionQuery, q, parent, args, context, info, loaderCache);
             }),
+          pothosPrismaFallbackPlan: fallbackPlan,
         },
         type: ref,
         resolve: (
@@ -400,14 +495,23 @@ export class PrismaObjectFieldBuilder<
             ...connectionOptions,
             fields: totalCount
               ? (
-                  t: PothosSchemaTypes.ObjectFieldBuilder<SchemaTypes, { totalCount?: number }>,
+                  t: PothosSchemaTypes.ObjectFieldBuilder<
+                    SchemaTypes,
+                    { totalCount?: number | (() => MaybePromise<number>) }
+                  >,
                 ) => ({
                   totalCount: t.int({
                     nullable: false,
                     extensions: {
                       pothosPrismaTotalCount: true,
                     },
-                    resolve: (parent, _args, _context) => parent.totalCount,
+                    // The loaded path has the count on the parent row already and passes the
+                    // number; the fallback has to go and ask for it, and passes a thunk so a
+                    // document that never selects this field never runs that query.
+                    resolve: (parent, _args, _context) =>
+                      typeof parent.totalCount === 'function'
+                        ? parent.totalCount()
+                        : parent.totalCount,
                   }),
                   ...(connectionOptions as { fields?: (t: unknown) => {} }).fields?.(t),
                 })

--- a/packages/plugin-prisma/src/prisma-field-builder.ts
+++ b/packages/plugin-prisma/src/prisma-field-builder.ts
@@ -404,10 +404,16 @@ export class PrismaObjectFieldBuilder<
         // path uses to decide whether to select `_count` at all — rather than deferred behind a
         // thunk, so what lands on the connection is a plain number for every field that reads it,
         // user-defined ones included, and not just for the generated one.
-        const { hasTotalCount } = connectionSelection(context, info);
+        const { hasTotalCount, totalCountOnly } = connectionSelection(context, info);
 
         return Promise.all([
-          resolve({ ...q, ...connectionQuery } as never, parent, args, context, info),
+          // Nothing beneath this connection but `totalCount`, so every row the resolver returned
+          // would be dropped on the floor. The loaded path already passes `[]` here rather than
+          // reading rows it will discard; the fallback does the same, rather than paying for a
+          // page of up to `maxSize` rows per parent that nothing reads.
+          totalCountOnly
+            ? []
+            : resolve({ ...q, ...connectionQuery } as never, parent, args, context, info),
           hasTotalCount
             ? totalCountFromParent(connectionQuery, parent, context, loaderCache, info)
             : undefined,

--- a/packages/plugin-prisma/src/prisma-field-builder.ts
+++ b/packages/plugin-prisma/src/prisma-field-builder.ts
@@ -51,8 +51,6 @@ import type { FallbackPlanRecipe } from './util/map-query.js';
 
 import type { FieldMap } from './util/relation-map.js';
 
-// The two ways a relay connection exposes its nodes, shared by the planned path's select function
-// and the fallback's plan recipe so both plan the same selection.
 const CONNECTION_NODE_PATHS: IndirectPathSegment[][] = [
   [{ name: 'nodes' }],
   [{ name: 'edges' }, { name: 'node' }],
@@ -335,9 +333,6 @@ export class PrismaObjectFieldBuilder<
         (parent as { _count?: Record<string, number> })._count?.[name],
       );
 
-    // The fallback branch's count: its rows come from the user's own resolver, not from a query
-    // that could have selected `_count` beside them, so the count is asked of the parent through
-    // the same `findUnique` every other load of it uses.
     const totalCountFromParent = (
       connectionQuery: { where?: {} },
       parent: unknown,
@@ -370,8 +365,6 @@ export class PrismaObjectFieldBuilder<
       ).then((row) => {
         const count = row?._count?.[name];
 
-        // `totalCount` is a non-nullable Int, and a parent the fallback was handed need not be a
-        // row at all, so a parent that matches none has no count to report.
         if (count === undefined) {
           throw new PothosValidationError(
             `Unable to load totalCount for ${field}: no ${loader.modelName} row matches the parent this connection resolved from`,
@@ -396,8 +389,6 @@ export class PrismaObjectFieldBuilder<
         const { hasTotalCount, totalCountOnly } = connectionSelection(context, info);
 
         return Promise.all([
-          // Nothing beneath this connection but `totalCount`, so every row the resolver returned
-          // would be dropped on the floor; the planned path passes `[]` here too.
           totalCountOnly
             ? []
             : resolve({ ...q, ...connectionQuery } as never, parent, args, context, info),
@@ -405,23 +396,10 @@ export class PrismaObjectFieldBuilder<
             ? totalCountFromParent(connectionQuery, parent, context, loaderCache, info)
             : undefined,
         ]).then(([result, count]) =>
-          wrapConnectionResult(
-            parent,
-            result,
-            args,
-            // The page size of the *connection* query, probe row included; `q` is the plan's
-            // selection map and has no `take` of its own.
-            connectionQuery.take,
-            formatCursor,
-            count,
-          ),
+          wrapConnectionResult(parent, result, args, connectionQuery.take, formatCursor, count),
         );
       });
 
-    // The field's return type is the relay wrapper, which has no model, so the planner is told
-    // what `relationSelect` computes for the planned path: the node type (from `ref`, never the
-    // wrapper, so a shared connection object still resolves to one model), the paths down to it,
-    // and the cursor columns to seed so `formatCursor` has something to read.
     const fallbackPlan: FallbackPlanRecipe | undefined =
       typeof resolve === 'function'
         ? () => {

--- a/packages/plugin-prisma/src/util/map-query.ts
+++ b/packages/plugin-prisma/src/util/map-query.ts
@@ -120,14 +120,6 @@ export function queryFromInfo<
   return result as QueryFromInfoReturn<Select, Include, Await>;
 }
 
-/**
- * How a field wants its fallback planned, recorded where the field is defined. A field whose
- * return type is not the type its rows come from — a relay connection wrapper, which has no model
- * of its own — cannot be planned from `info.returnType`, so it names the node type, the paths down
- * to it, and the columns to seed. Read through a function because `typeName` resolves against the
- * config store, which a field cannot read while it is being defined, and because `initial` is
- * merged into a plan's root and must not be shared between plans.
- */
 export type FallbackPlanRecipe = () => {
   typeName?: string;
   paths?: PathSegment[][];
@@ -163,8 +155,6 @@ export function fallbackQueryFromInfo(
       skipDeferredFragments,
     }) as MaybePromise<PrismaPlan> | undefined;
 
-    // Nothing is selected under the recipe's paths — a connection asked only for its `totalCount`.
-    // There is no plan to cache and nothing to map, so the caller gets back the recipe's own seed.
     if (!planned) {
       return initial ?? {};
     }

--- a/packages/plugin-prisma/src/util/map-query.ts
+++ b/packages/plugin-prisma/src/util/map-query.ts
@@ -121,6 +121,24 @@ export function queryFromInfo<
 }
 
 /**
+ * How a field wants its fallback planned, recorded where the field is defined. A field whose
+ * return type is not the type the rows come from — a relay connection wrapper, which has no model
+ * of its own — cannot be planned from `info.returnType`, and the planner has no way to guess the
+ * node type, the path down to it, or the columns the field needs seeded. So the field says, in the
+ * same terms its own select function already uses.
+ *
+ * This is a recipe, not a plan: the three values are static, fixed when the field is defined, and
+ * the plan is still built per request from `info`. It is read through a function only because
+ * `typeName` resolves against the config store, which a field cannot read while it is being
+ * defined, and because `initial` is merged into a plan's root and must not be shared between them.
+ */
+export type FallbackPlanRecipe = () => {
+  typeName?: string;
+  paths?: PathSegment[][];
+  initial?: SelectionMap;
+};
+
+/**
  * The query for the field `info` resolves, from a plan `plans` holds per `Type@path`. The
  * fallback in `wrapResolve` runs once per row of the list its parent came from, so the plan is
  * walked and settled once and played per call: each caller still gets a query of its own, and
@@ -132,17 +150,31 @@ export function fallbackQueryFromInfo(
   context: object,
   info: GraphQLResolveInfo,
   skipDeferredFragments = true,
+  recipe?: FallbackPlanRecipe,
 ): MaybePromise<SelectionMap> {
   const key = cacheKey(info.parentType.name, info.path);
   let plan = plans.get(key);
 
   if (!plan) {
-    plan = Plan.fromInfo(prismaAdapter, {
+    const { typeName, paths, initial } = recipe?.() ?? {};
+
+    const planned = Plan.fromInfo(prismaAdapter, {
       context,
       info,
+      typeName,
+      paths,
+      initial,
       skipDeferredFragments,
-    }) as MaybePromise<PrismaPlan>;
+    }) as MaybePromise<PrismaPlan> | undefined;
 
+    // Nothing is selected under the recipe's paths — a connection asked only for its `totalCount`.
+    // There is no plan to cache and nothing to map, so the caller gets back the seed the recipe
+    // asked for, which is what the plan would have started from anyway.
+    if (!planned) {
+      return initial ?? {};
+    }
+
+    plan = planned;
     plans.set(key, plan);
   }
 

--- a/packages/plugin-prisma/src/util/map-query.ts
+++ b/packages/plugin-prisma/src/util/map-query.ts
@@ -122,15 +122,11 @@ export function queryFromInfo<
 
 /**
  * How a field wants its fallback planned, recorded where the field is defined. A field whose
- * return type is not the type the rows come from — a relay connection wrapper, which has no model
- * of its own — cannot be planned from `info.returnType`, and the planner has no way to guess the
- * node type, the path down to it, or the columns the field needs seeded. So the field says, in the
- * same terms its own select function already uses.
- *
- * This is a recipe, not a plan: the three values are static, fixed when the field is defined, and
- * the plan is still built per request from `info`. It is read through a function only because
- * `typeName` resolves against the config store, which a field cannot read while it is being
- * defined, and because `initial` is merged into a plan's root and must not be shared between them.
+ * return type is not the type its rows come from — a relay connection wrapper, which has no model
+ * of its own — cannot be planned from `info.returnType`, so it names the node type, the paths down
+ * to it, and the columns to seed. Read through a function because `typeName` resolves against the
+ * config store, which a field cannot read while it is being defined, and because `initial` is
+ * merged into a plan's root and must not be shared between plans.
  */
 export type FallbackPlanRecipe = () => {
   typeName?: string;
@@ -168,8 +164,7 @@ export function fallbackQueryFromInfo(
     }) as MaybePromise<PrismaPlan> | undefined;
 
     // Nothing is selected under the recipe's paths — a connection asked only for its `totalCount`.
-    // There is no plan to cache and nothing to map, so the caller gets back the seed the recipe
-    // asked for, which is what the plan would have started from anyway.
+    // There is no plan to cache and nothing to map, so the caller gets back the recipe's own seed.
     if (!planned) {
       return initial ?? {};
     }

--- a/packages/plugin-prisma/tests/loader-batching.test.ts
+++ b/packages/plugin-prisma/tests/loader-batching.test.ts
@@ -198,8 +198,6 @@ const User = builder.prismaObject('User', {
       },
       resolve: (query, user) => prisma.post.findMany({ ...query, where: { authorId: user.id } }),
     }),
-    // No `resolve` of its own, so no fallback is installed: an unplanned parent reloads itself
-    // through the model loader, which plans the connection with the field's own select function.
     postsConnection: t.relatedConnection('posts', {
       cursor: 'id',
       query: () => ({ orderBy: { id: 'asc' } }),

--- a/packages/plugin-prisma/tests/loader-batching.test.ts
+++ b/packages/plugin-prisma/tests/loader-batching.test.ts
@@ -198,8 +198,8 @@ const User = builder.prismaObject('User', {
       },
       resolve: (query, user) => prisma.post.findMany({ ...query, where: { authorId: user.id } }),
     }),
-    // Planned through `fallbackQueryFromInfo` and resolved a row at a time, rather than through
-    // the model loader.
+    // No `resolve` of its own, so no fallback is installed: an unplanned parent reloads itself
+    // through the model loader, which plans the connection with the field's own select function.
     postsConnection: t.relatedConnection('posts', {
       cursor: 'id',
       query: () => ({ orderBy: { id: 'asc' } }),

--- a/packages/plugin-prisma/tests/related-connection-fallback.test.ts
+++ b/packages/plugin-prisma/tests/related-connection-fallback.test.ts
@@ -7,12 +7,7 @@ import { prisma, queries } from './example/builder';
 import { getDatamodel } from './generated.js';
 
 // A `relatedConnection` with a custom `resolve` installs a fallback resolver, which runs whenever
-// the parent row was not loaded with the connection's rows on it. The field's return type is the
-// relay wrapper, which has no model, so the fallback cannot be planned from it: the field records
-// what to plan instead — the node type, the paths down to it, and the cursor columns to seed — and
-// the fallback plans that per request. What it hands the user's resolver then has to match what the
-// planned path would have selected, and the page it wraps has to match what the planned path would
-// have paged.
+// the parent row was not loaded with the connection's rows on it.
 const builder = new SchemaBuilder<{
   PrismaTypes: PrismaTypesFromClient<typeof prisma>;
 }>({
@@ -37,8 +32,8 @@ interface FallbackQuery {
 
 const resolveCalls: FallbackQuery[] = [];
 
-// A resolver that does not key off the parent at all, which a custom `resolve` is free to do:
-// a page of rows comes back even for a parent that matches no row in the database.
+// A resolver that does not key off the parent at all, so a page of rows comes back even for a
+// parent that matches no row in the database.
 const resolveDetached = (query: FallbackQuery) => {
   resolveCalls.push(query);
 
@@ -136,8 +131,8 @@ const User = builder.prismaObject('User', {
         }),
       },
     ),
-    // No `resolve`: never installs a fallback, so an unplanned parent keeps reloading itself
-    // through the model loader. Here to pin that the recipe changes nothing for it.
+    // No `resolve`: never installs a fallback, so an unplanned parent reloads itself through the
+    // model loader.
     plainPosts: t.relatedConnection('posts', { cursor: 'id', totalCount: true }),
     plainCountWithCustomField: t.relatedConnection(
       'posts',
@@ -175,8 +170,7 @@ builder.queryType({
       resolve: (query) =>
         prisma.user.findMany({ ...query, where: { id: { in: [1, 2, 3, 4, 5] } } }),
     }),
-    // A parent that corresponds to no row at all, which only the fallback branch can produce: it
-    // came from a resolver of the user's own, not from a prisma query.
+    // A parent that corresponds to no row at all.
     ghostUser: t.field({
       type: User,
       resolve: () => ({ id: 999999 }) as never,
@@ -238,8 +232,8 @@ describe('relatedConnection with a custom resolve, unplanned parent', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    // `id` is the cursor column the recipe seeds; `title` is what the document asked for beneath
-    // `edges { node }`. Without the seed `formatCursor` would have no column to read.
+    // `id` is the cursor column the recipe seeds, without which `formatCursor` would have no
+    // column to read; `title` is what the document asked for beneath `edges { node }`.
     expect(resolveCalls[0].select).toStrictEqual({ id: true, title: true });
   });
 
@@ -327,7 +321,7 @@ describe('relatedConnection fallback totalCount', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    // Only the resolver's own findMany: the count is a thunk and nothing called it.
+    // Only the resolver's own findMany: `totalCount` is unselected, so no count is loaded.
     expect(queries).toStrictEqual([expect.objectContaining({ model: 'Post', action: 'findMany' })]);
   });
 
@@ -338,9 +332,8 @@ describe('relatedConnection fallback totalCount', () => {
 
     expect(result.errors).toBeUndefined();
     expect(connection(result, 'unplannedUser', 'postsWithCount').totalCount).toBe(250);
-    // `Plan.fromInfo` answers `undefined` here — there is nothing under `nodes`/`edges.node` to
-    // plan — and the fallback returns the recipe's own seed rather than crashing. Nothing reads
-    // the rows, so the resolver is not asked for them; see the query-count test below.
+    // `Plan.fromInfo` answers `undefined` here — nothing is selected under `nodes`/`edges.node`
+    // — and the fallback plans the recipe's own seed instead.
     expect(resolveCalls).toHaveLength(0);
   });
 });
@@ -363,9 +356,8 @@ describe('relatedConnection fallback pagination', () => {
 
     expect(result.errors).toBeUndefined();
     const posts = connection(result, 'unplannedUser', 'posts');
-    // The connection query asks for one row plus a probe; the probe has to be sliced off and
-    // reported as a next page. Reading `take` off the plan's selection map instead — which has
-    // none — left every page of every fallback connection reporting `hasNextPage: false`.
+    // The connection query asks for one row plus a probe; the probe is sliced off and reported
+    // as a next page.
     expect(resolveCalls[0].take).toBe(2);
     expect(posts.edges).toHaveLength(1);
     expect(posts.pageInfo.hasNextPage).toBe(true);
@@ -530,9 +522,8 @@ describe('relatedConnection fallback review follow-ups', () => {
       ghostUser { detachedWithCount(first: 2) { totalCount edges { node { id } } } }
     }`);
 
-    // The resolver still returns rows, so a count of 0 would sit next to a non-empty page: a
-    // wrong answer presented as a fact on a non-nullable Int. The field errors instead, naming
-    // what could not be counted.
+    // The resolver still returns rows, so a count of 0 would sit next to a non-empty page on a
+    // non-nullable Int.
     expect(result.errors?.[0]?.message).toMatch(
       /Unable to load totalCount for User\.detachedWithCount/,
     );
@@ -557,14 +548,12 @@ describe('relatedConnection fallback review follow-ups', () => {
       (result.data as any).unplannedUsers.map((u: any) => u.postsWithCount.totalCount),
     ).toStrictEqual([250, 250, 250, 250, 250]);
 
-    // Five counts and nothing else. Before, this also paid for five `Post.findMany` calls of up
-    // to `maxSize + 1` rows each, every row of which was discarded.
+    // Five counts and nothing else.
     expect(queries).toHaveLength(5);
     expect(queries.every((q) => (q as { model: string }).model === 'User')).toBe(true);
     expect(resolveCalls).toHaveLength(0);
 
-    // Which is what the same unplanned parents cost through the model loader, for a connection
-    // with no custom resolve at all.
+    // The same unplanned parents cost as much through the model loader.
     queries.length = 0;
     const viaLoader = await run('{ unplannedUsers { plainPosts { totalCount } } }');
 
@@ -579,8 +568,6 @@ describe('relatedConnection fallback review follow-ups', () => {
 
     expect(result.errors).toBeUndefined();
     expect(connection(result, 'unplannedUser', 'postsWithCount').totalCount).toBe(250);
-    // The loaded path passes `[]` rather than reading rows it will discard; the fallback does the
-    // same rather than paying for a findMany whose rows nothing reads.
     expect(resolveCalls).toHaveLength(0);
     expect(queries).toStrictEqual([
       expect.objectContaining({ model: 'User', action: 'findUnique' }),

--- a/packages/plugin-prisma/tests/related-connection-fallback.test.ts
+++ b/packages/plugin-prisma/tests/related-connection-fallback.test.ts
@@ -165,6 +165,16 @@ builder.queryType({
       type: User,
       resolve: () => ({ id: 1 }) as never,
     }),
+    // Five unplanned parents, for counting the queries a list of them costs.
+    unplannedUsers: t.field({
+      type: [User],
+      resolve: () => [1, 2, 3, 4, 5].map((id) => ({ id })) as never,
+    }),
+    plannedUsers: t.prismaField({
+      type: [User],
+      resolve: (query) =>
+        prisma.user.findMany({ ...query, where: { id: { in: [1, 2, 3, 4, 5] } } }),
+    }),
     // A parent that corresponds to no row at all, which only the fallback branch can produce: it
     // came from a resolver of the user's own, not from a prisma query.
     ghostUser: t.field({
@@ -328,9 +338,10 @@ describe('relatedConnection fallback totalCount', () => {
 
     expect(result.errors).toBeUndefined();
     expect(connection(result, 'unplannedUser', 'postsWithCount').totalCount).toBe(250);
-    // The plan is `undefined` here — there is nothing under `nodes`/`edges.node` to plan — so the
-    // resolver is handed the recipe's own seed rather than a crash.
-    expect(resolveCalls[0].select).toStrictEqual({ id: true });
+    // `Plan.fromInfo` answers `undefined` here — there is nothing under `nodes`/`edges.node` to
+    // plan — and the fallback returns the recipe's own seed rather than crashing. Nothing reads
+    // the rows, so the resolver is not asked for them; see the query-count test below.
+    expect(resolveCalls).toHaveLength(0);
   });
 });
 
@@ -535,6 +546,30 @@ describe('relatedConnection fallback review follow-ups', () => {
     // Nothing here needs the parent to exist, so nothing errors.
     expect(result.errors).toBeUndefined();
     expect(connection(result, 'ghostUser', 'detachedPosts').edges).toHaveLength(2);
+  });
+
+  it('costs one query per parent for a totalCount-only selection over a list', async () => {
+    const result = await run('{ unplannedUsers { postsWithCount { totalCount } } }');
+
+    expect(result.errors).toBeUndefined();
+    expect(
+      // biome-ignore lint/suspicious/noExplicitAny: reading a result the document's own shape defines
+      (result.data as any).unplannedUsers.map((u: any) => u.postsWithCount.totalCount),
+    ).toStrictEqual([250, 250, 250, 250, 250]);
+
+    // Five counts and nothing else. Before, this also paid for five `Post.findMany` calls of up
+    // to `maxSize + 1` rows each, every row of which was discarded.
+    expect(queries).toHaveLength(5);
+    expect(queries.every((q) => (q as { model: string }).model === 'User')).toBe(true);
+    expect(resolveCalls).toHaveLength(0);
+
+    // Which is what the same unplanned parents cost through the model loader, for a connection
+    // with no custom resolve at all.
+    queries.length = 0;
+    const viaLoader = await run('{ unplannedUsers { plainPosts { totalCount } } }');
+
+    expect(viaLoader.errors).toBeUndefined();
+    expect(queries).toHaveLength(5);
   });
 
   it('does not ask the resolver for rows it would throw away on a totalCount-only selection', async () => {

--- a/packages/plugin-prisma/tests/related-connection-fallback.test.ts
+++ b/packages/plugin-prisma/tests/related-connection-fallback.test.ts
@@ -37,6 +37,14 @@ interface FallbackQuery {
 
 const resolveCalls: FallbackQuery[] = [];
 
+// A resolver that does not key off the parent at all, which a custom `resolve` is free to do:
+// a page of rows comes back even for a parent that matches no row in the database.
+const resolveDetached = (query: FallbackQuery) => {
+  resolveCalls.push(query);
+
+  return prisma.post.findMany({ ...query, orderBy: { id: 'asc' } } as never);
+};
+
 const resolvePosts = (query: FallbackQuery, user: { id: number }) => {
   resolveCalls.push(query);
 
@@ -106,9 +114,46 @@ const User = builder.prismaObject('User', {
       { cursor: 'id', type: SelectedPost, resolve: resolvePosts },
       SharedPostConnection,
     ),
+    detachedWithCount: t.relatedConnection('posts', {
+      cursor: 'id',
+      totalCount: true,
+      resolve: resolveDetached,
+    }),
+    detachedPosts: t.relatedConnection('posts', { cursor: 'id', resolve: resolveDetached }),
+    // A user-defined field on the connection object, which reads `totalCount` off the connection
+    // the same way the generated field does.
+    countWithCustomField: t.relatedConnection(
+      'posts',
+      { cursor: 'id', totalCount: true, resolve: resolvePosts },
+      {
+        fields: (c) => ({
+          doubled: c.int({
+            resolve: (con) => ((con as { totalCount?: number }).totalCount ?? 0) * 2,
+          }),
+          countKind: c.string({
+            resolve: (con) => typeof (con as { totalCount?: unknown }).totalCount,
+          }),
+        }),
+      },
+    ),
     // No `resolve`: never installs a fallback, so an unplanned parent keeps reloading itself
     // through the model loader. Here to pin that the recipe changes nothing for it.
     plainPosts: t.relatedConnection('posts', { cursor: 'id', totalCount: true }),
+    plainCountWithCustomField: t.relatedConnection(
+      'posts',
+      { cursor: 'id', totalCount: true },
+      {
+        name: 'PlainCountConnection',
+        fields: (c) => ({
+          doubled: c.int({
+            resolve: (con) => ((con as { totalCount?: number }).totalCount ?? 0) * 2,
+          }),
+          countKind: c.string({
+            resolve: (con) => typeof (con as { totalCount?: unknown }).totalCount,
+          }),
+        }),
+      },
+    ),
   }),
 });
 
@@ -119,6 +164,12 @@ builder.queryType({
     unplannedUser: t.field({
       type: User,
       resolve: () => ({ id: 1 }) as never,
+    }),
+    // A parent that corresponds to no row at all, which only the fallback branch can produce: it
+    // came from a resolver of the user's own, not from a prisma query.
+    ghostUser: t.field({
+      type: User,
+      resolve: () => ({ id: 999999 }) as never,
     }),
     // The same user through a planned query, for comparing the two paths.
     plannedUser: t.prismaField({
@@ -427,5 +478,77 @@ describe('relatedConnection fallback agrees with the planned path', () => {
     const posts = connection(result, 'unplannedUser', 'plainPosts');
     expect(posts.totalCount).toBe(250);
     expect(posts.edges).toHaveLength(2);
+  });
+});
+
+describe('relatedConnection fallback review follow-ups', () => {
+  afterEach(() => {
+    queries.length = 0;
+    resolveCalls.length = 0;
+  });
+
+  it('hands user-defined connection fields the same totalCount the generated field gets', async () => {
+    const selection = 'countWithCustomField(first: 1) { totalCount countKind doubled }';
+
+    const fallback = await run(`{ unplannedUser { ${selection} } }`);
+    expect(fallback.errors).toBeUndefined();
+    expect(connection(fallback, 'unplannedUser', 'countWithCustomField')).toEqual({
+      totalCount: 250,
+      countKind: 'number',
+      doubled: 500,
+    });
+  });
+
+  it('matches the loader path for a user-defined connection field', async () => {
+    const fallback = await run(
+      '{ unplannedUser { countWithCustomField(first: 1) { totalCount countKind doubled } } }',
+    );
+    const loader = await run(
+      '{ unplannedUser { plainCountWithCustomField(first: 1) { totalCount countKind doubled } } }',
+    );
+
+    expect(fallback.errors).toBeUndefined();
+    expect(loader.errors).toBeUndefined();
+    expect(connection(fallback, 'unplannedUser', 'countWithCustomField')).toStrictEqual(
+      connection(loader, 'unplannedUser', 'plainCountWithCustomField'),
+    );
+  });
+
+  it('refuses to invent a totalCount for a parent that is not a row', async () => {
+    const result = await run(`{
+      ghostUser { detachedWithCount(first: 2) { totalCount edges { node { id } } } }
+    }`);
+
+    // The resolver still returns rows, so a count of 0 would sit next to a non-empty page: a
+    // wrong answer presented as a fact on a non-nullable Int. The field errors instead, naming
+    // what could not be counted.
+    expect(result.errors?.[0]?.message).toMatch(
+      /Unable to load totalCount for User\.detachedWithCount/,
+    );
+  });
+
+  it('still answers a page for a parent that is not a row when totalCount is not selected', async () => {
+    const result = await run(`{
+      ghostUser { detachedPosts(first: 2) { edges { node { id } } } }
+    }`);
+
+    // Nothing here needs the parent to exist, so nothing errors.
+    expect(result.errors).toBeUndefined();
+    expect(connection(result, 'ghostUser', 'detachedPosts').edges).toHaveLength(2);
+  });
+
+  it('does not ask the resolver for rows it would throw away on a totalCount-only selection', async () => {
+    const result = await run(`{
+      unplannedUser { postsWithCount { totalCount } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(connection(result, 'unplannedUser', 'postsWithCount').totalCount).toBe(250);
+    // The loaded path passes `[]` rather than reading rows it will discard; the fallback does the
+    // same rather than paying for a findMany whose rows nothing reads.
+    expect(resolveCalls).toHaveLength(0);
+    expect(queries).toStrictEqual([
+      expect.objectContaining({ model: 'User', action: 'findUnique' }),
+    ]);
   });
 });

--- a/packages/plugin-prisma/tests/related-connection-fallback.test.ts
+++ b/packages/plugin-prisma/tests/related-connection-fallback.test.ts
@@ -6,8 +6,6 @@ import PrismaPlugin, { type PrismaTypesFromClient } from '../src';
 import { prisma, queries } from './example/builder';
 import { getDatamodel } from './generated.js';
 
-// A `relatedConnection` with a custom `resolve` installs a fallback resolver, which runs whenever
-// the parent row was not loaded with the connection's rows on it.
 const builder = new SchemaBuilder<{
   PrismaTypes: PrismaTypesFromClient<typeof prisma>;
 }>({
@@ -32,8 +30,6 @@ interface FallbackQuery {
 
 const resolveCalls: FallbackQuery[] = [];
 
-// A resolver that does not key off the parent at all, so a page of rows comes back even for a
-// parent that matches no row in the database.
 const resolveDetached = (query: FallbackQuery) => {
   resolveCalls.push(query);
 
@@ -63,8 +59,6 @@ builder.prismaObject('User', {
   fields: (t) => ({ id: t.exposeID('id') }),
 });
 
-// A node type in select mode, where what the plan selected is visible in the emitted query rather
-// than implied by include mode's "every column".
 const SelectedPost = builder.prismaObject('Post', {
   variant: 'SelectedPost',
   select: { id: true },
@@ -75,8 +69,6 @@ const SelectedPost = builder.prismaObject('Post', {
   }),
 });
 
-// A connection object shared between fields: the recipe has to name the *node* type, since a
-// shared wrapper could never resolve to one model.
 const SharedPostConnection = builder.connectionObject(
   { type: SelectedPost, name: 'SharedPostConnection' },
   { name: 'SharedPostEdge' },
@@ -86,7 +78,6 @@ const User = builder.prismaObject('User', {
   fields: (t) => ({
     id: t.exposeID('id'),
     posts: t.relatedConnection('posts', { cursor: 'id', resolve: resolvePosts }),
-    // A page big enough to reach the end of the relation, past the default max size.
     allPosts: t.relatedConnection('posts', { cursor: 'id', maxSize: 500, resolve: resolvePosts }),
     selectedPosts: t.relatedConnection('posts', {
       cursor: 'id',
@@ -115,8 +106,6 @@ const User = builder.prismaObject('User', {
       resolve: resolveDetached,
     }),
     detachedPosts: t.relatedConnection('posts', { cursor: 'id', resolve: resolveDetached }),
-    // A user-defined field on the connection object, which reads `totalCount` off the connection
-    // the same way the generated field does.
     countWithCustomField: t.relatedConnection(
       'posts',
       { cursor: 'id', totalCount: true, resolve: resolvePosts },
@@ -131,8 +120,6 @@ const User = builder.prismaObject('User', {
         }),
       },
     ),
-    // No `resolve`: never installs a fallback, so an unplanned parent reloads itself through the
-    // model loader.
     plainPosts: t.relatedConnection('posts', { cursor: 'id', totalCount: true }),
     plainCountWithCustomField: t.relatedConnection(
       'posts',
@@ -154,13 +141,10 @@ const User = builder.prismaObject('User', {
 
 builder.queryType({
   fields: (t) => ({
-    // An unplanned parent: the row is built by hand, so nothing beneath it was planned into a
-    // prisma query and every field on it has to load itself.
     unplannedUser: t.field({
       type: User,
       resolve: () => ({ id: 1 }) as never,
     }),
-    // Five unplanned parents, for counting the queries a list of them costs.
     unplannedUsers: t.field({
       type: [User],
       resolve: () => [1, 2, 3, 4, 5].map((id) => ({ id })) as never,
@@ -170,12 +154,10 @@ builder.queryType({
       resolve: (query) =>
         prisma.user.findMany({ ...query, where: { id: { in: [1, 2, 3, 4, 5] } } }),
     }),
-    // A parent that corresponds to no row at all.
     ghostUser: t.field({
       type: User,
       resolve: () => ({ id: 999999 }) as never,
     }),
-    // The same user through a planned query, for comparing the two paths.
     plannedUser: t.prismaField({
       type: User,
       resolve: (query) => prisma.user.findUniqueOrThrow({ ...query, where: { id: 1 } }),
@@ -192,8 +174,6 @@ const connection = (result: { data?: unknown }, root: string, field: string): an
   // biome-ignore lint/suspicious/noExplicitAny: as above
   (result.data as any)[root][field];
 
-// The prisma call the planned path emitted for the relation, which is the connection's own query
-// nested under the parent's.
 const plannedRelationQuery = (relation = 'posts') =>
   (queries[0] as { args: { include?: Record<string, unknown> } }).args.include?.[relation];
 
@@ -232,8 +212,6 @@ describe('relatedConnection with a custom resolve, unplanned parent', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    // `id` is the cursor column the recipe seeds, without which `formatCursor` would have no
-    // column to read; `title` is what the document asked for beneath `edges { node }`.
     expect(resolveCalls[0].select).toStrictEqual({ id: true, title: true });
   });
 
@@ -311,7 +289,6 @@ describe('relatedConnection fallback totalCount', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    // 250 posts per user, published for `j > 100`: 149 of them.
     expect(connection(result, 'unplannedUser', 'publishedWithCount').totalCount).toBe(149);
   });
 
@@ -321,7 +298,6 @@ describe('relatedConnection fallback totalCount', () => {
     }`);
 
     expect(result.errors).toBeUndefined();
-    // Only the resolver's own findMany: `totalCount` is unselected, so no count is loaded.
     expect(queries).toStrictEqual([expect.objectContaining({ model: 'Post', action: 'findMany' })]);
   });
 
@@ -332,8 +308,6 @@ describe('relatedConnection fallback totalCount', () => {
 
     expect(result.errors).toBeUndefined();
     expect(connection(result, 'unplannedUser', 'postsWithCount').totalCount).toBe(250);
-    // `Plan.fromInfo` answers `undefined` here — nothing is selected under `nodes`/`edges.node`
-    // — and the fallback plans the recipe's own seed instead.
     expect(resolveCalls).toHaveLength(0);
   });
 });
@@ -356,8 +330,6 @@ describe('relatedConnection fallback pagination', () => {
 
     expect(result.errors).toBeUndefined();
     const posts = connection(result, 'unplannedUser', 'posts');
-    // The connection query asks for one row plus a probe; the probe is sliced off and reported
-    // as a next page.
     expect(resolveCalls[0].take).toBe(2);
     expect(posts.edges).toHaveLength(1);
     expect(posts.pageInfo.hasNextPage).toBe(true);
@@ -444,7 +416,6 @@ describe('relatedConnection fallback agrees with the planned path', () => {
 
     const planned = await run(`{ plannedUser { ${document} } }`);
     expect(planned.errors).toBeUndefined();
-    // The planned parent carries the rows, so the fallback never runs for it.
     expect(resolveCalls).toHaveLength(0);
 
     expect(fallbackQuery).toStrictEqual(plannedRelationQuery());
@@ -522,8 +493,6 @@ describe('relatedConnection fallback review follow-ups', () => {
       ghostUser { detachedWithCount(first: 2) { totalCount edges { node { id } } } }
     }`);
 
-    // The resolver still returns rows, so a count of 0 would sit next to a non-empty page on a
-    // non-nullable Int.
     expect(result.errors?.[0]?.message).toMatch(
       /Unable to load totalCount for User\.detachedWithCount/,
     );
@@ -534,7 +503,6 @@ describe('relatedConnection fallback review follow-ups', () => {
       ghostUser { detachedPosts(first: 2) { edges { node { id } } } }
     }`);
 
-    // Nothing here needs the parent to exist, so nothing errors.
     expect(result.errors).toBeUndefined();
     expect(connection(result, 'ghostUser', 'detachedPosts').edges).toHaveLength(2);
   });
@@ -548,12 +516,10 @@ describe('relatedConnection fallback review follow-ups', () => {
       (result.data as any).unplannedUsers.map((u: any) => u.postsWithCount.totalCount),
     ).toStrictEqual([250, 250, 250, 250, 250]);
 
-    // Five counts and nothing else.
     expect(queries).toHaveLength(5);
     expect(queries.every((q) => (q as { model: string }).model === 'User')).toBe(true);
     expect(resolveCalls).toHaveLength(0);
 
-    // The same unplanned parents cost as much through the model loader.
     queries.length = 0;
     const viaLoader = await run('{ unplannedUsers { plainPosts { totalCount } } }');
 

--- a/packages/plugin-prisma/tests/related-connection-fallback.test.ts
+++ b/packages/plugin-prisma/tests/related-connection-fallback.test.ts
@@ -1,0 +1,431 @@
+import SchemaBuilder from '@pothos/core';
+import RelayPlugin from '@pothos/plugin-relay';
+import { execute } from '@pothos/test-utils';
+import { gql } from 'graphql-tag';
+import PrismaPlugin, { type PrismaTypesFromClient } from '../src';
+import { prisma, queries } from './example/builder';
+import { getDatamodel } from './generated.js';
+
+// A `relatedConnection` with a custom `resolve` installs a fallback resolver, which runs whenever
+// the parent row was not loaded with the connection's rows on it. The field's return type is the
+// relay wrapper, which has no model, so the fallback cannot be planned from it: the field records
+// what to plan instead — the node type, the paths down to it, and the cursor columns to seed — and
+// the fallback plans that per request. What it hands the user's resolver then has to match what the
+// planned path would have selected, and the page it wraps has to match what the planned path would
+// have paged.
+const builder = new SchemaBuilder<{
+  PrismaTypes: PrismaTypesFromClient<typeof prisma>;
+}>({
+  plugins: [PrismaPlugin, RelayPlugin],
+  relay: {
+    nodesOnConnection: true,
+  },
+  prisma: {
+    client: () => prisma,
+    dmmf: getDatamodel(),
+    filterConnectionTotalCount: true,
+  },
+});
+
+interface FallbackQuery {
+  select?: Record<string, unknown>;
+  include?: Record<string, unknown>;
+  take?: number;
+  skip?: number;
+  cursor?: unknown;
+}
+
+const resolveCalls: FallbackQuery[] = [];
+
+const resolvePosts = (query: FallbackQuery, user: { id: number }) => {
+  resolveCalls.push(query);
+
+  return prisma.post.findMany({
+    ...query,
+    where: { authorId: user.id },
+    orderBy: { id: 'asc' },
+  } as never);
+};
+
+builder.prismaObject('Post', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    title: t.exposeString('title'),
+    author: t.relation('author'),
+  }),
+});
+
+builder.prismaObject('User', {
+  variant: 'PostAuthor',
+  fields: (t) => ({ id: t.exposeID('id') }),
+});
+
+// A node type in select mode, where what the plan selected is visible in the emitted query rather
+// than implied by include mode's "every column".
+const SelectedPost = builder.prismaObject('Post', {
+  variant: 'SelectedPost',
+  select: { id: true },
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    title: t.exposeString('title'),
+    content: t.exposeString('content', { nullable: true }),
+  }),
+});
+
+// A connection object shared between fields: the recipe has to name the *node* type, since a
+// shared wrapper could never resolve to one model.
+const SharedPostConnection = builder.connectionObject(
+  { type: SelectedPost, name: 'SharedPostConnection' },
+  { name: 'SharedPostEdge' },
+);
+
+const User = builder.prismaObject('User', {
+  fields: (t) => ({
+    id: t.exposeID('id'),
+    posts: t.relatedConnection('posts', { cursor: 'id', resolve: resolvePosts }),
+    // A page big enough to reach the end of the relation, past the default max size.
+    allPosts: t.relatedConnection('posts', { cursor: 'id', maxSize: 500, resolve: resolvePosts }),
+    selectedPosts: t.relatedConnection('posts', {
+      cursor: 'id',
+      type: SelectedPost,
+      resolve: resolvePosts,
+    }),
+    postsWithCount: t.relatedConnection('posts', {
+      cursor: 'id',
+      totalCount: true,
+      resolve: resolvePosts,
+    }),
+    publishedWithCount: t.relatedConnection('posts', {
+      cursor: 'id',
+      totalCount: true,
+      query: { where: { published: true } },
+      resolve: resolvePosts,
+    }),
+    sharedPosts: t.relatedConnection(
+      'posts',
+      { cursor: 'id', type: SelectedPost, resolve: resolvePosts },
+      SharedPostConnection,
+    ),
+    // No `resolve`: never installs a fallback, so an unplanned parent keeps reloading itself
+    // through the model loader. Here to pin that the recipe changes nothing for it.
+    plainPosts: t.relatedConnection('posts', { cursor: 'id', totalCount: true }),
+  }),
+});
+
+builder.queryType({
+  fields: (t) => ({
+    // An unplanned parent: the row is built by hand, so nothing beneath it was planned into a
+    // prisma query and every field on it has to load itself.
+    unplannedUser: t.field({
+      type: User,
+      resolve: () => ({ id: 1 }) as never,
+    }),
+    // The same user through a planned query, for comparing the two paths.
+    plannedUser: t.prismaField({
+      type: User,
+      resolve: (query) => prisma.user.findUniqueOrThrow({ ...query, where: { id: 1 } }),
+    }),
+  }),
+});
+
+const schema = builder.toSchema();
+
+const run = (document: string) => execute({ schema, document: gql(document), contextValue: {} });
+
+// biome-ignore lint/suspicious/noExplicitAny: reading a result the document's own shape defines
+const connection = (result: { data?: unknown }, root: string, field: string): any =>
+  // biome-ignore lint/suspicious/noExplicitAny: as above
+  (result.data as any)[root][field];
+
+// The prisma call the planned path emitted for the relation, which is the connection's own query
+// nested under the parent's.
+const plannedRelationQuery = (relation = 'posts') =>
+  (queries[0] as { args: { include?: Record<string, unknown> } }).args.include?.[relation];
+
+describe('relatedConnection with a custom resolve, unplanned parent', () => {
+  afterEach(() => {
+    queries.length = 0;
+    resolveCalls.length = 0;
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  it('resolves through edges { node } instead of failing to plan the wrapper', async () => {
+    const result = await run(`{
+      unplannedUser { posts(first: 2) { edges { node { id title } } } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(resolveCalls).toHaveLength(1);
+    expect(connection(result, 'unplannedUser', 'posts').edges).toHaveLength(2);
+  });
+
+  it('resolves through a nodes selection', async () => {
+    const result = await run(`{
+      unplannedUser { posts(first: 2) { nodes { id title } } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(connection(result, 'unplannedUser', 'posts').nodes).toHaveLength(2);
+  });
+
+  it('plans the node selection, not the wrapper, in select mode', async () => {
+    const result = await run(`{
+      unplannedUser { selectedPosts(first: 2) { edges { node { title } } } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    // `id` is the cursor column the recipe seeds; `title` is what the document asked for beneath
+    // `edges { node }`. Without the seed `formatCursor` would have no column to read.
+    expect(resolveCalls[0].select).toStrictEqual({ id: true, title: true });
+  });
+
+  it('plans the node selection through a nodes selection in select mode', async () => {
+    const result = await run(`{
+      unplannedUser { selectedPosts(first: 2) { nodes { content } } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(resolveCalls[0].select).toStrictEqual({ id: true, content: true });
+  });
+
+  it('plans the node selection through a fragment on the node type', async () => {
+    const result = await run(`
+      { unplannedUser { selectedPosts(first: 1) { edges { node { ...PostFields } } } } }
+      fragment PostFields on SelectedPost { title content }
+    `);
+
+    expect(result.errors).toBeUndefined();
+    expect(resolveCalls[0].select).toStrictEqual({ id: true, title: true, content: true });
+  });
+
+  it('names the node type, not the wrapper, for a shared connection object', async () => {
+    const result = await run(`{
+      unplannedUser { sharedPosts(first: 1) { edges { node { title } } } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(resolveCalls[0].select).toStrictEqual({ id: true, title: true });
+  });
+
+  it('plans relations beneath the node', async () => {
+    const result = await run(`{
+      unplannedUser { posts(first: 1) { edges { node { id author { id } } } } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(resolveCalls[0].include).toStrictEqual({ author: true });
+    expect(connection(result, 'unplannedUser', 'posts').edges[0].node.author.id).toBe('1');
+  });
+
+  it('seeds the cursor column even when the document does not select it', async () => {
+    const result = await run(`{
+      unplannedUser { selectedPosts(first: 1) { edges { cursor node { title } } } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(resolveCalls[0].select).toStrictEqual({ id: true, title: true });
+    expect(connection(result, 'unplannedUser', 'selectedPosts').edges[0].cursor).toEqual(
+      expect.any(String),
+    );
+  });
+});
+
+describe('relatedConnection fallback totalCount', () => {
+  afterEach(() => {
+    queries.length = 0;
+    resolveCalls.length = 0;
+  });
+
+  it('answers totalCount, which the parent row cannot carry', async () => {
+    const result = await run(`{
+      unplannedUser { postsWithCount(first: 2) { totalCount edges { node { id } } } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    const posts = connection(result, 'unplannedUser', 'postsWithCount');
+    expect(posts.totalCount).toBe(250);
+    expect(posts.edges).toHaveLength(2);
+  });
+
+  it('filters totalCount by the field query when filterConnectionTotalCount is on', async () => {
+    const result = await run(`{
+      unplannedUser { publishedWithCount(first: 1) { totalCount edges { node { id } } } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    // 250 posts per user, published for `j > 100`: 149 of them.
+    expect(connection(result, 'unplannedUser', 'publishedWithCount').totalCount).toBe(149);
+  });
+
+  it('does not count when the document does not select totalCount', async () => {
+    const result = await run(`{
+      unplannedUser { postsWithCount(first: 1) { edges { node { id } } } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    // Only the resolver's own findMany: the count is a thunk and nothing called it.
+    expect(queries).toStrictEqual([expect.objectContaining({ model: 'Post', action: 'findMany' })]);
+  });
+
+  it('answers a totalCount-only selection, where nothing is selected under the node paths', async () => {
+    const result = await run(`{
+      unplannedUser { postsWithCount { totalCount } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(connection(result, 'unplannedUser', 'postsWithCount').totalCount).toBe(250);
+    // The plan is `undefined` here — there is nothing under `nodes`/`edges.node` to plan — so the
+    // resolver is handed the recipe's own seed rather than a crash.
+    expect(resolveCalls[0].select).toStrictEqual({ id: true });
+  });
+});
+
+describe('relatedConnection fallback pagination', () => {
+  afterEach(() => {
+    queries.length = 0;
+    resolveCalls.length = 0;
+  });
+
+  it('reports hasNextPage from the connection query take', async () => {
+    const result = await run(`{
+      unplannedUser {
+        posts(first: 1) {
+          pageInfo { hasNextPage hasPreviousPage }
+          edges { node { id } }
+        }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    const posts = connection(result, 'unplannedUser', 'posts');
+    // The connection query asks for one row plus a probe; the probe has to be sliced off and
+    // reported as a next page. Reading `take` off the plan's selection map instead — which has
+    // none — left every page of every fallback connection reporting `hasNextPage: false`.
+    expect(resolveCalls[0].take).toBe(2);
+    expect(posts.edges).toHaveLength(1);
+    expect(posts.pageInfo.hasNextPage).toBe(true);
+    expect(posts.pageInfo.hasPreviousPage).toBe(false);
+  });
+
+  it('reports hasNextPage false on the last page', async () => {
+    const result = await run(`{
+      unplannedUser {
+        allPosts(first: 500) { pageInfo { hasNextPage } edges { node { id } } }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    const posts = connection(result, 'unplannedUser', 'allPosts');
+    expect(posts.edges).toHaveLength(250);
+    expect(posts.pageInfo.hasNextPage).toBe(false);
+  });
+
+  it('pages forward with after, reporting hasPreviousPage', async () => {
+    const first = await run(`{
+      unplannedUser { posts(first: 1) { edges { cursor node { id } } } }
+    }`);
+
+    expect(first.errors).toBeUndefined();
+    const firstEdge = connection(first, 'unplannedUser', 'posts').edges[0];
+
+    resolveCalls.length = 0;
+
+    const second = await run(`{
+      unplannedUser {
+        posts(first: 1, after: "${firstEdge.cursor}") {
+          pageInfo { hasNextPage hasPreviousPage }
+          edges { node { id } }
+        }
+      }
+    }`);
+
+    expect(second.errors).toBeUndefined();
+    const posts = connection(second, 'unplannedUser', 'posts');
+    expect(posts.edges).toHaveLength(1);
+    expect(posts.edges[0].node.id).not.toBe(firstEdge.node.id);
+    expect(posts.pageInfo.hasNextPage).toBe(true);
+    expect(posts.pageInfo.hasPreviousPage).toBe(true);
+  });
+
+  it('pages backward with last', async () => {
+    const result = await run(`{
+      unplannedUser {
+        posts(last: 2) { pageInfo { hasNextPage hasPreviousPage } edges { node { id } } }
+      }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    const posts = connection(result, 'unplannedUser', 'posts');
+    expect(resolveCalls[0].take).toBe(-3);
+    expect(posts.edges).toHaveLength(2);
+    expect(posts.pageInfo.hasPreviousPage).toBe(true);
+    expect(posts.pageInfo.hasNextPage).toBe(false);
+  });
+});
+
+describe('relatedConnection fallback agrees with the planned path', () => {
+  afterEach(() => {
+    queries.length = 0;
+    resolveCalls.length = 0;
+  });
+
+  it.each([
+    ['posts', 'edges { node { id title } }'],
+    ['posts', 'nodes { id title }'],
+    ['posts', 'edges { node { id author { id } } }'],
+    ['selectedPosts', 'edges { cursor node { title content } }'],
+    ['selectedPosts', 'nodes { title }'],
+  ])('emits the same relation query as the planned path: %s %s', async (field, selection) => {
+    const document = `${field}(first: 2) { ${selection} }`;
+
+    const fallback = await run(`{ unplannedUser { ${document} } }`);
+    expect(fallback.errors).toBeUndefined();
+    const fallbackQuery = resolveCalls[0];
+
+    resolveCalls.length = 0;
+    queries.length = 0;
+
+    const planned = await run(`{ plannedUser { ${document} } }`);
+    expect(planned.errors).toBeUndefined();
+    // The planned parent carries the rows, so the fallback never runs for it.
+    expect(resolveCalls).toHaveLength(0);
+
+    expect(fallbackQuery).toStrictEqual(plannedRelationQuery());
+    expect(connection(planned, 'plannedUser', field)).toStrictEqual(
+      connection(fallback, 'unplannedUser', field),
+    );
+  });
+
+  it('produces the same page and totalCount as the planned path', async () => {
+    const document =
+      'postsWithCount(first: 1) { totalCount pageInfo { hasNextPage } nodes { id } }';
+
+    const fallback = await run(`{ unplannedUser { ${document} } }`);
+    expect(fallback.errors).toBeUndefined();
+
+    queries.length = 0;
+    resolveCalls.length = 0;
+
+    const planned = await run(`{ plannedUser { ${document} } }`);
+    expect(planned.errors).toBeUndefined();
+
+    expect(connection(fallback, 'unplannedUser', 'postsWithCount')).toStrictEqual(
+      connection(planned, 'plannedUser', 'postsWithCount'),
+    );
+  });
+
+  it('leaves a relatedConnection without a resolve on the loader path', async () => {
+    const result = await run(`{
+      unplannedUser { plainPosts(first: 2) { totalCount edges { node { id } } } }
+    }`);
+
+    expect(result.errors).toBeUndefined();
+    expect(resolveCalls).toHaveLength(0);
+    const posts = connection(result, 'unplannedUser', 'plainPosts');
+    expect(posts.totalCount).toBe(250);
+    expect(posts.edges).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## The bug

`t.relatedConnection('posts', { cursor: 'id', resolve })` installs a fallback resolver, which runs whenever the parent row was not loaded with the connection's rows on it. The fallback planned its query from the field's own return type — `UserPostsConnection`, the relay wrapper, which has no prisma model — so every unplanned parent threw:

```
Expected UserPostsConnection to have a model
```

at path `["user","posts"]`, **before** the user's `resolve` ran. There was no test anywhere in `packages/plugin-prisma/tests` for `relatedConnection` + `resolve`, which is how this survived.

## The fix: the field records a recipe, not a plan

`relatedConnection` now emits a `pothosPrismaFallbackPlan` extension alongside `pothosPrismaFallback`. `wrapResolve` reads it off the field config and forwards it to `fallbackQueryFromInfo`, which hands it to `Plan.fromInfo`.

Worth being precise about what is recorded, because it defines the change:

- **Static, fixed where the field is defined** — the `typeName` (from the node `ref`, *never* the wrapper, so a shared connection object still resolves to one model), the traversal `paths` (`nodes` and `edges.node`), and `initial: { select: cursorSelection }`.
- **Still built per request** — the plan itself, via `Plan.fromInfo(info, …)`. Nothing about per-request planning changes. No plan is cached across requests.

This is byte-for-byte the recipe the planned path already computes in `relationSelect`, plus the cursor seed `t.prismaConnection` already passes to `queryFromInfo`. The `nodes`/`edges.node` paths are now a single shared constant used by both, so the two paths agree by construction rather than by two copies of the same guess drifting apart.

Two edge cases handled explicitly:

- `Plan.fromInfo` returns `undefined` when nothing is selected under the paths (a `totalCount`-only selection). The fallback returns the recipe's own seed rather than crashing.
- That `undefined` is never cached in the per-request `plans` map.

`t.relation` records no recipe and keeps today's behaviour exactly: with no recipe, `Plan.fromInfo` is called with no `typeName`/`paths`/`initial`, which is what it was called with before.

## Two further defects on the same branch, both masked by the throw

**`totalCount: true` had no count source.** The fallback passed no `totalCount` to `wrapConnectionResult` at all, while the loaded path passes `_count?.[name]`, and the generated `totalCount` field is `nullable: false`. A document selecting it got a null on a non-nullable `Int`.

I took the real fix rather than the build-time rejection of `totalCount` + `resolve`. The count is asked of the parent — `findUnique({ where, select: { _count: { select: { [relation]: countSelect } } } })` — through the parent's own `ModelLoader`, so it uses the same `findUnique` every other load of that parent uses and honours a custom one. It respects `filterConnectionTotalCount`, reusing the connection query's `where` exactly as the planned path's `selectConnection` does. It runs only when the document selects `totalCount`, gated on the same `hasTotalCount` signal the planned path uses to decide whether to select `_count` at all, and loads concurrently with the user's rows. The loaded path still passes a plain number and is untouched.

The extra query is per parent row, which is the same shape the branch already has: a custom `resolve` on `relatedConnection` is per-row by definition. The interim build-time error was not needed.

**`take` was read off the wrong object.** `wrapConnectionResult` was given `q.take`, where `q` is the *plan's selection map*, not the connection query — the loaded path correctly uses `connectionQuery.take`. So `take` was `undefined`, `gotFullResults` was never true, the extra probe row was never sliced off, and **`hasNextPage` was permanently `false`** on every paginating fallback connection. Now reads `connectionQuery.take`.

## Tests

New `packages/plugin-prisma/tests/related-connection-fallback.test.ts`, 23 tests against the real SQLite database — there was zero coverage for this combination before. Beyond the three reproductions:

- `edges { node }`, `nodes`, and a fragment on the node type
- select mode, where what was planned is visible in the emitted query (`{ id: true, title: true }` — `id` being the seeded cursor column)
- a shared connection object, proving the node type is named rather than the wrapper
- relations planned beneath the node (`include: { author: true }`)
- the cursor column seeded when the document does not select it
- `totalCount`, `totalCount` filtered by the field query, `totalCount` **not** counted when unselected, and a `totalCount`-only selection (the `Plan.fromInfo → undefined` branch)
- `hasNextPage` true mid-relation and false on the last page, `after` paging, and backward `last` paging
- **five parameterised cases asserting the fallback emits exactly the same relation query as the planned path for the same document**, and returns an identical connection — the direct guard against over- and under-selection
- a `relatedConnection` with no `resolve`, pinned to stay on the loader path

Nothing about planned queries changed: `fallbackQueryFromInfo` has exactly one caller, reachable only when `pothosPrismaFallback` exists, which only `relation` and `relatedConnection` set and only when the user passed `resolve`. The existing planned-path suites stay green.

Full suite from the package directory: **41 files / 282 tests passing, no type errors** (baseline on `main` with the generated fixtures present is 40 / 253). `tsc --project tsconfig.type.json` and `biome check packages/plugin-prisma` are both clean.

## Review follow-ups

An independent review found three further issues, all on the branch this PR newly makes reachable. None is a regression from `main` — that branch threw before — but all three are live now. One commit each.

**A user-defined field on the connection object got a function, not a number** (`1cbbccb`). The count was passed to `wrapConnectionResult` as a thunk for laziness, and only the *generated* `totalCount` field knew to call it. Any user field on the same connection object — `{ fields: (t) => ({ doubled: t.int({ resolve: (c) => c.totalCount * 2 }) }) }`, typed as a number via `Types['Connection']` — got the raw function, and arithmetic on it produced `NaN` on a non-nullable `Int`:

```
before  fallback : {"totalCount":250,"countKind":"function","doubled":null}  + Int cannot represent non-integer value: NaN
        planned  : {"totalCount":250,"countKind":"number","doubled":500}
after   fallback : {"totalCount":250,"countKind":"number","doubled":500}     (identical to the loader path)
```

The laziness did not need the thunk. `connectionSelection`'s `hasTotalCount` is the same signal the planned path uses to decide whether to select `_count`, so gating on it keeps the query from running when unselected *and* puts a plain number on the connection for every field that reads it. The generated field goes back to `parent.totalCount`.

**`?? 0` invented a count for a parent that is not a row** (`2955699`). The reason this branch exists is that the parent came from a resolver of the user's own and need not correspond to any row — so this is reachable exactly here, and not on the planned or loader paths. A custom `resolve` may ignore the parent and return rows anyway, which made the wrongness plain:

```
before  { ghostUser { detachedWithCount(first: 2) { totalCount edges { node { id } } } } }
        → {"totalCount":0,"edges":[{"node":{"id":"1"}},{"node":{"id":"2"}}]}
after   → Unable to load totalCount for User.detachedWithCount: no User row matches the parent
          this connection resolved from
```

**I chose to throw.** A zero next to a non-empty page is a guess presented as a fact on a field the schema declares non-nullable, and the caller has no way to tell it from a real zero. Propagating `null` would also be honest, but `Cannot return null for non-nullable field UserPostsConnection.totalCount` says nothing about why, and the cause here is specific and fixable: either the parent should be a real row, or the document should not ask this connection for a count. So the error names the field as the document names it and the model whose row was not found. A parent that *does* exist and simply has no related rows still counts `0`, as it should — only a missing row errors, and a page with no `totalCount` selected still resolves fine for a synthetic parent.

**A `totalCount`-only selection still ran the user's resolver** (`180af7c`). `connectionSelection` computes `totalCountOnly` and the loaded path honours it by passing `[]`; the fallback never consulted it, so every parent paid for a `findMany` of up to `maxSize + 1` rows that nothing read. Measured over five unplanned parents for `{ totalCount }` only:

```
before  fallback : 10 queries — 5x Post.findMany {select:{id:true},take:21,skip:0} + 5x User.findUnique(_count)
after   fallback :  5 queries — 5x User.findUnique(_count)
        loader   :  5 queries — 5x User.findUniqueOrThrow   (same parents, no custom resolve)
        planned  :  1 query   — 1x User.findMany            (parents already in a planned query)
```

The reviewer was right that my original test asserted `resolveCalls[0]`, pinning the wasteful call rather than catching it; it now asserts the resolver is not called, and a new test counts the queries and asserts parity with the loader path. The `Plan.fromInfo → undefined` branch is still exercised — the same document still reaches it and still gets the recipe's seed back — and is covered by that document resolving without error.

Test count is now **41 files / 282 tests** (29 in the new file).

## One stale comment corrected

`tests/loader-batching.test.ts:201-202` said its `postsConnection` was "Planned through `fallbackQueryFromInfo` … rather than through the model loader". That field has no `resolve`, so no fallback is ever installed for it. Confirmed by instrumenting `fallbackQueryFromInfo` and running the suite: `postsConnection` and `asyncPostsConnection` never reach it, while `resolvedPosts` and `asyncResolvedPosts` (which do have a `resolve`) do. Comment corrected to describe the loader path.

## Not touched

`src/util/cursors.ts` (open PR #1760) and `src/schema-builder.ts` / `src/model-loader.ts` (concurrent async node ID work). The `totalCount` fix reads `ModelLoader.modelName` / `.findUnique` but does not modify that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB

