### PR TITLE
style: remove review comments that landed with the plugin fixes

### DIFF
--- a/packages/plugin-federation/tests/custom-query-root.test.ts
+++ b/packages/plugin-federation/tests/custom-query-root.test.ts
@@ -44,9 +44,7 @@ describe('federation', () => {
       const queryType = schema.getQueryType()!;
 
       expect(queryType.name).toBe('Root');
-      // The rebuilt root must be the only type registered under its name.
       expect(schema.getType('Root')).toBe(queryType);
-      // Federation fields are only added to the rebuilt root.
       expect(Object.keys(queryType.getFields())).toEqual(
         expect.arrayContaining(['_entities', '_service', 'user']),
       );

--- a/packages/plugin-mocks/src/index.ts
+++ b/packages/plugin-mocks/src/index.ts
@@ -11,7 +11,6 @@ const pluginName = 'mocks';
 
 const builtInPrototypes: object[] = [Object.prototype, Function.prototype];
 
-// Descriptors, not property reads: `Function.prototype.caller` and `arguments` throw when read.
 function findDeclaringPrototype(map: object, key: string) {
   for (
     let proto: object | null = Object.getPrototypeOf(map) as object | null;

--- a/packages/plugin-smart-subscriptions/src/cache-node.ts
+++ b/packages/plugin-smart-subscriptions/src/cache-node.ts
@@ -76,7 +76,6 @@ export default class CacheNode<Types extends SchemaTypes> {
     this.typeManagers.delete(key);
   }
 
-  // Only recovers every entry for iterables that can be iterated more than once.
   private valueAsList(): unknown[] {
     if (Array.isArray(this.value)) {
       return this.value as unknown[];

--- a/packages/plugin-smart-subscriptions/src/manager/index.ts
+++ b/packages/plugin-smart-subscriptions/src/manager/index.ts
@@ -202,8 +202,6 @@ export default class SubscriptionManager implements AsyncIterator<object> {
       this.resolveNext(true);
     }
 
-    // The manager is already stopped and its registrations cleared, so a failed cleanup can never
-    // be retried.
     const errors: unknown[] = [];
 
     for (const name of names) {

--- a/packages/plugin-smart-subscriptions/src/resolve-with-cache.ts
+++ b/packages/plugin-smart-subscriptions/src/resolve-with-cache.ts
@@ -38,8 +38,6 @@ export default function resolveWithCache<Types extends SchemaTypes>(
 
     const sub = subscribe?.(cacheNode.managerForField(), parent, args, context, info);
 
-    // `cacheNode.value`, not `result`: the node may have normalized the value, and execution has to
-    // use the same one that refetches are written into.
     if (isThenable(sub)) {
       return sub.then(() => cacheNode.value);
     }

--- a/packages/plugin-tracing/src/util.ts
+++ b/packages/plugin-tracing/src/util.ts
@@ -42,7 +42,6 @@ export function resolveFieldType<Types extends SchemaTypes>(
 const spanCacheSymbol = Symbol.for('Pothos.tracing.spanCache');
 
 interface InternalContext<T> {
-  // A Map, not an object: field paths like `constructor` collide with `Object.prototype` members.
   [spanCacheSymbol]?: Map<string, T>;
 }
 


### PR DESCRIPTION
Six review-fix PRs (#1745, #1747, #1748, #1749, #1750, #1751) merged between two comment-cleanup passes, so they carried comments to `main` that the later, stricter standard removes:

> We only comment things if they are very non obvious and risky, that's kinda it (outside public facing jsdocs on options objects).

Comments only — no code, type, or formatting changes.

- `packages/plugin-mocks/src/index.ts`
- `packages/plugin-tracing/src/util.ts`
- `packages/plugin-smart-subscriptions/src/cache-node.ts`
- `packages/plugin-smart-subscriptions/src/manager/index.ts`
- `packages/plugin-smart-subscriptions/src/resolve-with-cache.ts`
- `packages/plugin-federation/tests/custom-query-root.test.ts`

No changeset: no behaviour and no published output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn2R8i49dU8V6c4LXuLUnB